### PR TITLE
Add return to load() when missing arguments

### DIFF
--- a/source/include/FluidMaxWrapper.hpp
+++ b/source/include/FluidMaxWrapper.hpp
@@ -1532,6 +1532,7 @@ private:
     if (ac < 2 || atom_getsym(av) != dictionarySymbol)
     {
       object_error((t_object*) x, "Expected a dictionary");
+      return; 
     }
 
     t_symbol*     dictName = atom_getsym(av + 1);


### PR DESCRIPTION
fixes #60 by adding missing `return` to exit on error 