### PR TITLE
[Enhance] Update fluid.waveform~

### DIFF
--- a/help/fluid.waveform~.maxhelp
+++ b/help/fluid.waveform~.maxhelp
@@ -3,14 +3,14 @@
 		"fileversion" : 1,
 		"appversion" : 		{
 			"major" : 8,
-			"minor" : 1,
-			"revision" : 11,
+			"minor" : 2,
+			"revision" : 2,
 			"architecture" : "x64",
 			"modernui" : 1
 		}
 ,
 		"classnamespace" : "box",
-		"rect" : [ 34.0, 79.0, 1394.0, 956.0 ],
+		"rect" : [ 34.0, 87.0, 988.0, 726.0 ],
 		"bglocked" : 0,
 		"openinpresentation" : 0,
 		"default_fontsize" : 12.0,
@@ -50,14 +50,14 @@
 						"fileversion" : 1,
 						"appversion" : 						{
 							"major" : 8,
-							"minor" : 1,
-							"revision" : 11,
+							"minor" : 2,
+							"revision" : 2,
 							"architecture" : "x64",
 							"modernui" : 1
 						}
 ,
 						"classnamespace" : "box",
-						"rect" : [ 0.0, 26.0, 1394.0, 930.0 ],
+						"rect" : [ 0.0, 26.0, 988.0, 700.0 ],
 						"bglocked" : 0,
 						"openinpresentation" : 0,
 						"default_fontsize" : 12.0,
@@ -152,8 +152,8 @@
 						"fileversion" : 1,
 						"appversion" : 						{
 							"major" : 8,
-							"minor" : 1,
-							"revision" : 11,
+							"minor" : 2,
+							"revision" : 2,
 							"architecture" : "x64",
 							"modernui" : 1
 						}
@@ -242,8 +242,8 @@
 						"fileversion" : 1,
 						"appversion" : 						{
 							"major" : 8,
-							"minor" : 1,
-							"revision" : 11,
+							"minor" : 2,
+							"revision" : 2,
 							"architecture" : "x64",
 							"modernui" : 1
 						}
@@ -332,14 +332,14 @@
 						"fileversion" : 1,
 						"appversion" : 						{
 							"major" : 8,
-							"minor" : 1,
-							"revision" : 11,
+							"minor" : 2,
+							"revision" : 2,
 							"architecture" : "x64",
 							"modernui" : 1
 						}
 ,
 						"classnamespace" : "box",
-						"rect" : [ 34.0, 105.0, 1394.0, 930.0 ],
+						"rect" : [ 34.0, 113.0, 988.0, 700.0 ],
 						"bglocked" : 0,
 						"openinpresentation" : 0,
 						"default_fontsize" : 12.0,
@@ -462,8 +462,8 @@
 									"numinlets" : 2,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 35.0, 299.399652600288391, 204.0, 22.0 ],
-									"text" : "addlayer image fluid.waveform.mags"
+									"patching_rect" : [ 35.0, 299.399652600288391, 221.0, 22.0 ],
+									"text" : "addlayer imagebuf fluid.waveform.mags"
 								}
 
 							}
@@ -524,8 +524,8 @@
 									"numinlets" : 2,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 552.0, 247.0, 381.0, 22.0 ],
-									"text" : "addlayer line fluid.waveform.pitch, color fluid.waveform.pitch 1. 0. 0. 1."
+									"patching_rect" : [ 552.0, 247.0, 417.0, 22.0 ],
+									"text" : "addlayer featurebuf fluid.waveform.pitch, color fluid.waveform.pitch 1. 0. 0. 1."
 								}
 
 							}
@@ -536,8 +536,8 @@
 									"numinlets" : 2,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 266.0, 173.0, 261.0, 22.0 ],
-									"text" : "addlayer wave fluid.waveform.src.layers source"
+									"patching_rect" : [ 266.0, 173.0, 279.0, 22.0 ],
+									"text" : "addlayer audiobuf fluid.waveform.src.layers source"
 								}
 
 							}
@@ -548,7 +548,7 @@
 									"numinlets" : 1,
 									"numoutlets" : 2,
 									"outlettype" : [ "float", "bang" ],
-									"patching_rect" : [ 750.944449543952942, 415.468550783672299, 215.0, 22.0 ],
+									"patching_rect" : [ 426.565008103847504, 409.968550783672299, 215.0, 22.0 ],
 									"text" : "buffer~ fluid.waveform.src.layers anton",
 									"varname" : "doesit"
 								}
@@ -563,7 +563,7 @@
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
 									"parameter_enable" : 0,
-									"patching_rect" : [ 35.0, 520.518521547317505, 1256.944449543952942, 384.067990250435855 ],
+									"patching_rect" : [ 35.0, 471.518521547317505, 606.565008103847504, 183.067990250435855 ],
 									"presentation" : 1,
 									"presentation_rect" : [ 634.573396921157837, 195.243875801563263, 500.59646075963974, 346.481478452682495 ]
 								}
@@ -576,7 +576,7 @@
 									"numinlets" : 1,
 									"numoutlets" : 2,
 									"outlettype" : [ "float", "bang" ],
-									"patching_rect" : [ 750.944449543952942, 446.0, 155.0, 22.0 ],
+									"patching_rect" : [ 426.565008103847504, 440.5, 155.0, 22.0 ],
 									"text" : "buffer~ fluid.waveform.pitch"
 								}
 
@@ -812,14 +812,14 @@
 						"fileversion" : 1,
 						"appversion" : 						{
 							"major" : 8,
-							"minor" : 1,
-							"revision" : 11,
+							"minor" : 2,
+							"revision" : 2,
 							"architecture" : "x64",
 							"modernui" : 1
 						}
 ,
 						"classnamespace" : "box",
-						"rect" : [ 0.0, 26.0, 1394.0, 930.0 ],
+						"rect" : [ 0.0, 26.0, 988.0, 700.0 ],
 						"bglocked" : 0,
 						"openinpresentation" : 0,
 						"default_fontsize" : 12.0,
