### PR TITLE
Remove spaces from installation path name

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -128,7 +128,7 @@ endforeach ()
 #install bits. Max packages bundle Windows and Mac builds together
 set(CMAKE_INSTALL_PREFIX "${CMAKE_CURRENT_SOURCE_DIR}/release-packaging")
 set(MAX_INSTALL_PREFIX "." CACHE PATH "Prefix for assembling max package")
-set(FLUID_PACKAGE_NAME "Fluid Corpus Manipulation" CACHE STRING "Name for published package")
+set(FLUID_PACKAGE_NAME "FluidCorpusManipulation" CACHE STRING "Name for published package")
 set(MAX_PACKAGE_ROOT ${MAX_INSTALL_PREFIX}/${FLUID_PACKAGE_NAME})
 
 foreach(PACKAGE_DIRECTORY examples;extras;help;init;patchers;interfaces;javascript;jsui;misc)


### PR DESCRIPTION
Previously when running something like `ninja install` the package folder in `release-packaging` would contain spaces. This removes those spaces.﻿
