### PR TITLE
Enable naming / sharing for all RT queryable model objects

### DIFF
--- a/source/include/FluidMaxWrapper.hpp
+++ b/source/include/FluidMaxWrapper.hpp
@@ -1004,8 +1004,8 @@ public:
   {
     void operator()(const T& param, FluidMaxWrapper* x, ParamSetType& paramSet)
     {
-      auto listenerFunc = [x, &param]() {
-        object_attr_touch((t_object*) (x), gensym(param.name));
+      auto listenerFunc = [x, name=gensym(lowerCase(param.name).c_str())]() {
+        object_attr_touch((t_object*) (x), name);
       };
       paramSet.template addListener<N>(std::move(listenerFunc), x);
     }

--- a/source/include/FluidMaxWrapper.hpp
+++ b/source/include/FluidMaxWrapper.hpp
@@ -1033,7 +1033,7 @@ public:
     void* x = object_alloc(getClass());
     new (x) FluidMaxWrapper(sym, ac, av);
 
-    if (static_cast<size_t>(attr_args_offset(static_cast<short>(ac), av)) >
+    if (static_cast<size_t>(attr_args_offset(static_cast<short>(ac), av)) - isControlIn<typename Client::Client> >
         ParamDescType::NumFixedParams)
     {
       object_warn((t_object*) x,
@@ -1056,7 +1056,7 @@ public:
 
     if (isControlIn<typename Client::Client>)
     {
-      class_addmethod(getClass(), (method) doList, "list", A_GIMME, 0);
+      class_addmethod(getClass(), (method) handleList, "list", A_GIMME, 0);
       t_object* a = attr_offset_new("autosize", USESYM(long), 0, nullptr, nullptr,
                                   calcoffset(FluidMaxWrapper, mAutosize));
       class_addattr(getClass(), a);

--- a/source/projects/fluid.libmanipulation/fluid.libmanipulation.cpp
+++ b/source/projects/fluid.libmanipulation/fluid.libmanipulation.cpp
@@ -29,7 +29,7 @@ void ext_main(void*)
   makeMaxWrapper<NRTThreadedDataSetClient>("fluid.dataset~");
   makeMaxWrapper<NRTThreadedDataSetQueryClient>("fluid.datasetquery~");
   makeMaxWrapper<NRTThreadedLabelSetClient>("fluid.labelset~");
-  makeMaxWrapper<RTKDTreeClient>("fluid.kdtree~");
+  makeMaxWrapper<NRTThreadedKDTreeClient>("fluid.kdtree~");
   makeMaxWrapper<RTKMeansClient>("fluid.kmeans~");
   makeMaxWrapper<RTKNNClassifierClient>("fluid.knnclassifier~");
   makeMaxWrapper<RTKNNRegressorClient>("fluid.knnregressor~");

--- a/source/projects/fluid.libmanipulation/fluid.libmanipulation.cpp
+++ b/source/projects/fluid.libmanipulation/fluid.libmanipulation.cpp
@@ -31,7 +31,7 @@ void ext_main(void*)
   makeMaxWrapper<NRTThreadedLabelSetClient>("fluid.labelset~");
   makeMaxWrapper<NRTThreadedKDTreeClient>("fluid.kdtree~");
   makeMaxWrapper<NRTThreadedKMeansClient>("fluid.kmeans~");
-  makeMaxWrapper<RTKNNClassifierClient>("fluid.knnclassifier~");
+  makeMaxWrapper<NRTThreadedKNNClassifierClient>("fluid.knnclassifier~");
   makeMaxWrapper<RTKNNRegressorClient>("fluid.knnregressor~");
   makeMaxWrapper<RTNormalizeClient>("fluid.normalize~");
   makeMaxWrapper<RTStandardizeClient>("fluid.standardize~");

--- a/source/projects/fluid.libmanipulation/fluid.libmanipulation.cpp
+++ b/source/projects/fluid.libmanipulation/fluid.libmanipulation.cpp
@@ -36,10 +36,10 @@ void ext_main(void*)
   makeMaxWrapper<NRTThreadedNormalizeClient>("fluid.normalize~");
   makeMaxWrapper<NRTThreadedStandardizeClient>("fluid.standardize~");
   makeMaxWrapper<NRTThreadedRobustScaleClient>("fluid.robustscale~");
-  makeMaxWrapper<RTPCAClient>("fluid.pca~");
+  makeMaxWrapper<NRTThreadedPCAClient>("fluid.pca~");
   makeMaxWrapper<NRTThreadedMDSClient>("fluid.mds~");
-  makeMaxWrapper<RTUMAPClient>("fluid.umap~");
+  makeMaxWrapper<NRTThreadedUMAPClient>("fluid.umap~");
   makeMaxWrapper<NRTThreadedGridClient>("fluid.grid~");
-  makeMaxWrapper<RTMLPRegressorClient>("fluid.mlpregressor~");
-  makeMaxWrapper<RTMLPClassifierClient>("fluid.mlpclassifier~");
+  makeMaxWrapper<NRTThreadedMLPRegressorClient>("fluid.mlpregressor~");
+  makeMaxWrapper<NRTThreadedMLPClassifierClient>("fluid.mlpclassifier~");
 }

--- a/source/projects/fluid.libmanipulation/fluid.libmanipulation.cpp
+++ b/source/projects/fluid.libmanipulation/fluid.libmanipulation.cpp
@@ -32,7 +32,7 @@ void ext_main(void*)
   makeMaxWrapper<NRTThreadedKDTreeClient>("fluid.kdtree~");
   makeMaxWrapper<NRTThreadedKMeansClient>("fluid.kmeans~");
   makeMaxWrapper<NRTThreadedKNNClassifierClient>("fluid.knnclassifier~");
-  makeMaxWrapper<RTKNNRegressorClient>("fluid.knnregressor~");
+  makeMaxWrapper<NRTThreadedKNNRegressorClient>("fluid.knnregressor~");
   makeMaxWrapper<RTNormalizeClient>("fluid.normalize~");
   makeMaxWrapper<RTStandardizeClient>("fluid.standardize~");
   makeMaxWrapper<RTRobustScaleClient>("fluid.robustscale~");

--- a/source/projects/fluid.libmanipulation/fluid.libmanipulation.cpp
+++ b/source/projects/fluid.libmanipulation/fluid.libmanipulation.cpp
@@ -33,7 +33,7 @@ void ext_main(void*)
   makeMaxWrapper<NRTThreadedKMeansClient>("fluid.kmeans~");
   makeMaxWrapper<NRTThreadedKNNClassifierClient>("fluid.knnclassifier~");
   makeMaxWrapper<NRTThreadedKNNRegressorClient>("fluid.knnregressor~");
-  makeMaxWrapper<RTNormalizeClient>("fluid.normalize~");
+  makeMaxWrapper<NRTThreadedNormalizeClient>("fluid.normalize~");
   makeMaxWrapper<RTStandardizeClient>("fluid.standardize~");
   makeMaxWrapper<RTRobustScaleClient>("fluid.robustscale~");
   makeMaxWrapper<RTPCAClient>("fluid.pca~");

--- a/source/projects/fluid.libmanipulation/fluid.libmanipulation.cpp
+++ b/source/projects/fluid.libmanipulation/fluid.libmanipulation.cpp
@@ -30,7 +30,7 @@ void ext_main(void*)
   makeMaxWrapper<NRTThreadedDataSetQueryClient>("fluid.datasetquery~");
   makeMaxWrapper<NRTThreadedLabelSetClient>("fluid.labelset~");
   makeMaxWrapper<NRTThreadedKDTreeClient>("fluid.kdtree~");
-  makeMaxWrapper<RTKMeansClient>("fluid.kmeans~");
+  makeMaxWrapper<NRTThreadedKMeansClient>("fluid.kmeans~");
   makeMaxWrapper<RTKNNClassifierClient>("fluid.knnclassifier~");
   makeMaxWrapper<RTKNNRegressorClient>("fluid.knnregressor~");
   makeMaxWrapper<RTNormalizeClient>("fluid.normalize~");

--- a/source/projects/fluid.libmanipulation/fluid.libmanipulation.cpp
+++ b/source/projects/fluid.libmanipulation/fluid.libmanipulation.cpp
@@ -35,7 +35,7 @@ void ext_main(void*)
   makeMaxWrapper<NRTThreadedKNNRegressorClient>("fluid.knnregressor~");
   makeMaxWrapper<NRTThreadedNormalizeClient>("fluid.normalize~");
   makeMaxWrapper<NRTThreadedStandardizeClient>("fluid.standardize~");
-  makeMaxWrapper<RTRobustScaleClient>("fluid.robustscale~");
+  makeMaxWrapper<NRTThreadedRobustScaleClient>("fluid.robustscale~");
   makeMaxWrapper<RTPCAClient>("fluid.pca~");
   makeMaxWrapper<NRTThreadedMDSClient>("fluid.mds~");
   makeMaxWrapper<RTUMAPClient>("fluid.umap~");

--- a/source/projects/fluid.libmanipulation/fluid.libmanipulation.cpp
+++ b/source/projects/fluid.libmanipulation/fluid.libmanipulation.cpp
@@ -34,7 +34,7 @@ void ext_main(void*)
   makeMaxWrapper<NRTThreadedKNNClassifierClient>("fluid.knnclassifier~");
   makeMaxWrapper<NRTThreadedKNNRegressorClient>("fluid.knnregressor~");
   makeMaxWrapper<NRTThreadedNormalizeClient>("fluid.normalize~");
-  makeMaxWrapper<RTStandardizeClient>("fluid.standardize~");
+  makeMaxWrapper<NRTThreadedStandardizeClient>("fluid.standardize~");
   makeMaxWrapper<RTRobustScaleClient>("fluid.robustscale~");
   makeMaxWrapper<RTPCAClient>("fluid.pca~");
   makeMaxWrapper<NRTThreadedMDSClient>("fluid.mds~");

--- a/source/projects/fluid.stats/CMakeLists.txt
+++ b/source/projects/fluid.stats/CMakeLists.txt
@@ -1,0 +1,19 @@
+# Part of the Fluid Corpus Manipulation Project (http://www.flucoma.org/)
+# Copyright 2017-2019 University of Huddersfield.
+# Licensed under the BSD-3 License.
+# See license.md file in the project root for full license information.
+# This project has received funding from the European Research Council (ERC)
+# under the European Union’s Horizon 2020 research and innovation programme
+# (grant agreement No 725899).
+
+cmake_minimum_required(VERSION 3.11)
+
+include(${CMAKE_CURRENT_SOURCE_DIR}/../../script/max-pretarget.cmake)
+
+add_library(
+	${PROJECT_NAME}
+	MODULE
+	${THIS_FOLDER_NAME}.cpp
+)
+
+include(${CMAKE_CURRENT_SOURCE_DIR}/../../script/max-posttarget.cmake)

--- a/source/projects/fluid.stats/fluid.stats.cpp
+++ b/source/projects/fluid.stats/fluid.stats.cpp
@@ -1,0 +1,18 @@
+/*
+Part of the Fluid Corpus Manipulation Project (http://www.flucoma.org/)
+Copyright 2017-2019 University of Huddersfield.
+Licensed under the BSD-3 License.
+See license.md file in the project root for full license information.
+This project has received funding from the European Research Council (ERC)
+under the European Union’s Horizon 2020 research and innovation programme
+(grant agreement No 725899).
+*/
+
+#include <clients/rt/RunningStatsClient.hpp>
+#include "FluidMaxWrapper.hpp" //nb: this include is order-sensitive because of macro name clashes in Eigen and C74
+
+void ext_main(void*)
+{
+  using namespace fluid::client;
+  makeMaxWrapper<RunningStatsClient>("fluid.stats");
+}


### PR DESCRIPTION
Supports this PR: https://github.com/flucoma/flucoma-core/pull/35

Besides a bug fix in the wrapper to do with making `attrui` refresh when another instance's params change, this consists just of updating the libmanipulation.cpp 

I do have locally some scraggly additions to some help files that I used to test, but don't want to interfere with the other branches doing updates to help files. 