@@ -855,7 +855,7 @@
 									"maxclass" : "comment",
 									"numinlets" : 1,
 									"numoutlets" : 0,
-									"patching_rect" : [ 964.944449543952942, 505.0, 150.0, 33.0 ],
+									"patching_rect" : [ 539.944449543952942, 426.0, 150.0, 33.0 ],
 									"text" : "TODO: re-dump markers back to original buffer / list"
 								}
 
@@ -867,7 +867,7 @@
 									"maxclass" : "comment",
 									"numinlets" : 1,
 									"numoutlets" : 0,
-									"patching_rect" : [ 79.5, 478.0, 330.0, 60.0 ],
+									"patching_rect" : [ 72.5, 406.0, 330.0, 60.0 ],
 									"text" : "When patcher locked: \nHover over a marker to select, click and drag to move. \nshift+click to add \nopt-click to remove"
 								}
 
@@ -879,7 +879,7 @@
 									"maxclass" : "comment",
 									"numinlets" : 1,
 									"numoutlets" : 0,
-									"patching_rect" : [ 130.0, 351.066044270992279, 238.0, 33.0 ],
+									"patching_rect" : [ 123.0, 330.066044270992279, 238.0, 33.0 ],
 									"text" : "need to supply source buffer as time reference (until I find a Better Way)",
 									"textcolor" : [ 0.129411764705882, 0.129411764705882, 0.129411764705882, 0.52 ]
 								}
@@ -891,7 +891,7 @@
 									"maxclass" : "comment",
 									"numinlets" : 1,
 									"numoutlets" : 0,
-									"patching_rect" : [ 79.5, 293.566044270992279, 186.0, 20.0 ],
+									"patching_rect" : [ 72.5, 272.566044270992279, 186.0, 20.0 ],
 									"text" : "markers messages adds markers",
 									"textcolor" : [ 0.129411764705882, 0.129411764705882, 0.129411764705882, 0.52 ]
 								}
@@ -903,7 +903,7 @@
 									"maxclass" : "comment",
 									"numinlets" : 1,
 									"numoutlets" : 0,
-									"patching_rect" : [ 90.5, 175.566044270992279, 104.0, 20.0 ],
+									"patching_rect" : [ 83.5, 154.566044270992279, 104.0, 20.0 ],
 									"text" : "make some slices",
 									"textcolor" : [ 0.129411764705882, 0.129411764705882, 0.129411764705882, 0.52 ]
 								}
@@ -916,7 +916,7 @@
 									"numinlets" : 2,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 59.0, 321.0, 313.0, 22.0 ],
+									"patching_rect" : [ 52.0, 300.0, 313.0, 22.0 ],
 									"text" : "markers fluid.waveform.slices fluid.waveform.src.markers"
 								}
 
@@ -929,7 +929,7 @@
 									"numoutlets" : 1,
 									"outlettype" : [ "bang" ],
 									"parameter_enable" : 0,
-									"patching_rect" : [ 59.0, 201.566044270992279, 24.0, 24.0 ]
+									"patching_rect" : [ 52.0, 180.566044270992279, 24.0, 24.0 ]
 								}
 
 							}
@@ -952,7 +952,7 @@
 									"maxclass" : "comment",
 									"numinlets" : 1,
 									"numoutlets" : 0,
-									"patching_rect" : [ 238.5, 124.5, 313.0, 20.0 ],
+									"patching_rect" : [ 231.5, 103.5, 313.0, 20.0 ],
 									"text" : "what are we segmenting?",
 									"textcolor" : [ 0.129411764705882, 0.129411764705882, 0.129411764705882, 0.52 ]
 								}
@@ -965,7 +965,7 @@
 									"numinlets" : 2,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 656.944449543952942, 386.018521547317505, 49.0, 22.0 ],
+									"patching_rect" : [ 649.944449543952942, 365.018521547317505, 49.0, 22.0 ],
 									"text" : "refresh"
 								}
 
@@ -977,7 +977,7 @@
 									"numinlets" : 2,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 17.0, 124.5, 186.0, 22.0 ],
+									"patching_rect" : [ 10.0, 103.5, 186.0, 22.0 ],
 									"text" : "buffer fluid.waveform.src.markers"
 								}
 
@@ -989,7 +989,7 @@
 									"numinlets" : 1,
 									"numoutlets" : 2,
 									"outlettype" : [ "float", "bang" ],
-									"patching_rect" : [ 448.944449543952942, 351.066044270992279, 227.0, 22.0 ],
+									"patching_rect" : [ 441.944449543952942, 330.066044270992279, 227.0, 22.0 ],
 									"text" : "buffer~ fluid.waveform.src.markers jongly",
 									"varname" : "doesit"
 								}
@@ -1004,7 +1004,7 @@
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
 									"parameter_enable" : 0,
-									"patching_rect" : [ 59.0, 555.410335123538971, 1055.944449543952942, 291.176176674214389 ],
+									"patching_rect" : [ 52.0, 483.410335123538971, 606.565008103847504, 183.067990250435855 ],
 									"presentation" : 1,
 									"presentation_rect" : [ 634.573396921157837, 195.243875801563263, 500.59646075963974, 346.481478452682495 ]
 								}
@@ -1017,7 +1017,7 @@
 									"numinlets" : 1,
 									"numoutlets" : 2,
 									"outlettype" : [ "float", "bang" ],
-									"patching_rect" : [ 448.944449543952942, 321.0, 160.0, 22.0 ],
+									"patching_rect" : [ 441.944449543952942, 300.0, 160.0, 22.0 ],
 									"text" : "buffer~ fluid.waveform.slices"
 								}
 
@@ -1030,7 +1030,7 @@
 									"numinlets" : 1,
 									"numoutlets" : 3,
 									"outlettype" : [ "bang", "float", "" ],
-									"patching_rect" : [ 59.0, 234.518521547317505, 266.0, 35.0 ],
+									"patching_rect" : [ 52.0, 213.518521547317505, 266.0, 35.0 ],
 									"text" : "fluid.bufonsetslice~ @source fluid.waveform.src @indices fluid.waveform.slices @metric 2"
 								}
 
