### PR TITLE
Max buffer references weren't being freed safely (ASan)

### DIFF
--- a/source/include/MaxBufferAdaptor.hpp
+++ b/source/include/MaxBufferAdaptor.hpp
@@ -38,7 +38,10 @@ public:
 //      ;
     lock(); 
     release();
-    if (mBufref) object_free(mBufref);
+    t_buffer_ref* tmp{nullptr};
+    using std::swap;
+    swap(tmp,mBufref);
+    if (tmp) object_free(tmp);
   }
 
   MaxBufferAdaptor(const MaxBufferAdaptor&) = delete;


### PR DESCRIPTION
Address Sanitizer found out that when our objects are destroyed we weren't being completely safe with buffer references