### PR TITLE
[Fix] BufChroma sonification adapts to numchroma

### DIFF
--- a/help/fluid.bufchroma~.maxhelp
+++ b/help/fluid.bufchroma~.maxhelp
@@ -100,6 +100,30 @@
 						"assistshowspatchername" : 0,
 						"boxes" : [ 							{
 								"box" : 								{
+									"id" : "obj-22",
+									"maxclass" : "newobj",
+									"numinlets" : 2,
+									"numoutlets" : 2,
+									"outlettype" : [ "", "" ],
+									"patching_rect" : [ 301.0, 420.0, 103.0, 22.0 ],
+									"text" : "route numchroma"
+								}
+
+							}
+, 							{
+								"box" : 								{
+									"id" : "obj-18",
+									"maxclass" : "message",
+									"numinlets" : 2,
+									"numoutlets" : 1,
+									"outlettype" : [ "" ],
+									"patching_rect" : [ 51.5, 310.0, 89.0, 22.0 ],
+									"text" : "getnumchroma"
+								}
+
+							}
+, 							{
+								"box" : 								{
 									"id" : "obj-17",
 									"maxclass" : "newobj",
 									"numinlets" : 1,
@@ -200,7 +224,7 @@
  ]
 									}
 ,
-									"patching_rect" : [ 10.0, 400.0, 80.0, 22.0 ],
+									"patching_rect" : [ 10.0, 420.0, 80.0, 22.0 ],
 									"saved_object_attributes" : 									{
 										"description" : "",
 										"digest" : "",
@@ -217,12 +241,12 @@
 									"fontname" : "Arial",
 									"fontsize" : 13.0,
 									"id" : "obj-2",
-									"linecount" : 4,
+									"linecount" : 8,
 									"maxclass" : "comment",
 									"numinlets" : 1,
 									"numoutlets" : 0,
-									"patching_rect" : [ 330.0, 302.0, 410.0, 65.0 ],
-									"text" : "More chromas can be specified with both the @numchroma attribute and by providing the maximum number of chromas as the first argument. The chroma values are also scaled with @normalize 1, meaning each collection of chromas will sum to a value of 1.",
+									"patching_rect" : [ 390.0, 236.0, 410.0, 123.0 ],
+									"text" : "More chromas can be specified with both the @numchroma attribute and by providing the maximum number of chromas as the first argument. You can allocate a higher maximum chroma than numchromas. However, this will result in empty channels that you will need to account for.\n\nThe chroma values are also scaled with @normalize 1, meaning each collection of chromas will sum to a value of 1.",
 									"textcolor" : [ 0.501961, 0.501961, 0.501961, 1.0 ]
 								}
 
@@ -991,7 +1015,7 @@
 									"maxclass" : "comment",
 									"numinlets" : 1,
 									"numoutlets" : 0,
-									"patching_rect" : [ 671.0, 456.0, 146.0, 50.0 ],
+									"patching_rect" : [ 551.0, 500.0, 146.0, 50.0 ],
 									"text" : "Feature buffer has 19 channels. One channel for each pitch class.",
 									"textcolor" : [ 0.501961, 0.501961, 0.501961, 1.0 ]
 								}
