### PR TITLE
Copy misc folder on install target

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -131,7 +131,7 @@ set(MAX_INSTALL_PREFIX "." CACHE PATH "Prefix for assembling max package")
 set(FLUID_PACKAGE_NAME "Fluid Corpus Manipulation" CACHE STRING "Name for published package")
 set(MAX_PACKAGE_ROOT ${MAX_INSTALL_PREFIX}/${FLUID_PACKAGE_NAME})
 
-foreach(PACKAGE_DIRECTORY examples;extras;help;init;patchers;interfaces;javascript;jsui)
+foreach(PACKAGE_DIRECTORY examples;extras;help;init;patchers;interfaces;javascript;jsui;misc)
   install(DIRECTORY ${PACKAGE_DIRECTORY} DESTINATION ${MAX_PACKAGE_ROOT})
 endforeach(PACKAGE_DIRECTORY)
 


### PR DESCRIPTION
This makes `cmake` copy the `misc` folder into the distribution package when using the install target.﻿
