### PR TITLE
fluid.plotter reset points on receiving setdict()

### DIFF
--- a/jsui/fluid.plotter.js
+++ b/jsui/fluid.plotter.js
@@ -141,6 +141,7 @@ function setdict(name) {
 		fail = true;
 	}
 	if (!fail) {
+		points = {};
 		var rawData = JSON.parse(dataDict.stringify()).data;
 		Object.keys(rawData).forEach(function(pt) { 
 			points[pt] = {


### PR DESCRIPTION
Prior to this PR fluid.plotter would not reset the points in its internal JSON object when receiving a new dictionary in the left inlet.

This meant that changing the size to a smaller set of points would leave the old points in the object between giving it new data (if the keys were not overwritten).

This PR explicitly resets the points if all the preliminary checks on the integrity of the dictionary pass.﻿