@@ -1001,7 +1025,7 @@
 								"box" : 								{
 									"id" : "obj-69",
 									"maxclass" : "newobj",
-									"numinlets" : 1,
+									"numinlets" : 2,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
 									"patcher" : 									{
@@ -1045,13 +1069,14 @@
 										"assistshowspatchername" : 0,
 										"boxes" : [ 											{
 												"box" : 												{
-													"id" : "obj-1",
-													"maxclass" : "newobj",
-													"numinlets" : 1,
-													"numoutlets" : 9,
-													"outlettype" : [ "float", "list", "float", "float", "float", "float", "float", "", "int" ],
-													"patching_rect" : [ 17.0, 253.0, 168.0, 22.0 ],
-													"text" : "info~ bufchroma.help.features"
+													"comment" : "",
+													"id" : "obj-2",
+													"index" : 2,
+													"maxclass" : "inlet",
+													"numinlets" : 0,
+													"numoutlets" : 1,
+													"outlettype" : [ "" ],
+													"patching_rect" : [ 232.0, 242.0, 30.0, 30.0 ]
 												}
 
 											}
@@ -1216,9 +1241,8 @@
  ],
 										"lines" : [ 											{
 												"patchline" : 												{
-													"destination" : [ "obj-58", 0 ],
-													"midpoints" : [ 175.5, 278.0, 26.5, 278.0 ],
-													"source" : [ "obj-1", 8 ]
+													"destination" : [ "obj-58", 1 ],
+													"source" : [ "obj-2", 0 ]
 												}
 
 											}
@@ -1289,7 +1313,7 @@
 											}
 , 											{
 												"patchline" : 												{
-													"destination" : [ "obj-1", 0 ],
+													"destination" : [ "obj-58", 0 ],
 													"source" : [ "obj-59", 0 ]
 												}
 
@@ -1297,7 +1321,7 @@
 , 											{
 												"patchline" : 												{
 													"destination" : [ "obj-60", 1 ],
-													"midpoints" : [ 97.5, 239.0, 273.0, 239.0, 273.0, 356.0, 252.0, 356.0 ],
+													"midpoints" : [ 97.5, 231.0, 273.0, 231.0, 273.0, 357.0, 252.0, 357.0 ],
 													"source" : [ "obj-59", 1 ]
 												}
 
@@ -1320,7 +1344,7 @@
 , 											{
 												"patchline" : 												{
 													"destination" : [ "obj-37", 2 ],
-													"midpoints" : [ 252.0, 356.0, 396.5, 356.0 ],
+													"midpoints" : [ 252.0, 357.0, 396.5, 357.0 ],
 													"source" : [ "obj-65", 1 ]
 												}
 
@@ -1328,7 +1352,7 @@
 , 											{
 												"patchline" : 												{
 													"destination" : [ "obj-60", 0 ],
-													"midpoints" : [ 241.5, 344.0, 241.5, 344.0 ],
+													"midpoints" : [ 241.5, 345.0, 241.5, 345.0 ],
 													"source" : [ "obj-65", 0 ]
 												}
 
@@ -1366,7 +1390,7 @@
 									"orientation" : 0,
 									"outlettype" : [ "", "" ],
 									"parameter_enable" : 0,
-									"patching_rect" : [ 10.0, 440.0, 450.0, 130.0 ],
+									"patching_rect" : [ 10.0, 480.0, 310.0, 90.0 ],
 									"setminmax" : [ 0.0, 1.0 ],
 									"slidercolor" : [ 1.0, 0.792156862745098, 0.0, 1.0 ]
 								}
@@ -1687,7 +1711,7 @@
 									"numoutlets" : 2,
 									"outlettype" : [ "", "bang" ],
 									"parameter_enable" : 0,
-									"patching_rect" : [ 619.0, 470.0, 50.0, 22.0 ]
+									"patching_rect" : [ 499.0, 514.0, 50.0, 22.0 ]
 								}
 
 							}
@@ -1720,7 +1744,7 @@
 									"numinlets" : 1,
 									"numoutlets" : 9,
 									"outlettype" : [ "float", "list", "float", "float", "float", "float", "float", "", "int" ],
-									"patching_rect" : [ 470.0, 440.0, 168.0, 22.0 ],
+									"patching_rect" : [ 350.0, 480.0, 168.0, 22.0 ],
 									"text" : "info~ bufchroma.help.features"
 								}
 
@@ -1734,7 +1758,7 @@
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
 									"parameter_enable" : 0,
-									"patching_rect" : [ 10.0, 440.0, 450.0, 130.0 ]
+									"patching_rect" : [ 10.0, 480.0, 310.0, 90.0 ]
 								}
 
 							}