@@ -1066,7 +1066,7 @@
 									"numoutlets" : 3,
 									"outlettype" : [ "", "", "int" ],
 									"parameter_enable" : 0,
-									"patching_rect" : [ 59.0, 175.566044270992279, 20.0, 20.0 ],
+									"patching_rect" : [ 52.0, 154.566044270992279, 20.0, 20.0 ],
 									"rounded" : 60.0,
 									"text" : "2",
 									"textcolor" : [ 0.34902, 0.34902, 0.34902, 1.0 ],
@@ -1092,7 +1092,7 @@
 									"numoutlets" : 3,
 									"outlettype" : [ "", "", "int" ],
 									"parameter_enable" : 0,
-									"patching_rect" : [ 213.0, 124.5, 20.0, 20.0 ],
+									"patching_rect" : [ 206.0, 103.5, 20.0, 20.0 ],
 									"rounded" : 60.0,
 									"text" : "1",
 									"textcolor" : [ 0.34902, 0.34902, 0.34902, 1.0 ],
@@ -1135,7 +1135,7 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-39", 0 ],
-									"midpoints" : [ 666.444449543952942, 424.759260773658752, 68.5, 424.759260773658752 ],
+									"midpoints" : [ 659.444449543952942, 403.759260773658752, 61.5, 403.759260773658752 ],
 									"source" : [ "obj-62", 0 ]
 								}
 
@@ -1143,7 +1143,7 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-39", 0 ],
-									"midpoints" : [ 26.5, 455.205167561769485, 68.5, 455.205167561769485 ],
+									"midpoints" : [ 19.5, 434.205167561769485, 61.5, 434.205167561769485 ],
 									"source" : [ "obj-9", 0 ]
 								}
 
@@ -1190,14 +1190,14 @@
 						"fileversion" : 1,
 						"appversion" : 						{
 							"major" : 8,
-							"minor" : 1,
-							"revision" : 11,
+							"minor" : 2,
+							"revision" : 2,
 							"architecture" : "x64",
 							"modernui" : 1
 						}
 ,
 						"classnamespace" : "box",
-						"rect" : [ 0.0, 26.0, 1394.0, 930.0 ],
+						"rect" : [ 0.0, 26.0, 988.0, 700.0 ],
 						"bglocked" : 0,
 						"openinpresentation" : 0,
 						"default_fontsize" : 13.0,
@@ -1232,8 +1232,8 @@
 									"maxclass" : "comment",
 									"numinlets" : 1,
 									"numoutlets" : 0,
-									"patching_rect" : [ 15.463916659355164, 876.288610696792603, 513.0, 21.0 ],
-									"text" : "'dump' writes the current state to a dict, but loading is still TODO, so not useful yet"
+									"patching_rect" : [ 15.463916659355164, 663.288610696792603, 513.0, 21.0 ],
+									"text" : "'dump' writes the current state to a dic, but loading is still TODO, so not useful yet"
 								}
 
 							}
@@ -1295,7 +1295,7 @@
 									"numinlets" : 2,
 									"numoutlets" : 4,
 									"outlettype" : [ "dictionary", "", "", "" ],
-									"patching_rect" : [ 15.249425232410431, 843.701033353805542, 50.5, 23.0 ],
+									"patching_rect" : [ 15.249425232410431, 630.701033353805542, 50.5, 23.0 ],
 									"saved_object_attributes" : 									{
 										"embed" : 0,
 										"parameter_enable" : 0,
@@ -1455,7 +1455,7 @@
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
 									"parameter_enable" : 0,
-									"patching_rect" : [ 15.249425232410431, 428.972132682800293, 1315.944449543952942, 398.067990250435855 ],
+									"patching_rect" : [ 15.249425232410431, 428.972132682800293, 606.565008103847504, 183.067990250435855 ],
 									"presentation" : 1,
 									"presentation_rect" : [ 619.573396921157837, 180.243875801563263, 500.59646075963974, 346.481478452682495 ]
 								}
@@ -1654,14 +1654,14 @@
 						"fileversion" : 1,
 						"appversion" : 						{
 							"major" : 8,
-							"minor" : 1,
-							"revision" : 11,
+							"minor" : 2,
+							"revision" : 2,
 							"architecture" : "x64",
 							"modernui" : 1
 						}
 ,
 						"classnamespace" : "box",
-						"rect" : [ 0.0, 26.0, 1394.0, 930.0 ],
+						"rect" : [ 0.0, 26.0, 988.0, 700.0 ],
 						"bglocked" : 0,
 						"openinpresentation" : 0,
 						"default_fontsize" : 12.0,
@@ -1710,31 +1710,6 @@
  ],
 		"lines" : [  ],
 		"dependency_cache" : [ 			{
-				"name" : "helpname.js",
-				"bootpath" : "C74:/help/resources",
-				"type" : "TEXT",
-				"implicit" : 1
-			}
-, 			{
-				"name" : "helpdetails.js",
-				"bootpath" : "C74:/help/resources",
-				"type" : "TEXT",
-				"implicit" : 1
-			}
-, 			{
-				"name" : "fluid.waveform~.js",
-				"bootpath" : "~/Documents/Max 8/Packages/fav4max/javascript",
-				"patcherrelativepath" : "../javascript",
-				"type" : "TEXT",
-				"implicit" : 1
-			}
-, 			{
-				"name" : "helpstarter.js",
-				"bootpath" : "C74:/help/resources",
-				"type" : "TEXT",
-				"implicit" : 1
-			}
-, 			{
 				"name" : "fluid.bufonsetslice~.mxo",
 				"type" : "iLaX"
 			}
@@ -1745,6 +1720,31 @@
 , 			{
 				"name" : "fluid.bufstft~.mxo",
 				"type" : "iLaX"
+			}
+, 			{
+				"name" : "fluid.waveform~.js",
+				"bootpath" : "~/dev/flucoma/max/jsui",
+				"patcherrelativepath" : "../jsui",
+				"type" : "TEXT",
+				"implicit" : 1
+			}
+, 			{
+				"name" : "helpdetails.js",
+				"bootpath" : "C74:/help/resources",
+				"type" : "TEXT",
+				"implicit" : 1
+			}
+, 			{
+				"name" : "helpname.js",
+				"bootpath" : "C74:/help/resources",
+				"type" : "TEXT",
+				"implicit" : 1
+			}
+, 			{
+				"name" : "helpstarter.js",
+				"bootpath" : "C74:/help/resources",
+				"type" : "TEXT",
+				"implicit" : 1
 			}
  ],
 		"autosave" : 0

