### PR TITLE
Trigger compilation from CI on PRs

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -113,6 +113,7 @@ jobs:
           path: release-packaging/Fluid\ Corpus\ Manipulation/
   
   release:
+    if: ${{ github.ref == 'refs/heads/dev' }}
     runs-on: ubuntu-latest
     needs: [winbuild, macbuild, docs]
 

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -3,6 +3,8 @@ name: Nightly Releases
 on:
   push:
     branches: [ dev, ci/automatic-building ]
+  pull_request:
+    branches: [ dev ]
 
 jobs:
   docs:


### PR DESCRIPTION
Triggers a custom version of the nightly build CI action on PRs. This gives an inline report of whether the build worked for each PR.
