### PR TITLE
Adjust cmake to handle changes to Max SDK from 8.2 onwards

### DIFF
--- a/source/script/max-posttarget.cmake
+++ b/source/script/max-posttarget.cmake
@@ -3,6 +3,10 @@
 
 target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_14)
 
+target_sources(${PROJECT_NAME} PRIVATE 
+  "${C74_MAX_API_DIR}/max-includes/common/commonsyms.c"
+)
+
 set_target_properties(${PROJECT_NAME} PROPERTIES
     CXX_STANDARD 14
     CXX_STANDARD_REQUIRED ON
@@ -26,7 +30,7 @@ if(MSVC)
   target_compile_options(${PROJECT_NAME} PRIVATE /W3 )
 else()
   target_compile_options(${PROJECT_NAME} PRIVATE
-    -Wall -Wno-gnu-zero-variadic-macro-arguments -Wextra -Wpedantic -Wreturn-type
+    -Wall -Wno-gnu-zero-variadic-macro-arguments -Wextra -Wpedantic -Wreturn-type -include "${C74_MAX_INCLUDES}/macho-prefix.pch"
   )
 endif()
 
@@ -82,9 +86,7 @@ if (APPLE)
   #If we target 10.7 (actually < 10.9), we have to manually include this:
   target_compile_options(${PROJECT_NAME} PRIVATE -stdlib=libc++)
 elseif (WIN32)
-  
-  target_sources(${PROJECT_NAME} PRIVATE "${C74_MAX_API_DIR}/max-includes/common/commonsyms.c")
-  
+    
 	target_link_libraries(${PROJECT_NAME} PRIVATE ${MaxAPI_LIB})
 	target_link_libraries(${PROJECT_NAME} PRIVATE ${MaxAudio_LIB})
 	target_link_libraries(${PROJECT_NAME} PRIVATE ${Jitter_LIB})

--- a/source/script/max-pretarget.cmake
+++ b/source/script/max-pretarget.cmake
@@ -17,7 +17,17 @@ endif()
 
 if (NOT DEFINED C74_MAX_API_DIR)
    file(TO_CMAKE_PATH "${MAX_SDK_PATH}" MAX_SDK_FULLPATH)
-   set(C74_MAX_API_DIR "${MAX_SDK_FULLPATH}/source/c74support")
+   if(EXISTS "${MAX_SDK_FULLPATH}/source/c74support")
+     set(C74_MAX_API_DIR "${MAX_SDK_FULLPATH}/source/c74support")
+   # newer SDK layout, full Max-SDK download 
+   elseif(EXISTS "${MAX_SDK_FULLPATH}/source/max-sdk-base/c74support") 
+     set(C74_MAX_API_DIR "${MAX_SDK_FULLPATH}/source/max-sdk-base/c74support")
+    # newer SDK layout, just max-sdk-base   
+   elseif(EXISTS "${MAX_SDK_FULLPATH}/c74support")   
+      set(C74_MAX_API_DIR "${MAX_SDK_FULLPATH}/74support")
+   else()
+     message(FATAL_ERROR "Could not find Cycling 74 support folder")
+   endif()
 endif ()
 #set(C74_INCLUDES "${C74_MAX_API_DIR}/include")
 set(C74_MAX_INCLUDES ${C74_MAX_API_DIR}/max-includes)
@@ -28,9 +38,6 @@ set(C74_SCRIPTS "../../script")
 
 set(C74_CXX_STANDARD 0)
 
-if (APPLE)	
-	SET( CMAKE_CXX_FLAGS  "${CMAKE_CXX_FLAGS} -include \"${C74_MAX_INCLUDES}/macho-prefix.pch\"")
-endif ()
 
 # if (NOT DEFINED C74_BUILD_MAX_EXTENSION)
 # 	set(CMAKE_LIBRARY_OUTPUT_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/../../../externals")

--- a/source/script/max-pretarget.cmake
+++ b/source/script/max-pretarget.cmake
@@ -24,7 +24,7 @@ if (NOT DEFINED C74_MAX_API_DIR)
      set(C74_MAX_API_DIR "${MAX_SDK_FULLPATH}/source/max-sdk-base/c74support")
     # newer SDK layout, just max-sdk-base   
    elseif(EXISTS "${MAX_SDK_FULLPATH}/c74support")   
-      set(C74_MAX_API_DIR "${MAX_SDK_FULLPATH}/74support")
+      set(C74_MAX_API_DIR "${MAX_SDK_FULLPATH}/c74support")
    else()
      message(FATAL_ERROR "Could not find Cycling 74 support folder")
    endif()


### PR DESCRIPTION
**commonsyms is no longer included in the `.framework` (which was apparently an error), so needs to be built with the mxo on Mac as well as windows now** 

This seems to work fine against the v7 SDK. Weirdly it wouldn't work until the flag for including the precompiled headers was moved from the CXXFLAGs into the target compiler options (which is better anyway). Unfortunately, the error you get when this is broken is not at all helpful (it dies trying to find an old carbon header, Files.h)

**The directory structure has changed such that what used to be `sources/c74support` can now be `sources\/max-sdk-base/c74support`.**

This gives three possible scenarios:

1. Legacy SDK, with includes where they used to be 
2. New complete SDK, with sources folder, and addition `max-sdk-base` path 
3. Just max-sdk-base, in which case there is only the `c74support` folder

I'm doing this with an `if` tree at the moment, which sucks. It would be *nicer* to divine the SDK version from `ext.h` directly, but that's a chicken and egg problem (because we have to find it first) . 

@jamesb93 @tremblap can you see if your respective builds both work against this? 