--- a/help/fluid.waveform~.maxhelp
+++ b/help/fluid.waveform~.maxhelp
@@ -339,7 +339,7 @@
 						}
 ,
 						"classnamespace" : "box",
-						"rect" : [ 34.0, 113.0, 988.0, 700.0 ],
+						"rect" : [ 0.0, 26.0, 988.0, 700.0 ],
 						"bglocked" : 0,
 						"openinpresentation" : 0,
 						"default_fontsize" : 12.0,
@@ -389,7 +389,7 @@
 									"maxclass" : "comment",
 									"numinlets" : 1,
 									"numoutlets" : 0,
-									"patching_rect" : [ 739.0, 285.0, 172.0, 33.0 ],
+									"patching_rect" : [ 751.0, 285.0, 172.0, 33.0 ],
 									"text" : "use color message to change feature curves to red",
 									"textcolor" : [ 0.129411764705882, 0.129411764705882, 0.129411764705882, 0.52 ]
 								}
@@ -401,7 +401,7 @@
 									"maxclass" : "comment",
 									"numinlets" : 1,
 									"numoutlets" : 0,
-									"patching_rect" : [ 599.0, 144.0, 172.0, 20.0 ],
+									"patching_rect" : [ 611.0, 144.0, 172.0, 20.0 ],
 									"text" : "draw pitch + confidence on top",
 									"textcolor" : [ 0.129411764705882, 0.129411764705882, 0.129411764705882, 0.52 ]
 								}
@@ -462,8 +462,8 @@
 									"numinlets" : 2,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 35.0, 299.399652600288391, 221.0, 22.0 ],
-									"text" : "addlayer imagebuf fluid.waveform.mags"
+									"patching_rect" : [ 35.0, 299.399652600288391, 234.0, 22.0 ],
+									"text" : "addlayer imagebuffer fluid.waveform.mags"
 								}
 
 							}
@@ -500,7 +500,7 @@
 									"numoutlets" : 1,
 									"outlettype" : [ "bang" ],
 									"parameter_enable" : 0,
-									"patching_rect" : [ 552.0, 142.0, 24.0, 24.0 ]
+									"patching_rect" : [ 564.0, 142.0, 24.0, 24.0 ]
 								}
 
 							}
@@ -524,8 +524,8 @@
 									"numinlets" : 2,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 552.0, 247.0, 417.0, 22.0 ],
-									"text" : "addlayer featurebuf fluid.waveform.pitch, color fluid.waveform.pitch 1. 0. 0. 1."
+									"patching_rect" : [ 564.0, 247.0, 430.0, 22.0 ],
+									"text" : "addlayer featurebuffer fluid.waveform.pitch, color fluid.waveform.pitch 1. 0. 0. 1."
 								}
 
 							}
@@ -536,8 +536,8 @@
 									"numinlets" : 2,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 266.0, 173.0, 279.0, 22.0 ],
-									"text" : "addlayer audiobuf fluid.waveform.src.layers source"
+									"patching_rect" : [ 266.0, 173.0, 292.0, 22.0 ],
+									"text" : "addlayer audiobuffer fluid.waveform.src.layers source"
 								}
 
 							}
@@ -613,7 +613,7 @@
 									"numinlets" : 1,
 									"numoutlets" : 3,
 									"outlettype" : [ "bang", "float", "" ],
-									"patching_rect" : [ 552.0, 173.0, 197.0, 62.0 ],
+									"patching_rect" : [ 564.0, 173.0, 197.0, 62.0 ],
 									"text" : "fluid.bufpitch~ @source fluid.waveform.src.layers @features fluid.waveform.pitch @unit 0"
 								}
 
@@ -675,7 +675,7 @@
 									"numoutlets" : 3,
 									"outlettype" : [ "", "", "int" ],
 									"parameter_enable" : 0,
-									"patching_rect" : [ 577.0, 142.0, 20.0, 20.0 ],
+									"patching_rect" : [ 589.0, 142.0, 20.0, 20.0 ],
 									"rounded" : 60.0,
 									"text" : "3",
 									"textcolor" : [ 0.34902, 0.34902, 0.34902, 1.0 ],
@@ -767,7 +767,7 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-39", 0 ],
-									"midpoints" : [ 561.5, 366.759260773658752, 44.5, 366.759260773658752 ],
+									"midpoints" : [ 573.5, 366.759260773658752, 44.5, 366.759260773658752 ],
 									"source" : [ "obj-5", 0 ]
 								}
 
