### PR TITLE
Add ampcurve, onsetcurve, noveltycurve + buf versions

### DIFF
--- a/source/projects/fluid.ampcurve_tilde/CMakeLists.txt
+++ b/source/projects/fluid.ampcurve_tilde/CMakeLists.txt
@@ -1,0 +1,19 @@
+# Part of the Fluid Corpus Manipulation Project (http://www.flucoma.org/)
+# Copyright 2017-2019 University of Huddersfield.
+# Licensed under the BSD-3 License.
+# See license.md file in the project root for full license information.
+# This project has received funding from the European Research Council (ERC)
+# under the European Union’s Horizon 2020 research and innovation programme
+# (grant agreement No 725899).
+
+cmake_minimum_required(VERSION 3.11)
+
+include(${CMAKE_CURRENT_SOURCE_DIR}/../../script/max-pretarget.cmake)
+
+add_library(
+	${PROJECT_NAME}
+	MODULE
+	${THIS_FOLDER_NAME}.cpp
+)
+
+include(${CMAKE_CURRENT_SOURCE_DIR}/../../script/max-posttarget.cmake)

--- a/source/projects/fluid.ampcurve_tilde/fluid.ampcurve_tilde.cpp
+++ b/source/projects/fluid.ampcurve_tilde/fluid.ampcurve_tilde.cpp
@@ -1,0 +1,18 @@
+/*
+Part of the Fluid Corpus Manipulation Project (http://www.flucoma.org/)
+Copyright 2017-2019 University of Huddersfield.
+Licensed under the BSD-3 License.
+See license.md file in the project root for full license information.
+This project has received funding from the European Research Council (ERC)
+under the European Union’s Horizon 2020 research and innovation programme
+(grant agreement No 725899).
+*/
+
+#include <clients/rt/AmpFeatureClient.hpp>
+#include "FluidMaxWrapper.hpp" //nb: this include is order-sensitive because of macro name clashes in Eigen and C74
+
+void ext_main(void*)
+{
+  using namespace fluid::client;
+  makeMaxWrapper<RTAmpFeatureClient>("fluid.ampcurve~");
+}

--- a/source/projects/fluid.bufampcurve_tilde/CMakeLists.txt
+++ b/source/projects/fluid.bufampcurve_tilde/CMakeLists.txt
@@ -1,0 +1,19 @@
+# Part of the Fluid Corpus Manipulation Project (http://www.flucoma.org/)
+# Copyright 2017-2019 University of Huddersfield.
+# Licensed under the BSD-3 License.
+# See license.md file in the project root for full license information.
+# This project has received funding from the European Research Council (ERC)
+# under the European Union’s Horizon 2020 research and innovation programme
+# (grant agreement No 725899).
+
+cmake_minimum_required(VERSION 3.11)
+
+include(${CMAKE_CURRENT_SOURCE_DIR}/../../script/max-pretarget.cmake)
+
+add_library(
+	${PROJECT_NAME}
+	MODULE
+	${THIS_FOLDER_NAME}.cpp
+)
+
+include(${CMAKE_CURRENT_SOURCE_DIR}/../../script/max-posttarget.cmake)

--- a/source/projects/fluid.bufampcurve_tilde/fluid.bufampcurve_tilde.cpp
+++ b/source/projects/fluid.bufampcurve_tilde/fluid.bufampcurve_tilde.cpp
@@ -1,0 +1,18 @@
+/*
+Part of the Fluid Corpus Manipulation Project (http://www.flucoma.org/)
+Copyright 2017-2019 University of Huddersfield.
+Licensed under the BSD-3 License.
+See license.md file in the project root for full license information.
+This project has received funding from the European Research Council (ERC)
+under the European Union’s Horizon 2020 research and innovation programme
+(grant agreement No 725899).
+*/
+
+#include <clients/rt/AmpFeatureClient.hpp>
+#include "FluidMaxWrapper.hpp" //nb: this include is order-sensitive because of macro name clashes in Eigen and C74
+
+void ext_main(void*)
+{
+  using namespace fluid::client;
+  makeMaxWrapper<NRTThreadedAmpFeatureClient>("fluid.bufampcurve~");
+}

