### PR TITLE
Fix over eager zeroing of control outputs

### DIFF
--- a/source/include/FluidMaxWrapper.hpp
+++ b/source/include/FluidMaxWrapper.hpp
@@ -167,7 +167,6 @@ public:
       mOutputs[asUnsigned(i)].reset(outs[asUnsigned(i)], 0, sampleframes);
     }
 
-    std::fill(mControlOutputs.begin(), mControlOutputs.end(),0.0);
     client.process(mInputs, mOutputs, mContext);
 
     if (mControlClock && !mTick.test_and_set()) clock_delay(mControlClock, 0);


### PR DESCRIPTION
Didn't take into account that process() doesn't always act, dependong on 
hop size etc, so could produce garbage at certain sigvs settings

fixes #40