@@ -1922,7 +1946,7 @@
 									"numinlets" : 1,
 									"numoutlets" : 3,
 									"outlettype" : [ "bang", "float", "" ],
-									"patching_rect" : [ 10.0, 310.0, 310.0, 49.0 ],
+									"patching_rect" : [ 10.0, 349.0, 310.0, 49.0 ],
 									"text" : "fluid.bufchroma~ 19 @source bufchroma.help.src.mono @features bufchroma.help.features @numchroma 19 @normalize 1 @fftsettings 4096 1024 4096"
 								}
 
@@ -1931,7 +1955,7 @@
 						"lines" : [ 							{
 								"patchline" : 								{
 									"destination" : [ "obj-16", 0 ],
-									"midpoints" : [ 19.5, 385.0, 479.5, 385.0 ],
+									"midpoints" : [ 19.5, 408.0, 288.0, 408.0, 288.0, 465.0, 359.5, 465.0 ],
 									"order" : 0,
 									"source" : [ "obj-1", 0 ]
 								}
@@ -1940,8 +1964,16 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-17", 0 ],
+									"midpoints" : [ 19.5, 399.0, 19.5, 399.0 ],
 									"order" : 1,
 									"source" : [ "obj-1", 0 ]
+								}
+
+							}
+, 							{
+								"patchline" : 								{
+									"destination" : [ "obj-22", 0 ],
+									"source" : [ "obj-1", 2 ]
 								}
 
 							}
@@ -1964,6 +1996,17 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-1", 0 ],
+									"midpoints" : [ 19.5, 294.0, 19.5, 294.0 ],
+									"order" : 1,
+									"source" : [ "obj-13", 0 ]
+								}
+
+							}
+, 							{
+								"patchline" : 								{
+									"destination" : [ "obj-18", 0 ],
+									"midpoints" : [ 19.5, 306.0, 61.0, 306.0 ],
+									"order" : 0,
 									"source" : [ "obj-13", 0 ]
 								}
 
@@ -1978,7 +2021,16 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-25", 0 ],
+									"midpoints" : [ 19.5, 435.0, 19.5, 435.0 ],
 									"source" : [ "obj-17", 0 ]
+								}
+
+							}
+, 							{
+								"patchline" : 								{
+									"destination" : [ "obj-1", 0 ],
+									"midpoints" : [ 61.0, 333.0, 19.5, 333.0 ],
+									"source" : [ "obj-18", 0 ]
 								}
 
 							}
@@ -1986,6 +2038,14 @@
 								"patchline" : 								{
 									"destination" : [ "obj-69", 0 ],
 									"source" : [ "obj-21", 0 ]
+								}
+
+							}
+, 							{
+								"patchline" : 								{
+									"destination" : [ "obj-69", 1 ],
+									"midpoints" : [ 310.5, 465.0, 330.0, 465.0, 330.0, 582.0, 103.5, 582.0 ],
+									"source" : [ "obj-22", 0 ]
 								}
 
 							}
@@ -2134,7 +2194,7 @@
 						}
 ,
 						"classnamespace" : "box",
-						"rect" : [ 0.0, 26.0, 835.0, 736.0 ],
+						"rect" : [ 100.0, 126.0, 835.0, 736.0 ],
 						"bglocked" : 0,
 						"openinpresentation" : 0,
 						"default_fontsize" : 12.0,
@@ -3930,8 +3990,8 @@
 			}
 , 			{
 				"name" : "fluid.bufloader.maxpat",
-				"bootpath" : "~/dev/flucoma/max/misc",
-				"patcherrelativepath" : "../misc",
+				"bootpath" : "~/dev/flucoma/max/patchers",
+				"patcherrelativepath" : "../patchers",
 				"type" : "JSON",
 				"implicit" : 1
 			}


### PR DESCRIPTION
The current patch has adapts to the maxnumchroma, rather than the numchroma. This PR changes it so that the sonification patch for the chroma respects the numchroma.﻿