@@ -850,6 +850,19 @@
 						"assistshowspatchername" : 0,
 						"boxes" : [ 							{
 								"box" : 								{
+									"id" : "obj-1",
+									"maxclass" : "message",
+									"numinlets" : 2,
+									"numoutlets" : 1,
+									"outlettype" : [ "" ],
+									"patching_rect" : [ 52.0, 305.018521547317505, 337.0, 22.0 ],
+									"presentation_linecount" : 2,
+									"text" : "indicesbuffer fluid.waveform.slices fluid.waveform.src.markers"
+								}
+
+							}
+, 							{
+								"box" : 								{
 									"id" : "obj-13",
 									"linecount" : 2,
 									"maxclass" : "comment",
@@ -891,7 +904,7 @@
 									"maxclass" : "comment",
 									"numinlets" : 1,
 									"numoutlets" : 0,
-									"patching_rect" : [ 72.5, 272.566044270992279, 186.0, 20.0 ],
+									"patching_rect" : [ 206.0, 279.566044270992279, 186.0, 20.0 ],
 									"text" : "markers messages adds markers",
 									"textcolor" : [ 0.129411764705882, 0.129411764705882, 0.129411764705882, 0.52 ]
 								}
@@ -906,18 +919,6 @@
 									"patching_rect" : [ 83.5, 154.566044270992279, 104.0, 20.0 ],
 									"text" : "make some slices",
 									"textcolor" : [ 0.129411764705882, 0.129411764705882, 0.129411764705882, 0.52 ]
-								}
-
-							}
-, 							{
-								"box" : 								{
-									"id" : "obj-5",
-									"maxclass" : "message",
-									"numinlets" : 2,
-									"numoutlets" : 1,
-									"outlettype" : [ "" ],
-									"patching_rect" : [ 52.0, 300.0, 313.0, 22.0 ],
-									"text" : "markers fluid.waveform.slices fluid.waveform.src.markers"
 								}
 
 							}
@@ -952,7 +953,7 @@
 									"maxclass" : "comment",
 									"numinlets" : 1,
 									"numoutlets" : 0,
-									"patching_rect" : [ 231.5, 103.5, 313.0, 20.0 ],
+									"patching_rect" : [ 316.0, 103.5, 145.0, 20.0 ],
 									"text" : "what are we segmenting?",
 									"textcolor" : [ 0.129411764705882, 0.129411764705882, 0.129411764705882, 0.52 ]
 								}
@@ -977,8 +978,8 @@
 									"numinlets" : 2,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 10.0, 103.5, 186.0, 22.0 ],
-									"text" : "buffer fluid.waveform.src.markers"
+									"patching_rect" : [ 10.0, 103.5, 304.0, 22.0 ],
+									"text" : "addlayer audiobuffer fluid.waveform.src.markers source"
 								}
 
 							}
@@ -1106,7 +1107,14 @@
  ],
 						"lines" : [ 							{
 								"patchline" : 								{
-									"destination" : [ "obj-5", 0 ],
+									"destination" : [ "obj-39", 0 ],
+									"source" : [ "obj-1", 0 ]
+								}
+
+							}
+, 							{
+								"patchline" : 								{
+									"destination" : [ "obj-1", 0 ],
 									"source" : [ "obj-20", 0 ]
 								}
 
@@ -1122,13 +1130,6 @@
 								"patchline" : 								{
 									"destination" : [ "obj-62", 0 ],
 									"source" : [ "obj-37", 1 ]
-								}
-
-							}
-, 							{
-								"patchline" : 								{
-									"destination" : [ "obj-39", 0 ],
-									"source" : [ "obj-5", 0 ]
 								}
 
 							}
@@ -1197,7 +1198,7 @@
 						}
 ,
 						"classnamespace" : "box",
-						"rect" : [ 0.0, 26.0, 988.0, 700.0 ],
+						"rect" : [ 34.0, 113.0, 988.0, 700.0 ],
 						"bglocked" : 0,
 						"openinpresentation" : 0,
 						"default_fontsize" : 13.0,
@@ -1352,7 +1353,7 @@
 									"maxclass" : "comment",
 									"numinlets" : 1,
 									"numoutlets" : 0,
-									"patching_rect" : [ 205.749425232410431, 109.050583183765411, 309.0, 36.0 ],
+									"patching_rect" : [ 300.666099548339844, 110.550583183765411, 309.0, 36.0 ],
 									"text" : "buffer <buffer name> will display a buffer as a waveform. see the layers tab for finer control",
 									"textcolor" : [ 0.129411764705882, 0.129411764705882, 0.129411764705882, 0.52 ]
 								}
@@ -1428,8 +1429,8 @@
 									"numinlets" : 2,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 15.249425232410431, 117.050583183765411, 150.0, 23.0 ],
-									"text" : "buffer fluid.waveform.src"
+									"patching_rect" : [ 15.249425232410431, 117.050583183765411, 278.0, 23.0 ],
+									"text" : "addlayer audiobuffer fluid.waveform.src source"
 								}
 
 							}

--- a/help/fluid.waveform~.maxhelp
+++ b/help/fluid.waveform~.maxhelp
@@ -524,8 +524,8 @@
 									"numinlets" : 2,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 564.0, 247.0, 430.0, 22.0 ],
-									"text" : "addlayer featurebuffer fluid.waveform.pitch, color fluid.waveform.pitch 1. 0. 0. 1."
+									"patching_rect" : [ 564.0, 247.0, 436.0, 22.0 ],
+									"text" : "addlayer featuresbuffer fluid.waveform.pitch, color fluid.waveform.pitch 1. 0. 0. 1."
 								}
 
 							}
@@ -855,8 +855,8 @@
 									"numinlets" : 2,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 52.0, 305.018521547317505, 331.0, 22.0 ],
-									"text" : "indicebuffer fluid.waveform.slices fluid.waveform.src.markers"
+									"patching_rect" : [ 52.0, 305.018521547317505, 337.0, 22.0 ],
+									"text" : "indicesbuffer fluid.waveform.slices fluid.waveform.src.markers"
 								}
 
 							}

--- a/help/fluid.waveform~.maxhelp
+++ b/help/fluid.waveform~.maxhelp
@@ -10,7 +10,7 @@
 		}
 ,
 		"classnamespace" : "box",
-		"rect" : [ 34.0, 87.0, 988.0, 726.0 ],
+		"rect" : [ 1257.0, 604.0, 1025.0, 726.0 ],
 		"bglocked" : 0,
 		"openinpresentation" : 0,
 		"default_fontsize" : 12.0,
@@ -57,7 +57,7 @@
 						}
 ,
 						"classnamespace" : "box",
-						"rect" : [ 0.0, 26.0, 988.0, 700.0 ],
+						"rect" : [ 0.0, 26.0, 1025.0, 700.0 ],
 						"bglocked" : 0,
 						"openinpresentation" : 0,
 						"default_fontsize" : 12.0,
