### PR TITLE
reconfigure fluid.plotter interface

### DIFF
--- a/jsui/fluid.plotter.js
+++ b/jsui/fluid.plotter.js
@@ -124,7 +124,7 @@ function setdict(name) {
 		fail = true;
 	}
 	if (dataDict.get('cols') != 2) {
-		error('fluid.dataset~ should be exactly two dimensions.', '\n')
+		error('fluid.dataset~ should be exactly two dimensions', '\n')
 		fail = true;
 	}
 	if (!fail) {
@@ -147,11 +147,11 @@ function setcategories(name) {
 	// Check that it is a valid dictionary from flucoma.
 	if (!labelDict.contains('data') || !labelDict.contains('cols')) {
 		labelDict = null;
-		error('Please provide a valid dictionary of labels from a fluid.labelset~')
+		error('Please provide a valid dictionary of labels from a fluid.labelset~', '\n')
 	}
 	if (labelDict.get('cols') != 1) {
 		labelDict = null;
-		error('There should only be one column of data which is a label.')
+		error('There should only be one column of data which is a label', '\n')
 	}
 
 	// Convert the internal representation to a JSON object for speedier referencing.
@@ -211,7 +211,7 @@ function addpoint(id, x, y, size) {
 		pointUpdate(id, x, y, size);
 	} 
 	else {
-		error(id, 'already exists');
+		error('The identifier:', id, 'already exists', '\n');
 	}
 }
 

--- a/jsui/fluid.plotter.js
+++ b/jsui/fluid.plotter.js
@@ -248,25 +248,27 @@ function todataset() {
 	// A method to convert the internal representation to converted to a dataset allowing manual visual editing
 }
 
-function xmin(x) {
-	_xmin = x;
+function xrange(min, max) {
+	// Set the domain on the x axis
+	_xmin = min;
+	_xmax = max;
 	mgraphics.redraw();
 }
 
-function xmax(x) {
-	_xmax = x;
+function yrange(min, max) {
+	// Set the domain on the y axis
+	_ymin = min;
+	_ymax = max;
 	mgraphics.redraw();
 }
 
-function ymin(x) {
-	_ymin = x;
+function range(min, max) {
+	// Set the domain on both axis simultaneously
+	xrange(min, max);
+	yrange(min, max);
 	mgraphics.redraw();
 }
 
-function ymax(x) {
-	_ymax = x;
-	mgraphics.redraw();
-}
 
 function shape(x) {
 	_shape = x;

--- a/jsui/fluid.plotter.js
+++ b/jsui/fluid.plotter.js
@@ -47,6 +47,7 @@ var labelDict = null;
 var labelJSON = null;
 var dataDict = null;
 var colorMap = {};
+var pointColors = {};
 
 
 function hexToRGB(hex, a) {
@@ -83,10 +84,14 @@ function paint() {
 
 	Object.keys(points).forEach(function(pt) {
 		var point = points[pt];
-		var color = point.color;
+		var color = _pointcolor;
+
+		if (pointColors.hasOwnProperty(pt)) {
+			color = pointColors[pt];
+		}
 
 		if (labelJSON) {
-			var label = labelJSON[pt]
+			var label = labelJSON[pt];
 			color = colorMap[label];
 		}
 		mgraphics.set_source_rgba(color);
@@ -133,7 +138,6 @@ function setdict(name) {
 			points[pt] = {
 				x : rawData[pt][0],
 				y : rawData[pt][1],
-				color: _pointcolor,
 				size: 0.1
 			}
 		})
@@ -200,8 +204,7 @@ function pointUpdate(id, x, y, size) {
 	points[id] = {
 		x : x,
 		y : y,
-		size : size,
-		color : _pointcolor,
+		size : size
 	};
 	mgraphics.redraw();
 }
@@ -217,6 +220,15 @@ function addpoint(id, x, y, size) {
 
 function setpoint(id, x, y, size) {
 	pointUpdate(id, x, y, size)
+}
+
+function setpointcolor(id, r, g, b, a) {
+	var r = 0 || r;
+	var g = 0 || g;
+	var b = 0 || b;
+	var a = 1 || a;
+	pointColors[id] = [r, g, b, a];
+	mgraphics.redraw();
 }
 
 function todataset() {
@@ -245,7 +257,7 @@ function shape(x) {
 }
 
 function pointcolor(r, g, b, a) {
-	_pointcolor = [r, g, b, a]
+	_pointcolor = [r, g, b, a];
 	mgraphics.redraw();
 }
 

--- a/jsui/fluid.plotter.js
+++ b/jsui/fluid.plotter.js
@@ -219,6 +219,10 @@ function setpoint(id, x, y, size) {
 	pointUpdate(id, x, y, size)
 }
 
+function todataset() {
+	// A method to convert the internal representation to converted to a dataset allowing manual visual editing
+}
+
 function xrange(min, max) {
 	_xrange = [min, max];
 	mgraphics.redraw();

--- a/jsui/fluid.plotter.js
+++ b/jsui/fluid.plotter.js
@@ -196,7 +196,7 @@ function colorscheme(scheme) {
 }
 
 function pointUpdate(id, x, y, size) {
-	var size = size || 1.0;
+	var size = size || 0.1;
 	points[id] = {
 		x : x,
 		y : y,


### PR DESCRIPTION
This adds several changes to the fluid.plotter object. Fundamentally it changes how the data of the fluid.dataset~ dump is dealt with.

1) No longer are the points in the plot an `array`. They are now a `JSON Object`. This has the consequence of each point being a key-value pair with information about its position, size and colour. This means that points are now unique. This has consequences on the `addpoint` message below.

2) `addpoint` now has mirrored functionality with `fluid.datasets~` method. If the point already exists, and you try to use the advanced interface to manually add a point with the same identifier it will throw an error.

3) To make the changes for `addpoint` feel like one is losing something, `setpoint` now exists for changing the properties of individual points after the fact.
