### PR TITLE
CI tag name

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -3,8 +3,6 @@ name: Nightly Releases
 on:
   push:
     branches: [ dev, ci/automatic-building ]
-  pull_request:
-    branches: [ dev ]
 
 jobs:
   docs:

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -146,7 +146,7 @@ jobs:
       - uses: dev-drprasad/delete-tag-and-release@v0.2.0
         with:
           delete_release: true # default: false
-          tag_name: 1.0.0-nightly # tag name to delete
+          tag_name: nightly # tag name to delete
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         
@@ -159,6 +159,6 @@ jobs:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
           file: FluCoMa-Max-nightly.zip
           asset_name: FluCoMa-Max-nightly.zip
-          tag: 1.0.0-nightly
+          tag: nightly
           overwrite: true
         


### PR DESCRIPTION
When github actions create a pre-release nightly there has to be a tag associated to that release. I was using one called 1.0.0-nightly, but I think nightlies are inherently versionless and their version information is compiled into the obecjts anyway. The actions will also delete and move the tag as necessary so the name of it is just another thing to manage if it contains specific major version information. Thus it is now just `nightly`.﻿