@@ -339,7 +339,7 @@
 						}
 ,
 						"classnamespace" : "box",
-						"rect" : [ 0.0, 26.0, 988.0, 700.0 ],
+						"rect" : [ 1257.0, 630.0, 1025.0, 700.0 ],
 						"bglocked" : 0,
 						"openinpresentation" : 0,
 						"default_fontsize" : 12.0,
@@ -819,7 +819,7 @@
 						}
 ,
 						"classnamespace" : "box",
-						"rect" : [ 0.0, 26.0, 988.0, 700.0 ],
+						"rect" : [ 0.0, 26.0, 1025.0, 700.0 ],
 						"bglocked" : 0,
 						"openinpresentation" : 0,
 						"default_fontsize" : 12.0,
@@ -855,9 +855,8 @@
 									"numinlets" : 2,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 52.0, 305.018521547317505, 337.0, 22.0 ],
-									"presentation_linecount" : 2,
-									"text" : "indicesbuffer fluid.waveform.slices fluid.waveform.src.markers"
+									"patching_rect" : [ 52.0, 305.018521547317505, 331.0, 22.0 ],
+									"text" : "indicebuffer fluid.waveform.slices fluid.waveform.src.markers"
 								}
 
 							}
@@ -904,8 +903,8 @@
 									"maxclass" : "comment",
 									"numinlets" : 1,
 									"numoutlets" : 0,
-									"patching_rect" : [ 206.0, 279.566044270992279, 186.0, 20.0 ],
-									"text" : "markers messages adds markers",
+									"patching_rect" : [ 206.0, 279.566044270992279, 252.0, 20.0 ],
+									"text" : "indicesbuffer messages adds vertical markers",
 									"textcolor" : [ 0.129411764705882, 0.129411764705882, 0.129411764705882, 0.52 ]
 								}
 
@@ -916,7 +915,7 @@
 									"maxclass" : "comment",
 									"numinlets" : 1,
 									"numoutlets" : 0,
-									"patching_rect" : [ 83.5, 154.566044270992279, 104.0, 20.0 ],
+									"patching_rect" : [ 78.0, 154.566044270992279, 104.0, 20.0 ],
 									"text" : "make some slices",
 									"textcolor" : [ 0.129411764705882, 0.129411764705882, 0.129411764705882, 0.52 ]
 								}
@@ -942,7 +941,7 @@
 									"numinlets" : 1,
 									"numoutlets" : 0,
 									"patching_rect" : [ 10.0, 69.599853515625, 408.0, 21.0 ],
-									"text" : "show and manipulate markers on top of a wavveform ",
+									"text" : "show and manipulate markers on top of a waveform ",
 									"textcolor" : [ 0.129411764705882, 0.129411764705882, 0.129411764705882, 1.0 ]
 								}
 
@@ -1198,7 +1197,7 @@
 						}
 ,
 						"classnamespace" : "box",
-						"rect" : [ 34.0, 113.0, 988.0, 700.0 ],
+						"rect" : [ 0.0, 26.0, 1025.0, 700.0 ],
 						"bglocked" : 0,
 						"openinpresentation" : 0,
 						"default_fontsize" : 13.0,
@@ -1234,7 +1233,7 @@
 									"numinlets" : 1,
 									"numoutlets" : 0,
 									"patching_rect" : [ 15.463916659355164, 663.288610696792603, 513.0, 21.0 ],
-									"text" : "'dump' writes the current state to a dic, but loading is still TODO, so not useful yet"
+									"text" : "'dump' writes the current state to a dict, but loading is still TODO, so not useful yet"
 								}
 
 							}
@@ -1662,7 +1661,7 @@
 						}
 ,
 						"classnamespace" : "box",
-						"rect" : [ 0.0, 26.0, 988.0, 700.0 ],
+						"rect" : [ 0.0, 26.0, 1025.0, 700.0 ],
 						"bglocked" : 0,
 						"openinpresentation" : 0,
 						"default_fontsize" : 12.0,