--- a/source/projects/fluid.bufnoveltycurve_tilde/CMakeLists.txt
+++ b/source/projects/fluid.bufnoveltycurve_tilde/CMakeLists.txt
@@ -1,0 +1,19 @@
+# Part of the Fluid Corpus Manipulation Project (http://www.flucoma.org/)
+# Copyright 2017-2019 University of Huddersfield.
+# Licensed under the BSD-3 License.
+# See license.md file in the project root for full license information.
+# This project has received funding from the European Research Council (ERC)
+# under the European Union’s Horizon 2020 research and innovation programme
+# (grant agreement No 725899).
+
+cmake_minimum_required(VERSION 3.11)
+
+include(${CMAKE_CURRENT_SOURCE_DIR}/../../script/max-pretarget.cmake)
+
+add_library(
+	${PROJECT_NAME}
+	MODULE
+	${THIS_FOLDER_NAME}.cpp
+)
+
+include(${CMAKE_CURRENT_SOURCE_DIR}/../../script/max-posttarget.cmake)

--- a/source/projects/fluid.bufnoveltycurve_tilde/fluid.bufnoveltycurve_tilde.cpp
+++ b/source/projects/fluid.bufnoveltycurve_tilde/fluid.bufnoveltycurve_tilde.cpp
@@ -1,0 +1,18 @@
+/*
+Part of the Fluid Corpus Manipulation Project (http://www.flucoma.org/)
+Copyright 2017-2019 University of Huddersfield.
+Licensed under the BSD-3 License.
+See license.md file in the project root for full license information.
+This project has received funding from the European Research Council (ERC)
+under the European Union’s Horizon 2020 research and innovation programme
+(grant agreement No 725899).
+*/
+
+#include <clients/rt/NoveltyFeatureClient.hpp>
+#include "FluidMaxWrapper.hpp" //nb: this include is order-sensitive because of macro name clashes in Eigen and C74
+
+void ext_main(void*)
+{
+  using namespace fluid::client;
+  makeMaxWrapper<NRTThreadedNoveltyFeatureClient>("fluid.bufnoveltycurve~");
+}

--- a/source/projects/fluid.bufonsetcurve_tilde/CMakeLists.txt
+++ b/source/projects/fluid.bufonsetcurve_tilde/CMakeLists.txt
@@ -1,0 +1,19 @@
+# Part of the Fluid Corpus Manipulation Project (http://www.flucoma.org/)
+# Copyright 2017-2019 University of Huddersfield.
+# Licensed under the BSD-3 License.
+# See license.md file in the project root for full license information.
+# This project has received funding from the European Research Council (ERC)
+# under the European Union’s Horizon 2020 research and innovation programme
+# (grant agreement No 725899).
+
+cmake_minimum_required(VERSION 3.11)
+
+include(${CMAKE_CURRENT_SOURCE_DIR}/../../script/max-pretarget.cmake)
+
+add_library(
+	${PROJECT_NAME}
+	MODULE
+	${THIS_FOLDER_NAME}.cpp
+)
+
+include(${CMAKE_CURRENT_SOURCE_DIR}/../../script/max-posttarget.cmake)

--- a/source/projects/fluid.bufonsetcurve_tilde/fluid.bufonsetcurve_tilde.cpp
+++ b/source/projects/fluid.bufonsetcurve_tilde/fluid.bufonsetcurve_tilde.cpp
@@ -1,0 +1,18 @@
+/*
+Part of the Fluid Corpus Manipulation Project (http://www.flucoma.org/)
+Copyright 2017-2019 University of Huddersfield.
+Licensed under the BSD-3 License.
+See license.md file in the project root for full license information.
+This project has received funding from the European Research Council (ERC)
+under the European Union’s Horizon 2020 research and innovation programme
+(grant agreement No 725899).
+*/
+
+#include <clients/rt/OnsetFeatureClient.hpp>
+#include "FluidMaxWrapper.hpp" //nb: this include is order-sensitive because of macro name clashes in Eigen and C74
+
+void ext_main(void*)
+{
+  using namespace fluid::client;
+  makeMaxWrapper<NRTThreadedOnsetFeatureClient>("fluid.bufonsetcurve~");
+}