--- a/jsui/fav-max.js
+++ b/jsui/fav-max.js
@@ -16,7 +16,7 @@ function _classCallCheck(instance, Constructor) { if (!(instance instanceof Cons
 
 function _defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } }
 
-function _createClass(Constructor, protoProps, staticProps) { if (protoProps) _defineProperties(Constructor.prototype, protoProps); if (staticProps) _defineProperties(Constructor, staticProps); return Constructor; }
+function _createClass(Constructor, protoProps, staticProps) { if (protoProps) _defineProperties(Constructor.prototype, protoProps); if (staticProps) _defineProperties(Constructor, staticProps); Object.defineProperty(Constructor, "prototype", { writable: false }); return Constructor; }
 
 Object.defineProperty(exports, '__esModule', {
   value: true
@@ -123,16 +123,7 @@ var Signal = /*#__PURE__*/function () {
       return new Signal(this.rank == 2 ? this.data.map(function (x) {
         return x.map(f);
       }) : this.data.map(f), this.sampleRate, newType ? newType : this.type, newMin !== null ? newMin : this.min, newMax !== null ? newMax : this.max);
-    } // slice(start, end)
-    // {
-    //   // post("SDSKDLSKDLSDKLSKDD",start,end,'\n')
-    //   throw "HWHQHQHQHQH"
-    //   return new Signal(
-    //     this.rank == 2 ? this.data.map(s => s.slice(start,end)) : this.data.slice(start,end), 
-    //     this.sampleRate, this.type, this.min, this.max
-    //   );
-    // }
-
+    }
   }, {
     key: "draw",
     value: function draw(target, style) {
@@ -150,14 +141,14 @@ Signal.TYPE_INT = 1;
 Signal.TYPE_BINARY = 2;
 var signal = Signal;
 
-var Marker = function Marker(position) {
+var Marker = /*#__PURE__*/_createClass(function Marker(position) {
   var selected = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : false;
 
   _classCallCheck(this, Marker);
 
   this.position = position;
   this.selected = selected;
-};
+});
 
 Marker.prototype.valueOf = function () {
   return this.position;
@@ -263,27 +254,25 @@ var stats = {
   }
 };
 var unaryops = {
-  'threshold': function threshold(th) {
+  "threshold": function threshold(th) {
     return this.map(function (x) {
       return x > th;
     }, 2, 0, 1);
   },
-  'slice': function slice(from, to) {
-    var unit = arguments.length > 2 && arguments[2] !== undefined ? arguments[2] : 'samples';
+  "slice": function slice(from, to) {
+    var unit = arguments.length > 2 && arguments[2] !== undefined ? arguments[2] : "samples";
 
-    if (unit === 'seconds') {
+    if (unit === "seconds") {
       from = Math.round(from * this.sampleRate);
       to = Math.round(to * this.sampleRate);
     }
 
     var clone = this.clone();
-    clone.data = clone.rank == 2 ? clone.data.map(function (s) {
-      return s.slice(from, to);
-    }) : this.data.slice(from, to);
+    clone.data = clone.data.slice(from, to);
     clone.computeRange();
     return clone;
   },
-  'normalize': function normalize() {
+  "normalize": function normalize() {
     var _this = this;
 
     var newDesc = this.map(function (x) {
@@ -293,63 +282,63 @@ var unaryops = {
     newDesc.max = 1;
     return newDesc;
   },
-  'offset': function offset(num) {
+  "offset": function offset(num) {
     return this.map(function (x) {
       return x + num;
     });
   },
-  'log': function log() {
+  "log": function log() {
     return this.map(Math.log).computeRange();
   },
-  'square': function square() {
+  "square": function square() {
     return this.map(function (x) {
       return Math.pow(x, 2);
     });
   },
-  'pow': function pow(n) {
+  "pow": function pow(n) {
     return this.map(function (x) {
       return Math.pow(x, n);
     });
   },
-  'exp': function exp() {
+  "exp": function exp() {
     return this.map(Math.exp);
   },
-  'sqrt': function sqrt() {
+  "sqrt": function sqrt() {
     return this.map(Math.sqrt);
   },
-  'abs': function abs() {
+  "abs": function abs() {
     return this.map(Math.abs);
   },
-  'scale': function scale(num) {
+  "scale": function scale(num) {
     return this.map(function (x) {
       return x * num;
     });
   },
-  'reflect': function reflect(num) {
+  "reflect": function reflect(num) {
     var _this2 = this;
 
     return this.map(function (x) {
       return _this2.max - x;
     });
   },
-  'diff': function diff() {
+  "diff": function diff() {
     var _this3 = this;
 
     return this.map(function (x, i) {
       return i == 0 ? i : x - _this3.data[i - 1];
     }).computeRange();
   },
-  'delay': function delay(n) {
+  "delay": function delay(n) {
     var _this4 = this;
 
     return this.map(function (x, i) {
       return i <= n ? 0 : _this4.data[i - n];
     }).computeRange();
   },
-  'smooth': function smooth(n) {
+  "smooth": function smooth(n) {
     var _this5 = this;
 
-    var stat = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : 'mean';
+    var stat = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : "mean";
     var nPrev = Math.floor(n / 2);
     var newDesc = this.map(function (x, i) {
       return i <= nPrev ? stats[stat](_this5.data.slice(0, n - i)) : stats[stat](_this5.data.slice(i - nPrev, i + n - nPrev));
@@ -357,7 +346,7 @@ var unaryops = {
     newDesc.computeRange();
     return newDesc;
   },
-  'schmitt': function schmitt(th0, th1) {
+  "schmitt": function schmitt(th0, th1) {
     this.clone();
     var state = 0;
 
@@ -370,7 +359,7 @@ var unaryops = {
 
     return this;
   },
-  'slide': function slide(up, down) {
+  "slide": function slide(up, down) {
     up = Math.max(up, 1);
     down = Math.max(down, 1);
     var previous = 0;
@@ -378,13 +367,7 @@ var unaryops = {
 
     for (var i = 0; i < this.length; i++) {
       var current = this.data[i];
-
-      if (current >= previous) {
-        slide = up;
-      } else {
-        slide = down;
-      }
-
+      if (current >= previous) slide = up;else slide = down;
       this.data[i] = previous + (current - previous) / slide;
       previous = this.data[i];
     }
@@ -435,29 +418,6 @@ var binaryops = {
       return x == desc.data[i] ? 1 : 0;
     });
   }
-};
-var samplers = {
-  "sample": function sample(step) {
-    var method = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : "mean";
-    var newSize = Math.ceil(this.data.length / step);
-    var newData = new Array(newSize);
-    var newRate = this.sampleRate / step;
-    this.data.length / step;
-
-    for (var i = 0; i < newSize; i += 1) {
-      var bucketStart = Math.floor(i * step);
-      var bucketEnd = Math.floor((i + 1) * step);
-      if (bucketStart > this.data.length - 1) bucketStart = this.data.length - 1;
-      if (bucketEnd > this.data.length - 1) bucketEnd = this.data.length - 1;
-
-      if (bucketStart === bucketEnd) {
-        newData[i] = i > 0 ? newData[i - 1] : this.data[i];
-      } else newData[i] = stats[method](this.data.slice(bucketStart, bucketEnd));
-    }
-
-    var s = new signal(newData, newRate, this.type);
-    return s;
-  }
 }; // Lightest-weight wrapping around MGraphics possible, to allow for layers to draw into sub-regions of an MGrpahics using function calls that match the HTMLContext names
 
 var SubContext = /*#__PURE__*/function () {
@@ -487,7 +447,7 @@ var SubContext = /*#__PURE__*/function () {
     set: function set(s) {
       var _this$mg;
 
-      (_this$mg = this.mg).set_source_rgb.apply(_this$mg, _toConsumableArray(s));
+      (_this$mg = this.mg).set_source_rgba.apply(_this$mg, _toConsumableArray(s));
 
       this.stroke_style = s;
     }
@@ -887,16 +847,17 @@ var Layer = /*#__PURE__*/function () {
         throw 'Trying to draw 1D signal as image';
       }
 
-      desc = desc.offset(1e-6).log().normalize();
-      var imageData = new Image(desc.length, desc.nBands);
+      desc = desc.offset(1e-6).log().normalize(); //orientation is actually flipped wrt to what Fav.js assumes
 
-      for (var i = 0; i < desc.nBands; i++) {
-        desc.nBands - i;
+      var len = desc.nBands;
+      var bands = desc.length;
+      var imageData = new Image(len, bands);
 
-        for (var j = 0; j < desc.length; j++) {
-          var val = desc.data[j][i];
+      for (var i = 0; i < bands; i++) {
+        for (var j = 0; j < len; j++) {
+          var val = desc.data[i][j];
           var rgb = this.hslToRgb(val, 0, val);
-          imageData.setpixel(j, desc.nBands - i, rgb[0], rgb[1], rgb[2], 1);
+          imageData.setpixel(j, bands - i, rgb[0], rgb[1], rgb[2], 1);
         }
       }
 
@@ -937,6 +898,11 @@ var MarkerLayer = /*#__PURE__*/function () {
   }
 
   _createClass(MarkerLayer, [{
+    key: "setRange",
+    value: function setRange(range) {
+      this.context = new SubContext(this, range);
+    }
+  }, {
     key: "draw",
     value: function draw(desc, style) {
       var extent = desc.length;
@@ -1071,8 +1037,24 @@ var Display = /*#__PURE__*/function () {
   return Display;
 }();
 
-var displayJsui = Display; // import "core-js/stable";
-// import "regenerator-runtime/runtime";
+var displayJsui = Display;
+
+unaryops_1['slice'] = function (from, to) {
+  var unit = arguments.length > 2 && arguments[2] !== undefined ? arguments[2] : "samples";
+
+  if (unit === "seconds") {
+    from = Math.round(from * this.sampleRate);
+    to = Math.round(to * this.sampleRate);
+  }
+
+  var clone = this.clone();
+  clone.data = clone.rank == 2 ? clone.data.map(function (s) {
+    return s.slice(from, to);
+  }) : this.data.slice(from, to); //<-- diff 
+
+  clone.computeRange();
+  return clone;
+};
 
 for (var key in unaryops_1) {
   signal.prototype[key] = unaryops_1[key];
@@ -1080,11 +1062,32 @@ for (var key in unaryops_1) {
 
 for (var key in binaryops) {
   signal.prototype[key] = binaryops[key];
-}
+} // for (var key in samplers) {
+//   Signal.prototype[key] = samplers[key];
+// }
 
-for (var key in samplers) {
-  signal.prototype[key] = samplers[key];
-}
+
+signal.prototype['sample'] = function (step) {
+  var method = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : "mean";
+  var newSize = Math.ceil(this.data.length / step);
+  var newData = new Array(newSize);
+  var newRate = this.sampleRate / step;
+  this.data.length / step;
+
+  for (var i = 0; i < newSize; i += 1) {
+    var bucketStart = Math.floor(i * step);
+    var bucketEnd = Math.floor((i + 1) * step);
+    if (bucketStart > this.data.length - 1) bucketStart = this.data.length - 1;
+    if (bucketEnd > this.data.length - 1) bucketEnd = this.data.length - 1;
+
+    if (bucketStart === bucketEnd) {
+      newData[i] = i > 0 ? newData[i - 1] : this.data[i]; //<------- diff
+    } else newData[i] = stats[method](this.data.slice(bucketStart, bucketEnd));
+  }
+
+  var s = new signal(newData, newRate, this.type);
+  return s;
+};
 
 var apiMax = {
   "Signal": signal,

--- a/jsui/fluid.waveform~.js
+++ b/jsui/fluid.waveform~.js
@@ -206,7 +206,7 @@ function addlayer (type, source, _name) {
 
   var layerTypes = {
     'imagebuffer' : 'image',
-    'featurebuffer' : 'line',
+    'featuresbuffer' : 'line',
     'audiobuffer' : 'wave',
     'line' : 'line',
     'image' : 'image',
@@ -233,7 +233,7 @@ function addlayer (type, source, _name) {
   refresh(); 
 }
 
-function indicebuffer(source, reference, _name) {
+function indicesbuffer(source, reference, _name) {
   addmarkers(source, reference, _name);
 }
 

--- a/jsui/fluid.waveform~.js
+++ b/jsui/fluid.waveform~.js
@@ -205,9 +205,9 @@ function addlayer (type, source, _name) {
   const index = find(_name ? _name : source); 
 
   var layerTypes = {
-    'imagebuf' : 'image',
-    'featurebuf' : 'line',
-    'audiobuf' : 'wave',
+    'imagebuffer' : 'image',
+    'featurebuffer' : 'line',
+    'audiobuffer' : 'wave',
     'line' : 'line',
     'image' : 'image',
     'wave' : 'wave'

--- a/jsui/fluid.waveform~.js
+++ b/jsui/fluid.waveform~.js
@@ -233,7 +233,7 @@ function addlayer (type, source, _name) {
   refresh(); 
 }
 
-function indicesbuffer(source, reference, _name) {
+function indicebuffer(source, reference, _name) {
   addmarkers(source, reference, _name);
 }
 

--- a/jsui/fluid.waveform~.js
+++ b/jsui/fluid.waveform~.js
@@ -233,6 +233,10 @@ function addlayer (type, source, _name) {
   refresh(); 
 }
 
+function indicesbuffer(source, reference, _name) {
+  addmarkers(source, reference, _name);
+}
+
 function addmarkers(source, reference, _name)
 {
   if (!reference || !source) error('marker layer must have a source (buffer) and a reference (buffer or sample rate)\n');


### PR DESCRIPTION
Updates fluid.waveform~ to have parity with the SuperCollider waveform.

`addlayer line` is now `addlayer featurebuf`.

`addlayer image` is now `addlayer imagebuf`

`addlayer wave` is now `addlayer audiobuf`

All calls are backwards compatible too.