--- a/source/projects/fluid.noveltycurve_tilde/CMakeLists.txt
+++ b/source/projects/fluid.noveltycurve_tilde/CMakeLists.txt
@@ -1,0 +1,19 @@
+# Part of the Fluid Corpus Manipulation Project (http://www.flucoma.org/)
+# Copyright 2017-2019 University of Huddersfield.
+# Licensed under the BSD-3 License.
+# See license.md file in the project root for full license information.
+# This project has received funding from the European Research Council (ERC)
+# under the European Union’s Horizon 2020 research and innovation programme
+# (grant agreement No 725899).
+
+cmake_minimum_required(VERSION 3.11)
+
+include(${CMAKE_CURRENT_SOURCE_DIR}/../../script/max-pretarget.cmake)
+
+add_library(
+	${PROJECT_NAME}
+	MODULE
+	${THIS_FOLDER_NAME}.cpp
+)
+
+include(${CMAKE_CURRENT_SOURCE_DIR}/../../script/max-posttarget.cmake)

--- a/source/projects/fluid.noveltycurve_tilde/fluid.noveltycurve_tilde.cpp
+++ b/source/projects/fluid.noveltycurve_tilde/fluid.noveltycurve_tilde.cpp
@@ -1,0 +1,18 @@
+/*
+Part of the Fluid Corpus Manipulation Project (http://www.flucoma.org/)
+Copyright 2017-2019 University of Huddersfield.
+Licensed under the BSD-3 License.
+See license.md file in the project root for full license information.
+This project has received funding from the European Research Council (ERC)
+under the European Union’s Horizon 2020 research and innovation programme
+(grant agreement No 725899).
+*/
+
+#include <clients/rt/NoveltyFeatureClient.hpp>
+#include "FluidMaxWrapper.hpp" //nb: this include is order-sensitive because of macro name clashes in Eigen and C74
+
+void ext_main(void*)
+{
+  using namespace fluid::client;
+  makeMaxWrapper<RTNoveltyFeatureClient>("fluid.noveltycurve~");
+}

--- a/source/projects/fluid.onsetcurve_tilde/CMakeLists.txt
+++ b/source/projects/fluid.onsetcurve_tilde/CMakeLists.txt
@@ -1,0 +1,19 @@
+# Part of the Fluid Corpus Manipulation Project (http://www.flucoma.org/)
+# Copyright 2017-2019 University of Huddersfield.
+# Licensed under the BSD-3 License.
+# See license.md file in the project root for full license information.
+# This project has received funding from the European Research Council (ERC)
+# under the European Union’s Horizon 2020 research and innovation programme
+# (grant agreement No 725899).
+
+cmake_minimum_required(VERSION 3.11)
+
+include(${CMAKE_CURRENT_SOURCE_DIR}/../../script/max-pretarget.cmake)
+
+add_library(
+	${PROJECT_NAME}
+	MODULE
+	${THIS_FOLDER_NAME}.cpp
+)
+
+include(${CMAKE_CURRENT_SOURCE_DIR}/../../script/max-posttarget.cmake)

--- a/source/projects/fluid.onsetcurve_tilde/fluid.onsetcurve_tilde.cpp
+++ b/source/projects/fluid.onsetcurve_tilde/fluid.onsetcurve_tilde.cpp
@@ -1,0 +1,18 @@
+/*
+Part of the Fluid Corpus Manipulation Project (http://www.flucoma.org/)
+Copyright 2017-2019 University of Huddersfield.
+Licensed under the BSD-3 License.
+See license.md file in the project root for full license information.
+This project has received funding from the European Research Council (ERC)
+under the European Union’s Horizon 2020 research and innovation programme
+(grant agreement No 725899).
+*/
+
+#include <clients/rt/OnsetFeatureClient.hpp>
+#include "FluidMaxWrapper.hpp" //nb: this include is order-sensitive because of macro name clashes in Eigen and C74
+
+void ext_main(void*)
+{
+  using namespace fluid::client;
+  makeMaxWrapper<RTOnsetFeatureClient>("fluid.onsetcurve~");
+}


### PR DESCRIPTION
See https://github.com/flucoma/flucoma-core/pull/114 

Max objects that produce the features used for slice detection in ampslice, noveltyslice, onsetslice, called `fluid.[whatever]curve~` (which we can think about)