### PR TITLE
[Fix] Broken patches due to new dataset/buffer interface interface

### DIFF
--- a/help/fluid.bufstats~.maxhelp
+++ b/help/fluid.bufstats~.maxhelp
@@ -3,8 +3,8 @@
 		"fileversion" : 1,
 		"appversion" : 		{
 			"major" : 8,
-			"minor" : 1,
-			"revision" : 11,
+			"minor" : 3,
+			"revision" : 0,
 			"architecture" : "x64",
 			"modernui" : 1
 		}
@@ -50,8 +50,8 @@
 						"fileversion" : 1,
 						"appversion" : 						{
 							"major" : 8,
-							"minor" : 1,
-							"revision" : 11,
+							"minor" : 3,
+							"revision" : 0,
 							"architecture" : "x64",
 							"modernui" : 1
 						}
@@ -130,7 +130,7 @@
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
 									"patching_rect" : [ 818.0, 468.0, 115.0, 22.0 ],
-									"text" : "6. 14."
+									"text" : "press bang to see..."
 								}
 
 							}
@@ -145,8 +145,8 @@
 										"fileversion" : 1,
 										"appversion" : 										{
 											"major" : 8,
-											"minor" : 1,
-											"revision" : 11,
+											"minor" : 3,
+											"revision" : 0,
 											"architecture" : "x64",
 											"modernui" : 1
 										}
@@ -428,9 +428,9 @@
 												"box" : 												{
 													"id" : "obj-13",
 													"maxclass" : "newobj",
-													"numinlets" : 1,
-													"numoutlets" : 3,
-													"outlettype" : [ "bang", "float", "" ],
+													"numinlets" : 2,
+													"numoutlets" : 2,
+													"outlettype" : [ "", "" ],
 													"patching_rect" : [ 50.0, 130.0, 359.0, 22.0 ],
 													"text" : "fluid.bufstats~ @stats bufstats.help.outliers.iqr @low 25 @high 75"
 												}
@@ -660,17 +660,17 @@
 , 											{
 												"name" : "max6message",
 												"default" : 												{
-													"textcolor_inverse" : [ 0.0, 0.0, 0.0, 1.0 ],
 													"bgfillcolor" : 													{
-														"type" : "gradient",
+														"angle" : 270.0,
+														"autogradient" : 0,
+														"color" : [ 0.290196, 0.309804, 0.301961, 1.0 ],
 														"color1" : [ 0.866667, 0.866667, 0.866667, 1.0 ],
 														"color2" : [ 0.788235, 0.788235, 0.788235, 1.0 ],
-														"color" : [ 0.290196, 0.309804, 0.301961, 1.0 ],
-														"angle" : 270.0,
 														"proportion" : 0.39,
-														"autogradient" : 0
+														"type" : "gradient"
 													}
-
+,
+													"textcolor_inverse" : [ 0.0, 0.0, 0.0, 1.0 ]
 												}
 ,
 												"parentstyle" : "max6box",
@@ -716,9 +716,9 @@
 								"box" : 								{
 									"id" : "obj-18",
 									"maxclass" : "newobj",
-									"numinlets" : 1,
-									"numoutlets" : 3,
-									"outlettype" : [ "bang", "float", "" ],
+									"numinlets" : 2,
+									"numoutlets" : 2,
+									"outlettype" : [ "", "" ],
 									"patching_rect" : [ 422.0, 433.0, 387.0, 22.0 ],
 									"text" : "fluid.bufstats~ @stats bufstats.help.outliers.stripped @outlierscutoff 1.5"
 								}
@@ -822,9 +822,9 @@
 								"box" : 								{
 									"id" : "obj-13",
 									"maxclass" : "newobj",
-									"numinlets" : 1,
-									"numoutlets" : 3,
-									"outlettype" : [ "bang", "float", "" ],
+									"numinlets" : 2,
+									"numoutlets" : 2,
+									"outlettype" : [ "", "" ],
 									"patching_rect" : [ 95.0, 438.0, 266.0, 22.0 ],
 									"text" : "fluid.bufstats~ @stats bufstats.help.outliers.plain"
 								}
@@ -940,6 +940,7 @@
 									"numinlets" : 1,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
+									"parameter_enable" : 0,
 									"patching_rect" : [ 422.0, 359.0, 150.0, 22.0 ]
 								}
 
@@ -1187,17 +1188,17 @@
 , 							{
 								"name" : "max6message",
 								"default" : 								{
-									"textcolor_inverse" : [ 0.0, 0.0, 0.0, 1.0 ],
 									"bgfillcolor" : 									{
-										"type" : "gradient",
+										"angle" : 270.0,
+										"autogradient" : 0,
+										"color" : [ 0.290196, 0.309804, 0.301961, 1.0 ],
 										"color1" : [ 0.866667, 0.866667, 0.866667, 1.0 ],
 										"color2" : [ 0.788235, 0.788235, 0.788235, 1.0 ],
-										"color" : [ 0.290196, 0.309804, 0.301961, 1.0 ],
-										"angle" : 270.0,
 										"proportion" : 0.39,
-										"autogradient" : 0
+										"type" : "gradient"
 									}
-
+,
+									"textcolor_inverse" : [ 0.0, 0.0, 0.0, 1.0 ]
 								}
 ,
 								"parentstyle" : "max6box",
@@ -1238,14 +1239,14 @@
 						"fileversion" : 1,
 						"appversion" : 						{
 							"major" : 8,
-							"minor" : 1,
-							"revision" : 11,
+							"minor" : 3,
+							"revision" : 0,
 							"architecture" : "x64",
 							"modernui" : 1
 						}
 ,
 						"classnamespace" : "box",
-						"rect" : [ 100.0, 126.0, 1057.0, 825.0 ],
+						"rect" : [ 0.0, 26.0, 1057.0, 825.0 ],
 						"bglocked" : 0,
 						"openinpresentation" : 0,
 						"default_fontsize" : 12.0,
@@ -1276,25 +1277,26 @@
 						"assistshowspatchername" : 0,
 						"boxes" : [ 							{
 								"box" : 								{
-									"id" : "obj-10",
-									"maxclass" : "newobj",
+									"id" : "obj-21",
+									"maxclass" : "message",
 									"numinlets" : 2,
-									"numoutlets" : 2,
-									"outlettype" : [ "", "" ],
-									"patching_rect" : [ 159.0, 379.0, 70.0, 22.0 ],
-									"text" : "route buffer"
+									"numoutlets" : 1,
+									"outlettype" : [ "" ],
+									"patching_rect" : [ 159.0, 398.0, 99.0, 22.0 ],
+									"presentation_linecount" : 2,
+									"text" : "weights $2, bang"
 								}
 
 							}
 , 							{
 								"box" : 								{
-									"id" : "obj-8",
-									"maxclass" : "newobj",
+									"id" : "obj-18",
+									"maxclass" : "message",
 									"numinlets" : 2,
-									"numoutlets" : 2,
-									"outlettype" : [ "", "" ],
-									"patching_rect" : [ 27.0, 379.0, 70.0, 22.0 ],
-									"text" : "route buffer"
+									"numoutlets" : 1,
+									"outlettype" : [ "" ],
+									"patching_rect" : [ 27.0, 398.0, 56.0, 22.0 ],
+									"text" : "buffer $2"
 								}
 
 							}
@@ -1348,8 +1350,8 @@
 										"fileversion" : 1,
 										"appversion" : 										{
 											"major" : 8,
-											"minor" : 1,
-											"revision" : 11,
+											"minor" : 3,
+											"revision" : 0,
 											"architecture" : "x64",
 											"modernui" : 1
 										}
@@ -1580,30 +1582,6 @@
 							}
 , 							{
 								"box" : 								{
-									"id" : "obj-18",
-									"maxclass" : "message",
-									"numinlets" : 2,
-									"numoutlets" : 1,
-									"outlettype" : [ "" ],
-									"patching_rect" : [ 27.0, 412.0, 95.0, 22.0 ],
-									"text" : "source $1, bang"
-								}
-
-							}
-, 							{
-								"box" : 								{
-									"id" : "obj-17",
-									"maxclass" : "message",
-									"numinlets" : 2,
-									"numoutlets" : 1,
-									"outlettype" : [ "" ],
-									"patching_rect" : [ 159.0, 412.0, 99.0, 22.0 ],
-									"text" : "weights $1, bang"
-								}
-
-							}
-, 							{
-								"box" : 								{
 									"id" : "obj-15",
 									"maxclass" : "comment",
 									"numinlets" : 1,
@@ -1651,6 +1629,7 @@
 , 							{
 								"box" : 								{
 									"candycane" : 5,
+									"contdata" : 1,
 									"id" : "obj-7",
 									"maxclass" : "multislider",
 									"numinlets" : 1,
@@ -1667,6 +1646,7 @@
 , 							{
 								"box" : 								{
 									"candycane" : 5,
+									"contdata" : 1,
 									"id" : "obj-6",
 									"maxclass" : "multislider",
 									"numinlets" : 1,
@@ -1711,9 +1691,9 @@
 								"box" : 								{
 									"id" : "obj-1",
 									"maxclass" : "newobj",
-									"numinlets" : 1,
-									"numoutlets" : 3,
-									"outlettype" : [ "bang", "float", "" ],
+									"numinlets" : 2,
+									"numoutlets" : 2,
+									"outlettype" : [ "", "" ],
 									"patching_rect" : [ 27.0, 452.0, 239.0, 22.0 ],
 									"text" : "fluid.bufstats~ @stats bufstats.help.weights"
 								}
@@ -1758,13 +1738,6 @@
 							}
 , 							{
 								"patchline" : 								{
-									"destination" : [ "obj-17", 0 ],
-									"source" : [ "obj-10", 0 ]
-								}
-
-							}
-, 							{
-								"patchline" : 								{
 									"destination" : [ "obj-7", 0 ],
 									"hidden" : 1,
 									"source" : [ "obj-11", 0 ]
@@ -1773,16 +1746,8 @@
 							}
 , 							{
 								"patchline" : 								{
-									"destination" : [ "obj-8", 0 ],
+									"destination" : [ "obj-18", 0 ],
 									"source" : [ "obj-12", 0 ]
-								}
-
-							}
-, 							{
-								"patchline" : 								{
-									"destination" : [ "obj-1", 0 ],
-									"midpoints" : [ 168.5, 441.0, 36.5, 441.0 ],
-									"source" : [ "obj-17", 0 ]
 								}
 
 							}
@@ -1797,6 +1762,14 @@
 								"patchline" : 								{
 									"destination" : [ "obj-34", 0 ],
 									"source" : [ "obj-19", 0 ]
+								}
+
+							}
+, 							{
+								"patchline" : 								{
+									"destination" : [ "obj-1", 0 ],
+									"midpoints" : [ 168.5, 438.0, 36.5, 438.0 ],
+									"source" : [ "obj-21", 0 ]
 								}
 
 							}
@@ -1910,14 +1883,7 @@
 							}
 , 							{
 								"patchline" : 								{
-									"destination" : [ "obj-18", 0 ],
-									"source" : [ "obj-8", 0 ]
-								}
-
-							}
-, 							{
-								"patchline" : 								{
-									"destination" : [ "obj-10", 0 ],
+									"destination" : [ "obj-21", 0 ],
 									"source" : [ "obj-9", 0 ]
 								}
 
@@ -1946,17 +1912,17 @@
 , 							{
 								"name" : "max6message",
 								"default" : 								{
-									"textcolor_inverse" : [ 0.0, 0.0, 0.0, 1.0 ],
 									"bgfillcolor" : 									{
-										"type" : "gradient",
+										"angle" : 270.0,
+										"autogradient" : 0,
+										"color" : [ 0.290196, 0.309804, 0.301961, 1.0 ],
 										"color1" : [ 0.866667, 0.866667, 0.866667, 1.0 ],
 										"color2" : [ 0.788235, 0.788235, 0.788235, 1.0 ],
-										"color" : [ 0.290196, 0.309804, 0.301961, 1.0 ],
-										"angle" : 270.0,
 										"proportion" : 0.39,
-										"autogradient" : 0
+										"type" : "gradient"
 									}
-
+,
+									"textcolor_inverse" : [ 0.0, 0.0, 0.0, 1.0 ]
 								}
 ,
 								"parentstyle" : "max6box",
@@ -2025,8 +1991,8 @@
 						"fileversion" : 1,
 						"appversion" : 						{
 							"major" : 8,
-							"minor" : 1,
-							"revision" : 11,
+							"minor" : 3,
+							"revision" : 0,
 							"architecture" : "x64",
 							"modernui" : 1
 						}
@@ -2063,6 +2029,39 @@
 						"assistshowspatchername" : 0,
 						"boxes" : [ 							{
 								"box" : 								{
+									"bgmode" : 0,
+									"border" : 0,
+									"clickthrough" : 0,
+									"enablehscroll" : 0,
+									"enablevscroll" : 0,
+									"id" : "obj-6",
+									"lockeddragscroll" : 0,
+									"lockedsize" : 0,
+									"maxclass" : "bpatcher",
+									"name" : "fluid.bufloader.maxpat",
+									"numinlets" : 0,
+									"numoutlets" : 1,
+									"offset" : [ 0.0, 0.0 ],
+									"outlettype" : [ "" ],
+									"patching_rect" : [ 95.5, 103.0, 284.0, 27.0 ],
+									"viewvisibility" : 1
+								}
+
+							}
+, 							{
+								"box" : 								{
+									"id" : "obj-1",
+									"maxclass" : "newobj",
+									"numinlets" : 1,
+									"numoutlets" : 1,
+									"outlettype" : [ "bang" ],
+									"patching_rect" : [ 381.5, 290.5, 22.0, 22.0 ],
+									"text" : "t b"
+								}
+
+							}
+, 							{
+								"box" : 								{
 									"id" : "obj-59",
 									"maxclass" : "comment",
 									"numinlets" : 1,
@@ -2082,272 +2081,6 @@
 									"numoutlets" : 0,
 									"patching_rect" : [ 10.0, 67.567627000000002, 261.0, 21.0 ],
 									"text" : "sort buffer segments by descriptor statistics"
-								}
-
-							}
-, 							{
-								"box" : 								{
-									"bgmode" : 0,
-									"border" : 0,
-									"clickthrough" : 0,
-									"embed" : 1,
-									"enablehscroll" : 0,
-									"enablevscroll" : 0,
-									"id" : "obj-54",
-									"lockeddragscroll" : 0,
-									"maxclass" : "bpatcher",
-									"numinlets" : 0,
-									"numoutlets" : 1,
-									"offset" : [ 0.0, 0.0 ],
-									"outlettype" : [ "" ],
-									"patcher" : 									{
-										"fileversion" : 1,
-										"appversion" : 										{
-											"major" : 8,
-											"minor" : 1,
-											"revision" : 11,
-											"architecture" : "x64",
-											"modernui" : 1
-										}
-,
-										"classnamespace" : "box",
-										"rect" : [ 59.0, 104.0, 640.0, 480.0 ],
-										"bglocked" : 0,
-										"openinpresentation" : 1,
-										"default_fontsize" : 12.0,
-										"default_fontface" : 0,
-										"default_fontname" : "Arial",
-										"gridonopen" : 1,
-										"gridsize" : [ 15.0, 15.0 ],
-										"gridsnaponopen" : 1,
-										"objectsnaponopen" : 1,
-										"statusbarvisible" : 2,
-										"toolbarvisible" : 1,
-										"lefttoolbarpinned" : 0,
-										"toptoolbarpinned" : 0,
-										"righttoolbarpinned" : 0,
-										"bottomtoolbarpinned" : 0,
-										"toolbars_unpinned_last_save" : 0,
-										"tallnewobj" : 0,
-										"boxanimatetime" : 200,
-										"enablehscroll" : 1,
-										"enablevscroll" : 1,
-										"devicewidth" : 0.0,
-										"description" : "",
-										"digest" : "",
-										"tags" : "",
-										"style" : "",
-										"subpatcher_template" : "",
-										"assistshowspatchername" : 0,
-										"boxes" : [ 											{
-												"box" : 												{
-													"id" : "obj-2",
-													"maxclass" : "newobj",
-													"numinlets" : 1,
-													"numoutlets" : 1,
-													"outlettype" : [ "" ],
-													"patching_rect" : [ 6.0, 4.0, 89.0, 22.0 ],
-													"text" : "loadmess path"
-												}
-
-											}
-, 											{
-												"box" : 												{
-													"comment" : "",
-													"id" : "obj-1",
-													"index" : 1,
-													"maxclass" : "outlet",
-													"numinlets" : 1,
-													"numoutlets" : 0,
-													"patching_rect" : [ 130.5, 194.0, 30.0, 30.0 ]
-												}
-
-											}
-, 											{
-												"box" : 												{
-													"id" : "obj-48",
-													"maxclass" : "newobj",
-													"numinlets" : 1,
-													"numoutlets" : 1,
-													"outlettype" : [ "" ],
-													"patching_rect" : [ 130.5, 167.833344000000011, 97.0, 22.0 ],
-													"text" : "prepend replace"
-												}
-
-											}
-, 											{
-												"box" : 												{
-													"id" : "obj-45",
-													"maxclass" : "newobj",
-													"numinlets" : 1,
-													"numoutlets" : 1,
-													"outlettype" : [ "" ],
-													"patching_rect" : [ 73.5, 113.833343999999997, 87.0, 22.0 ],
-													"text" : "prepend prefix"
-												}
-
-											}
-, 											{
-												"box" : 												{
-													"autopopulate" : 1,
-													"id" : "obj-44",
-													"items" : [ "Green-Box639.wav", ",", "Green-Box641.wav", ",", "Nicol-LoopE-M.wav", ",", "Tremblay-AaS-AcBassGuit-Melo-M.wav", ",", "Tremblay-AaS-AcousticStrums-M.wav", ",", "Tremblay-AaS-SynthTwoVoices-M.wav", ",", "Tremblay-AaS-VoiceQC-B2K.wav", ",", "Tremblay-ASWINE-ScratchySynth-M.wav", ",", "Tremblay-BaB-HumDC-M.wav", ",", "Tremblay-BaB-SoundscapeGolcarWithDog.wav", ",", "Tremblay-beatRemember.wav", ",", "Tremblay-CEL-GlitchyMusicBoxMelo.wav", ",", "Tremblay-CF-ChurchBells.wav", ",", "Tremblay-FMTri-M.wav", ",", "Tremblay-FMTriDist-M.wav", ",", "Tremblay-Iterative-M.wav", ",", "Tremblay-SA-UprightPianoPedalWide.wav", ",", "Tremblay-SlideChoirAdd-M.wav", ",", "Tremblay-SlideChoirSin-M.wav", ",", "Tremblay-UW-ComplexDescent-M.wav" ],
-													"maxclass" : "umenu",
-													"numinlets" : 1,
-													"numoutlets" : 3,
-													"outlettype" : [ "int", "", "" ],
-													"parameter_enable" : 0,
-													"patching_rect" : [ 73.5, 140.833344000000011, 133.0, 22.0 ],
-													"prefix" : "~/Documents/documents@hudd/research/projects/fluid corpus navigation/research/flucoma-max/media/",
-													"presentation" : 1,
-													"presentation_rect" : [ 2.5, 2.833344, 282.0, 22.0 ],
-													"types" : [ "WAVE", "AIFF" ]
-												}
-
-											}
-, 											{
-												"box" : 												{
-													"id" : "obj-40",
-													"maxclass" : "newobj",
-													"numinlets" : 2,
-													"numoutlets" : 2,
-													"outlettype" : [ "", "" ],
-													"patching_rect" : [ 73.5, 85.833343999999997, 125.0, 22.0 ],
-													"text" : "combine path /media/"
-												}
-
-											}
-, 											{
-												"box" : 												{
-													"fontname" : "Arial",
-													"fontsize" : 13.0,
-													"id" : "obj-37",
-													"maxclass" : "newobj",
-													"numinlets" : 1,
-													"numoutlets" : 5,
-													"outlettype" : [ "", "", "", "", "" ],
-													"patching_rect" : [ 56.0, 57.833343999999997, 89.0, 23.0 ],
-													"text" : "regexp (.+)/.+"
-												}
-
-											}
-, 											{
-												"box" : 												{
-													"id" : "obj-23",
-													"maxclass" : "newobj",
-													"numinlets" : 1,
-													"numoutlets" : 2,
-													"outlettype" : [ "", "" ],
-													"patching_rect" : [ 6.0, 32.0, 69.0, 22.0 ],
-													"save" : [ "#N", "thispatcher", ";", "#Q", "end", ";" ],
-													"text" : "thispatcher"
-												}
-
-											}
- ],
-										"lines" : [ 											{
-												"patchline" : 												{
-													"destination" : [ "obj-23", 0 ],
-													"source" : [ "obj-2", 0 ]
-												}
-
-											}
-, 											{
-												"patchline" : 												{
-													"destination" : [ "obj-37", 0 ],
-													"source" : [ "obj-23", 1 ]
-												}
-
-											}
-, 											{
-												"patchline" : 												{
-													"destination" : [ "obj-40", 0 ],
-													"source" : [ "obj-37", 1 ]
-												}
-
-											}
-, 											{
-												"patchline" : 												{
-													"destination" : [ "obj-45", 0 ],
-													"source" : [ "obj-40", 0 ]
-												}
-
-											}
-, 											{
-												"patchline" : 												{
-													"destination" : [ "obj-48", 0 ],
-													"source" : [ "obj-44", 1 ]
-												}
-
-											}
-, 											{
-												"patchline" : 												{
-													"destination" : [ "obj-44", 0 ],
-													"source" : [ "obj-45", 0 ]
-												}
-
-											}
-, 											{
-												"patchline" : 												{
-													"destination" : [ "obj-1", 0 ],
-													"source" : [ "obj-48", 0 ]
-												}
-
-											}
- ],
-										"styles" : [ 											{
-												"name" : "max6box",
-												"default" : 												{
-													"accentcolor" : [ 0.8, 0.839216, 0.709804, 1.0 ],
-													"bgcolor" : [ 1.0, 1.0, 1.0, 0.5 ],
-													"textcolor_inverse" : [ 0.0, 0.0, 0.0, 1.0 ]
-												}
-,
-												"parentstyle" : "",
-												"multi" : 0
-											}
-, 											{
-												"name" : "max6inlet",
-												"default" : 												{
-													"color" : [ 0.423529, 0.372549, 0.27451, 1.0 ]
-												}
-,
-												"parentstyle" : "",
-												"multi" : 0
-											}
-, 											{
-												"name" : "max6message",
-												"default" : 												{
-													"textcolor_inverse" : [ 0.0, 0.0, 0.0, 1.0 ],
-													"bgfillcolor" : 													{
-														"type" : "gradient",
-														"color1" : [ 0.866667, 0.866667, 0.866667, 1.0 ],
-														"color2" : [ 0.788235, 0.788235, 0.788235, 1.0 ],
-														"color" : [ 0.290196, 0.309804, 0.301961, 1.0 ],
-														"angle" : 270.0,
-														"proportion" : 0.39,
-														"autogradient" : 0
-													}
-
-												}
-,
-												"parentstyle" : "max6box",
-												"multi" : 0
-											}
-, 											{
-												"name" : "max6outlet",
-												"default" : 												{
-													"color" : [ 0.0, 0.454902, 0.498039, 1.0 ]
-												}
-,
-												"parentstyle" : "",
-												"multi" : 0
-											}
- ]
-									}
-,
-									"patching_rect" : [ 10.0, 132.0, 286.0, 25.666656 ],
-									"viewvisibility" : 1
 								}
 
 							}
@@ -2374,8 +2107,8 @@
 										"fileversion" : 1,
 										"appversion" : 										{
 											"major" : 8,
-											"minor" : 1,
-											"revision" : 11,
+											"minor" : 3,
+											"revision" : 0,
 											"architecture" : "x64",
 											"modernui" : 1
 										}
@@ -2759,8 +2492,8 @@
 										"fileversion" : 1,
 										"appversion" : 										{
 											"major" : 8,
-											"minor" : 1,
-											"revision" : 11,
+											"minor" : 3,
+											"revision" : 0,
 											"architecture" : "x64",
 											"modernui" : 1
 										}
@@ -2937,8 +2670,8 @@
 										"fileversion" : 1,
 										"appversion" : 										{
 											"major" : 8,
-											"minor" : 1,
-											"revision" : 11,
+											"minor" : 3,
+											"revision" : 0,
 											"architecture" : "x64",
 											"modernui" : 1
 										}
@@ -3115,8 +2848,8 @@
 										"fileversion" : 1,
 										"appversion" : 										{
 											"major" : 8,
-											"minor" : 1,
-											"revision" : 11,
+											"minor" : 3,
+											"revision" : 0,
 											"architecture" : "x64",
 											"modernui" : 1
 										}
@@ -3151,6 +2884,18 @@
 										"subpatcher_template" : "",
 										"assistshowspatchername" : 0,
 										"boxes" : [ 											{
+												"box" : 												{
+													"id" : "obj-1",
+													"maxclass" : "newobj",
+													"numinlets" : 1,
+													"numoutlets" : 1,
+													"outlettype" : [ "bang" ],
+													"patching_rect" : [ 85.0, 76.0, 22.0, 22.0 ],
+													"text" : "t b"
+												}
+
+											}
+, 											{
 												"box" : 												{
 													"id" : "obj-113",
 													"maxclass" : "newobj",
@@ -3219,7 +2964,7 @@
 													"maxclass" : "inlet",
 													"numinlets" : 0,
 													"numoutlets" : 1,
-													"outlettype" : [ "bang" ],
+													"outlettype" : [ "" ],
 													"patching_rect" : [ 85.0, 40.0, 30.0, 30.0 ]
 												}
 
@@ -3264,6 +3009,13 @@
  ],
 										"lines" : [ 											{
 												"patchline" : 												{
+													"destination" : [ "obj-67", 0 ],
+													"source" : [ "obj-1", 0 ]
+												}
+
+											}
+, 											{
+												"patchline" : 												{
 													"destination" : [ "obj-20", 0 ],
 													"source" : [ "obj-113", 1 ]
 												}
@@ -3278,7 +3030,7 @@
 											}
 , 											{
 												"patchline" : 												{
-													"destination" : [ "obj-67", 0 ],
+													"destination" : [ "obj-1", 0 ],
 													"source" : [ "obj-17", 0 ]
 												}
 
@@ -3347,8 +3099,8 @@
 										"fileversion" : 1,
 										"appversion" : 										{
 											"major" : 8,
-											"minor" : 1,
-											"revision" : 11,
+											"minor" : 3,
+											"revision" : 0,
 											"architecture" : "x64",
 											"modernui" : 1
 										}
@@ -3384,17 +3136,6 @@
 										"assistshowspatchername" : 0,
 										"boxes" : [ 											{
 												"box" : 												{
-													"id" : "obj-16",
-													"maxclass" : "newobj",
-													"numinlets" : 1,
-													"numoutlets" : 1,
-													"outlettype" : [ "" ],
-													"patching_rect" : [ 132.0, 46.0, 100.0, 22.0 ]
-												}
-
-											}
-, 											{
-												"box" : 												{
 													"id" : "obj-140",
 													"linecount" : 7,
 													"maxclass" : "comment",
@@ -3413,7 +3154,7 @@
 													"numoutlets" : 1,
 													"outlettype" : [ "" ],
 													"patching_rect" : [ 379.0, 279.0, 50.0, 22.0 ],
-													"text" : "2412"
+													"text" : "958"
 												}
 
 											}
@@ -3889,17 +3630,17 @@
 , 											{
 												"name" : "max6message",
 												"default" : 												{
-													"textcolor_inverse" : [ 0.0, 0.0, 0.0, 1.0 ],
 													"bgfillcolor" : 													{
-														"type" : "gradient",
+														"angle" : 270.0,
+														"autogradient" : 0,
+														"color" : [ 0.290196, 0.309804, 0.301961, 1.0 ],
 														"color1" : [ 0.866667, 0.866667, 0.866667, 1.0 ],
 														"color2" : [ 0.788235, 0.788235, 0.788235, 1.0 ],
-														"color" : [ 0.290196, 0.309804, 0.301961, 1.0 ],
-														"angle" : 270.0,
 														"proportion" : 0.39,
-														"autogradient" : 0
+														"type" : "gradient"
 													}
-
+,
+													"textcolor_inverse" : [ 0.0, 0.0, 0.0, 1.0 ]
 												}
 ,
 												"parentstyle" : "max6box",
@@ -4076,7 +3817,7 @@
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
 									"patching_rect" : [ 325.833344000000011, 500.5, 50.0, 22.0 ],
-									"text" : "9"
+									"text" : "0"
 								}
 
 							}
@@ -4099,7 +3840,7 @@
 									"numinlets" : 1,
 									"numoutlets" : 2,
 									"outlettype" : [ "float", "bang" ],
-									"patching_rect" : [ 10.0, 262.5, 171.0, 22.0 ],
+									"patching_rect" : [ 10.0, 274.5, 171.0, 22.0 ],
 									"text" : "buffer~ bufstats_help_stats2 1"
 								}
 
@@ -4109,9 +3850,9 @@
 									"id" : "obj-101",
 									"linecount" : 2,
 									"maxclass" : "newobj",
-									"numinlets" : 1,
-									"numoutlets" : 3,
-									"outlettype" : [ "bang", "float", "" ],
+									"numinlets" : 2,
+									"numoutlets" : 2,
+									"outlettype" : [ "", "" ],
 									"patching_rect" : [ 448.5, 388.0, 302.0, 35.0 ],
 									"text" : "fluid.bufstats~ @source bufstats_help_selectedfeature @stats bufstats_help_stats2 @numderivs 1"
 								}
@@ -4134,9 +3875,9 @@
 									"id" : "obj-90",
 									"maxclass" : "newobj",
 									"numinlets" : 1,
-									"numoutlets" : 3,
-									"outlettype" : [ "bang", "float", "" ],
-									"patching_rect" : [ 381.5, 247.5, 592.0, 22.0 ],
+									"numoutlets" : 2,
+									"outlettype" : [ "", "" ],
+									"patching_rect" : [ 381.5, 251.5, 592.0, 22.0 ],
 									"text" : "fluid.bufcompose~ @source bufstats_help_feats2 @destination bufstats_help_selectedfeature @numchans 1"
 								}
 
@@ -4148,7 +3889,7 @@
 									"numinlets" : 1,
 									"numoutlets" : 2,
 									"outlettype" : [ "float", "bang" ],
-									"patching_rect" : [ 10.0, 236.0, 221.0, 22.0 ],
+									"patching_rect" : [ 10.0, 248.0, 221.0, 22.0 ],
 									"text" : "buffer~ bufstats_help_selectedfeature 1"
 								}
 
@@ -4158,9 +3899,9 @@
 									"id" : "obj-88",
 									"maxclass" : "newobj",
 									"numinlets" : 1,
-									"numoutlets" : 3,
-									"outlettype" : [ "bang", "float", "" ],
-									"patching_rect" : [ 381.5, 215.5, 413.0, 22.0 ],
+									"numoutlets" : 2,
+									"outlettype" : [ "", "" ],
+									"patching_rect" : [ 381.5, 221.5, 413.0, 22.0 ],
 									"text" : "fluid.bufpitch~ @source bufstats_help_src2 @features bufstats_help_feats2"
 								}
 
@@ -4223,7 +3964,7 @@
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
 									"patching_rect" : [ 286.833344000000011, 394.0, 50.0, 22.0 ],
-									"text" : "15"
+									"text" : "29"
 								}
 
 							}
@@ -4233,8 +3974,8 @@
 									"linecount" : 2,
 									"maxclass" : "newobj",
 									"numinlets" : 1,
-									"numoutlets" : 3,
-									"outlettype" : [ "bang", "float", "" ],
+									"numoutlets" : 2,
+									"outlettype" : [ "", "" ],
 									"patching_rect" : [ 381.5, 176.0, 646.0, 35.0 ],
 									"text" : "fluid.bufonsetslice~ @minslicelength 10 @metric 9 @threshold 0.4 @filtersize 7 @source bufstats_help_src2 @indices bufstats_help_slices2"
 								}
@@ -4355,7 +4096,7 @@
 									"numinlets" : 1,
 									"numoutlets" : 2,
 									"outlettype" : [ "float", "bang" ],
-									"patching_rect" : [ 10.0, 209.5, 172.0, 22.0 ],
+									"patching_rect" : [ 10.0, 221.5, 172.0, 22.0 ],
 									"text" : "buffer~ bufstats_help_feats2 1"
 								}
 
@@ -4368,6 +4109,7 @@
 									"numinlets" : 1,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
+									"parameter_enable" : 0,
 									"patching_rect" : [ 415.5, 143.5, 150.0, 22.0 ]
 								}
 
@@ -4381,6 +4123,7 @@
 									"numinlets" : 1,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
+									"parameter_enable" : 0,
 									"patching_rect" : [ 847.833374000000049, 215.5, 105.0, 22.0 ],
 									"text_width" : 67.0
 								}
@@ -4394,12 +4137,19 @@
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
 									"patching_rect" : [ 396.5, 604.0, 102.0, 22.0 ],
-									"text" : "4543.444336"
+									"text" : "89.88446"
 								}
 
 							}
  ],
 						"lines" : [ 							{
+								"patchline" : 								{
+									"destination" : [ "obj-15", 0 ],
+									"source" : [ "obj-1", 0 ]
+								}
+
+							}
+, 							{
 								"patchline" : 								{
 									"destination" : [ "obj-22", 1 ],
 									"midpoints" : [ 458.0, 428.75, 594.75, 428.75 ],
@@ -4570,7 +4320,7 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-5", 0 ],
-									"source" : [ "obj-54", 0 ]
+									"source" : [ "obj-6", 0 ]
 								}
 
 							}
@@ -4604,7 +4354,7 @@
 							}
 , 							{
 								"patchline" : 								{
-									"destination" : [ "obj-15", 0 ],
+									"destination" : [ "obj-1", 0 ],
 									"source" : [ "obj-90", 0 ]
 								}
 
@@ -4641,17 +4391,17 @@
 , 							{
 								"name" : "max6message",
 								"default" : 								{
-									"textcolor_inverse" : [ 0.0, 0.0, 0.0, 1.0 ],
 									"bgfillcolor" : 									{
-										"type" : "gradient",
+										"angle" : 270.0,
+										"autogradient" : 0,
+										"color" : [ 0.290196, 0.309804, 0.301961, 1.0 ],
 										"color1" : [ 0.866667, 0.866667, 0.866667, 1.0 ],
 										"color2" : [ 0.788235, 0.788235, 0.788235, 1.0 ],
-										"color" : [ 0.290196, 0.309804, 0.301961, 1.0 ],
-										"angle" : 270.0,
 										"proportion" : 0.39,
-										"autogradient" : 0
+										"type" : "gradient"
 									}
-
+,
+									"textcolor_inverse" : [ 0.0, 0.0, 0.0, 1.0 ]
 								}
 ,
 								"parentstyle" : "max6box",
@@ -4691,8 +4441,8 @@
 						"fileversion" : 1,
 						"appversion" : 						{
 							"major" : 8,
-							"minor" : 1,
-							"revision" : 11,
+							"minor" : 3,
+							"revision" : 0,
 							"architecture" : "x64",
 							"modernui" : 1
 						}
@@ -4750,8 +4500,8 @@
 										"fileversion" : 1,
 										"appversion" : 										{
 											"major" : 8,
-											"minor" : 1,
-											"revision" : 11,
+											"minor" : 3,
+											"revision" : 0,
 											"architecture" : "x64",
 											"modernui" : 1
 										}
@@ -5324,8 +5074,8 @@
 										"fileversion" : 1,
 										"appversion" : 										{
 											"major" : 8,
-											"minor" : 1,
-											"revision" : 11,
+											"minor" : 3,
+											"revision" : 0,
 											"architecture" : "x64",
 											"modernui" : 1
 										}
@@ -5829,9 +5579,9 @@
 									"id" : "obj-1",
 									"linecount" : 2,
 									"maxclass" : "newobj",
-									"numinlets" : 1,
-									"numoutlets" : 3,
-									"outlettype" : [ "bang", "float", "" ],
+									"numinlets" : 2,
+									"numoutlets" : 2,
+									"outlettype" : [ "", "" ],
 									"patching_rect" : [ 374.0, 157.0, 267.0, 35.0 ],
 									"text" : "fluid.bufstats~ @source bufstats_help_src3 @stats bufstats_help_stats3 @numderivs 1"
 								}
@@ -5936,17 +5686,17 @@
 , 							{
 								"name" : "max6message",
 								"default" : 								{
-									"textcolor_inverse" : [ 0.0, 0.0, 0.0, 1.0 ],
 									"bgfillcolor" : 									{
-										"type" : "gradient",
+										"angle" : 270.0,
+										"autogradient" : 0,
+										"color" : [ 0.290196, 0.309804, 0.301961, 1.0 ],
 										"color1" : [ 0.866667, 0.866667, 0.866667, 1.0 ],
 										"color2" : [ 0.788235, 0.788235, 0.788235, 1.0 ],
-										"color" : [ 0.290196, 0.309804, 0.301961, 1.0 ],
-										"angle" : 270.0,
 										"proportion" : 0.39,
-										"autogradient" : 0
+										"type" : "gradient"
 									}
-
+,
+									"textcolor_inverse" : [ 0.0, 0.0, 0.0, 1.0 ]
 								}
 ,
 								"parentstyle" : "max6box",
@@ -5986,8 +5736,8 @@
 						"fileversion" : 1,
 						"appversion" : 						{
 							"major" : 8,
-							"minor" : 1,
-							"revision" : 11,
+							"minor" : 3,
+							"revision" : 0,
 							"architecture" : "x64",
 							"modernui" : 1
 						}
@@ -6031,6 +5781,7 @@
 									"enablevscroll" : 0,
 									"id" : "obj-2",
 									"lockeddragscroll" : 0,
+									"lockedsize" : 0,
 									"maxclass" : "bpatcher",
 									"name" : "fluid.flucomaorg.maxpat",
 									"numinlets" : 0,
@@ -6097,14 +5848,14 @@
 										"fileversion" : 1,
 										"appversion" : 										{
 											"major" : 8,
-											"minor" : 1,
-											"revision" : 11,
+											"minor" : 3,
+											"revision" : 0,
 											"architecture" : "x64",
 											"modernui" : 1
 										}
 ,
 										"classnamespace" : "box",
-										"rect" : [ 59.0, 104.0, 640.0, 480.0 ],
+										"rect" : [ 1555.0, 419.0, 696.0, 551.0 ],
 										"bglocked" : 0,
 										"openinpresentation" : 0,
 										"default_fontsize" : 12.0,
@@ -6139,7 +5890,7 @@
 													"numinlets" : 2,
 													"numoutlets" : 1,
 													"outlettype" : [ "" ],
-													"patching_rect" : [ 50.0, 315.0, 133.0, 22.0 ],
+													"patching_rect" : [ 20.0, 316.0, 133.0, 22.0 ],
 													"text" : "replace $3 $1 $2, bang"
 												}
 
@@ -6151,7 +5902,7 @@
 													"numinlets" : 2,
 													"numoutlets" : 1,
 													"outlettype" : [ "" ],
-													"patching_rect" : [ 50.0, 286.0, 346.0, 22.0 ],
+													"patching_rect" : [ 20.0, 287.0, 346.0, 22.0 ],
 													"text" : "join"
 												}
 
@@ -6163,7 +5914,7 @@
 													"numinlets" : 2,
 													"numoutlets" : 2,
 													"outlettype" : [ "", "" ],
-													"patching_rect" : [ 377.0, 256.0, 199.0, 22.0 ],
+													"patching_rect" : [ 347.0, 257.0, 199.0, 22.0 ],
 													"text" : "combine derivatives:: n @triggers 1"
 												}
 
@@ -6175,7 +5926,7 @@
 													"numinlets" : 1,
 													"numoutlets" : 2,
 													"outlettype" : [ "bang", "int" ],
-													"patching_rect" : [ 50.0, 100.0, 34.0, 22.0 ],
+													"patching_rect" : [ 20.0, 76.0, 34.0, 22.0 ],
 													"text" : "t b 0"
 												}
 
@@ -6187,7 +5938,7 @@
 													"numinlets" : 5,
 													"numoutlets" : 4,
 													"outlettype" : [ "int", "", "", "int" ],
-													"patching_rect" : [ 377.0, 221.0, 61.0, 22.0 ],
+													"patching_rect" : [ 347.0, 222.0, 61.0, 22.0 ],
 													"text" : "counter"
 												}
 
@@ -6199,7 +5950,7 @@
 													"numinlets" : 1,
 													"numoutlets" : 7,
 													"outlettype" : [ "float", "float", "float", "float", "float", "float", "float" ],
-													"patching_rect" : [ 50.0, 221.0, 324.0, 22.0 ],
+													"patching_rect" : [ 20.0, 222.0, 303.0, 22.0 ],
 													"text" : "unpack 0. 0. 0. 0. 0. 0. 0."
 												}
 
@@ -6211,7 +5962,7 @@
 													"numinlets" : 1,
 													"numoutlets" : 2,
 													"outlettype" : [ "", "bang" ],
-													"patching_rect" : [ 50.0, 192.0, 346.0, 22.0 ],
+													"patching_rect" : [ 20.0, 193.0, 346.0, 22.0 ],
 													"text" : "t l b"
 												}
 
@@ -6223,7 +5974,7 @@
 													"numinlets" : 2,
 													"numoutlets" : 2,
 													"outlettype" : [ "", "" ],
-													"patching_rect" : [ 50.0, 165.0, 49.0, 22.0 ],
+													"patching_rect" : [ 20.0, 154.0, 49.0, 22.0 ],
 													"text" : "zl iter 7"
 												}
 
@@ -6232,11 +5983,11 @@
 												"box" : 												{
 													"id" : "obj-27",
 													"maxclass" : "newobj",
-													"numinlets" : 1,
+													"numinlets" : 2,
 													"numoutlets" : 1,
-													"outlettype" : [ "" ],
-													"patching_rect" : [ 50.0, 138.0, 318.0, 22.0 ],
-													"text" : "jstrigger (new Buffer('bufstats_help_stats1').peek(1\\,0\\, 14))"
+													"outlettype" : [ "list" ],
+													"patching_rect" : [ 20.0, 116.0, 237.0, 22.0 ],
+													"text" : "fluid.buf2list @source bufstats_help_stats1"
 												}
 
 											}
@@ -6247,7 +5998,7 @@
 													"numinlets" : 2,
 													"numoutlets" : 4,
 													"outlettype" : [ "dictionary", "", "", "" ],
-													"patching_rect" : [ 50.0, 348.0, 50.5, 22.0 ],
+													"patching_rect" : [ 20.0, 349.0, 50.5, 22.0 ],
 													"saved_object_attributes" : 													{
 														"embed" : 0,
 														"parameter_enable" : 0,
@@ -6265,8 +6016,8 @@
 													"numinlets" : 7,
 													"numoutlets" : 1,
 													"outlettype" : [ "dictionary" ],
-													"patching_rect" : [ 50.0, 256.0, 324.0, 22.0 ],
-													"text" : "dict.pack mean: stddev: skewness: kurtosis: low: mid: high:"
+													"patching_rect" : [ 20.0, 257.0, 303.0, 22.0 ],
+													"text" : "dict.pack mean: std: skewness: kurtosis: low: mid: high:"
 												}
 
 											}
@@ -6276,7 +6027,7 @@
 													"maxclass" : "comment",
 													"numinlets" : 1,
 													"numoutlets" : 0,
-													"patching_rect" : [ 110.0, 100.0, 99.0, 20.0 ],
+													"patching_rect" : [ 80.0, 76.0, 99.0, 20.0 ],
 													"text" : "bang when done",
 													"textcolor" : [ 0.5, 0.5, 0.5, 1.0 ]
 												}
@@ -6290,8 +6041,8 @@
 													"maxclass" : "inlet",
 													"numinlets" : 0,
 													"numoutlets" : 1,
-													"outlettype" : [ "bang" ],
-													"patching_rect" : [ 50.0, 40.0, 30.0, 30.0 ]
+													"outlettype" : [ "" ],
+													"patching_rect" : [ 20.0, 16.0, 30.0, 30.0 ]
 												}
 
 											}
@@ -6303,7 +6054,7 @@
 													"maxclass" : "outlet",
 													"numinlets" : 1,
 													"numoutlets" : 0,
-													"patching_rect" : [ 50.0, 430.0, 30.0, 30.0 ]
+													"patching_rect" : [ 20.0, 431.0, 30.0, 30.0 ]
 												}
 
 											}
@@ -6402,7 +6153,7 @@
 , 											{
 												"patchline" : 												{
 													"destination" : [ "obj-53", 1 ],
-													"midpoints" : [ 386.5, 250.5, 566.5, 250.5 ],
+													"midpoints" : [ 356.5, 251.5, 536.5, 251.5 ],
 													"source" : [ "obj-48", 0 ]
 												}
 
@@ -6417,7 +6168,7 @@
 , 											{
 												"patchline" : 												{
 													"destination" : [ "obj-48", 2 ],
-													"midpoints" : [ 74.5, 126.0, 407.5, 126.0 ],
+													"midpoints" : [ 44.5, 102.0, 377.5, 102.0 ],
 													"source" : [ "obj-52", 1 ]
 												}
 
@@ -6514,8 +6265,8 @@
 										"fileversion" : 1,
 										"appversion" : 										{
 											"major" : 8,
-											"minor" : 1,
-											"revision" : 11,
+											"minor" : 3,
+											"revision" : 0,
 											"architecture" : "x64",
 											"modernui" : 1
 										}
@@ -6971,9 +6722,9 @@
 								"box" : 								{
 									"id" : "obj-13",
 									"maxclass" : "newobj",
-									"numinlets" : 1,
-									"numoutlets" : 3,
-									"outlettype" : [ "bang", "float", "" ],
+									"numinlets" : 2,
+									"numoutlets" : 2,
+									"outlettype" : [ "", "" ],
 									"patching_rect" : [ 506.0, 278.5, 476.0, 22.0 ],
 									"text" : "fluid.bufstats~ @source bufstats_help_src1 @stats bufstats_help_stats1 @numderivs 1"
 								}
@@ -7059,6 +6810,7 @@
 									"numinlets" : 1,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
+									"parameter_enable" : 0,
 									"patching_rect" : [ 553.0, 245.0, 158.0, 22.0 ],
 									"text_width" : 102.0
 								}
@@ -7072,6 +6824,7 @@
 									"numinlets" : 1,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
+									"parameter_enable" : 0,
 									"patching_rect" : [ 553.0, 199.0, 158.0, 22.0 ],
 									"text_width" : 102.0
 								}
@@ -7085,6 +6838,7 @@
 									"numinlets" : 1,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
+									"parameter_enable" : 0,
 									"patching_rect" : [ 553.0, 222.0, 158.0, 22.0 ],
 									"text_width" : 102.0
 								}
@@ -7098,6 +6852,7 @@
 									"numinlets" : 1,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
+									"parameter_enable" : 0,
 									"patching_rect" : [ 553.0, 176.0, 158.0, 22.0 ],
 									"text_width" : 102.0
 								}
@@ -7219,17 +6974,17 @@
 , 							{
 								"name" : "max6message",
 								"default" : 								{
-									"textcolor_inverse" : [ 0.0, 0.0, 0.0, 1.0 ],
 									"bgfillcolor" : 									{
-										"type" : "gradient",
+										"angle" : 270.0,
+										"autogradient" : 0,
+										"color" : [ 0.290196, 0.309804, 0.301961, 1.0 ],
 										"color1" : [ 0.866667, 0.866667, 0.866667, 1.0 ],
 										"color2" : [ 0.788235, 0.788235, 0.788235, 1.0 ],
-										"color" : [ 0.290196, 0.309804, 0.301961, 1.0 ],
-										"angle" : 270.0,
 										"proportion" : 0.39,
-										"autogradient" : 0
+										"type" : "gradient"
 									}
-
+,
+									"textcolor_inverse" : [ 0.0, 0.0, 0.0, 1.0 ]
 								}
 ,
 								"parentstyle" : "max6box",
@@ -7270,8 +7025,8 @@
 						"fileversion" : 1,
 						"appversion" : 						{
 							"major" : 8,
-							"minor" : 1,
-							"revision" : 11,
+							"minor" : 3,
+							"revision" : 0,
 							"architecture" : "x64",
 							"modernui" : 1
 						}
@@ -7350,70 +7105,6 @@
 			"inherited_shortname" : 1
 		}
 ,
-		"dependency_cache" : [ 			{
-				"name" : "helpname.js",
-				"bootpath" : "C74:/help/resources",
-				"type" : "TEXT",
-				"implicit" : 1
-			}
-, 			{
-				"name" : "fluid.bufview.js",
-				"bootpath" : "~/Documents/documents@hudd/research/projects/fluid corpus navigation/research/flucoma-max/help",
-				"patcherrelativepath" : ".",
-				"type" : "TEXT",
-				"implicit" : 1
-			}
-, 			{
-				"name" : "helpdetails.js",
-				"bootpath" : "C74:/help/resources",
-				"type" : "TEXT",
-				"implicit" : 1
-			}
-, 			{
-				"name" : "fluid.flucomaorg.maxpat",
-				"bootpath" : "~/Documents/documents@hudd/research/projects/fluid corpus navigation/research/flucoma-max/help",
-				"patcherrelativepath" : ".",
-				"type" : "JSON",
-				"implicit" : 1
-			}
-, 			{
-				"name" : "helpstarter.js",
-				"bootpath" : "C74:/help/resources",
-				"type" : "TEXT",
-				"implicit" : 1
-			}
-, 			{
-				"name" : "fluid_decomposition.blocking.maxpat",
-				"bootpath" : "~/Documents/documents@hudd/research/projects/fluid corpus navigation/research/flucoma-max/help",
-				"patcherrelativepath" : ".",
-				"type" : "JSON",
-				"implicit" : 1
-			}
-, 			{
-				"name" : "fluid.bufstats~.mxo",
-				"type" : "iLaX"
-			}
-, 			{
-				"name" : "fluid.bufonsetslice~.mxo",
-				"type" : "iLaX"
-			}
-, 			{
-				"name" : "fluid.bufpitch~.mxo",
-				"type" : "iLaX"
-			}
-, 			{
-				"name" : "fluid.bufcompose~.mxo",
-				"type" : "iLaX"
-			}
-, 			{
-				"name" : "fluid.list2buf.mxo",
-				"type" : "iLaX"
-			}
-, 			{
-				"name" : "fluid.buf2list.mxo",
-				"type" : "iLaX"
-			}
- ],
 		"autosave" : 0,
 		"styles" : [ 			{
 				"name" : "max6box",
@@ -7438,17 +7129,17 @@
 , 			{
 				"name" : "max6message",
 				"default" : 				{
-					"textcolor_inverse" : [ 0.0, 0.0, 0.0, 1.0 ],
 					"bgfillcolor" : 					{
-						"type" : "gradient",
+						"angle" : 270.0,
+						"autogradient" : 0,
+						"color" : [ 0.290196, 0.309804, 0.301961, 1.0 ],
 						"color1" : [ 0.866667, 0.866667, 0.866667, 1.0 ],
 						"color2" : [ 0.788235, 0.788235, 0.788235, 1.0 ],
-						"color" : [ 0.290196, 0.309804, 0.301961, 1.0 ],
-						"angle" : 270.0,
 						"proportion" : 0.39,
-						"autogradient" : 0
+						"type" : "gradient"
 					}
-
+,
+					"textcolor_inverse" : [ 0.0, 0.0, 0.0, 1.0 ]
 				}
 ,
 				"parentstyle" : "max6box",

--- a/help/fluid.datasetquery~.maxhelp
+++ b/help/fluid.datasetquery~.maxhelp
@@ -57,7 +57,7 @@
 						}
 ,
 						"classnamespace" : "box",
-						"rect" : [ 0.0, 26.0, 995.0, 751.0 ],
+						"rect" : [ 35.0, 114.0, 995.0, 751.0 ],
 						"bglocked" : 0,
 						"openinpresentation" : 0,
 						"default_fontsize" : 13.0,
@@ -125,7 +125,7 @@
 									"maxclass" : "comment",
 									"numinlets" : 1,
 									"numoutlets" : 0,
-									"patching_rect" : [ 409.0, 150.0, 212.0, 25.0 ],
+									"patching_rect" : [ 389.0, 110.0, 212.0, 25.0 ],
 									"text" : "Clear the filters so we start fresh",
 									"textcolor" : [ 0.0, 0.0, 0.0, 1.0 ]
 								}
@@ -138,7 +138,7 @@
 									"numinlets" : 2,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 370.0, 150.0, 37.0, 23.0 ],
+									"patching_rect" : [ 350.0, 110.0, 37.0, 23.0 ],
 									"text" : "clear"
 								}
 
@@ -156,7 +156,7 @@
 									"numoutlets" : 3,
 									"outlettype" : [ "", "", "int" ],
 									"parameter_enable" : 0,
-									"patching_rect" : [ 627.5, 150.0, 20.0, 20.0 ],
+									"patching_rect" : [ 607.5, 110.0, 20.0, 20.0 ],
 									"rounded" : 60.0,
 									"text" : "2",
 									"textcolor" : [ 0.34902, 0.34902, 0.34902, 1.0 ]
@@ -170,7 +170,7 @@
 									"maxclass" : "comment",
 									"numinlets" : 1,
 									"numoutlets" : 0,
-									"patching_rect" : [ 480.5, 190.0, 165.0, 25.0 ],
+									"patching_rect" : [ 460.5, 150.0, 165.0, 25.0 ],
 									"text" : "Now add our basic filter",
 									"textcolor" : [ 0.0, 0.0, 0.0, 1.0 ]
 								}
@@ -209,7 +209,7 @@
 									"numoutlets" : 3,
 									"outlettype" : [ "", "", "int" ],
 									"parameter_enable" : 0,
-									"patching_rect" : [ 652.0, 192.5, 20.0, 20.0 ],
+									"patching_rect" : [ 632.0, 152.5, 20.0, 20.0 ],
 									"rounded" : 60.0,
 									"text" : "3",
 									"textcolor" : [ 0.34902, 0.34902, 0.34902, 1.0 ]
@@ -374,7 +374,7 @@
  ]
 									}
 ,
-									"patching_rect" : [ 370.0, 440.0, 96.0, 23.0 ],
+									"patching_rect" : [ 350.0, 400.0, 96.0, 23.0 ],
 									"saved_object_attributes" : 									{
 										"description" : "",
 										"digest" : "",
@@ -393,7 +393,7 @@
 									"maxclass" : "comment",
 									"numinlets" : 1,
 									"numoutlets" : 0,
-									"patching_rect" : [ 537.0, 241.0, 215.0, 65.0 ],
+									"patching_rect" : [ 517.0, 201.0, 215.0, 65.0 ],
 									"text" : "Add a range of columns in the format <start> <number of columns>. This will add two columns starting from the second.",
 									"textcolor" : [ 0.129412, 0.129412, 0.129412, 0.5 ]
 								}
@@ -407,7 +407,7 @@
 									"maxclass" : "comment",
 									"numinlets" : 1,
 									"numoutlets" : 0,
-									"patching_rect" : [ 730.0, 321.5, 195.0, 40.0 ],
+									"patching_rect" : [ 710.0, 281.5, 195.0, 40.0 ],
 									"text" : "Transform to do the query and copy",
 									"textcolor" : [ 0.0, 0.0, 0.0, 1.0 ]
 								}
@@ -421,7 +421,7 @@
 									"maxclass" : "comment",
 									"numinlets" : 1,
 									"numoutlets" : 0,
-									"patching_rect" : [ 760.0, 251.5, 155.0, 40.0 ],
+									"patching_rect" : [ 740.0, 211.5, 155.0, 40.0 ],
 									"text" : "Add a range of columns to copy",
 									"textcolor" : [ 0.0, 0.0, 0.0, 1.0 ]
 								}
@@ -440,7 +440,7 @@
 									"numoutlets" : 3,
 									"outlettype" : [ "", "", "int" ],
 									"parameter_enable" : 0,
-									"patching_rect" : [ 335.0, 150.0, 20.0, 20.0 ],
+									"patching_rect" : [ 315.0, 110.0, 20.0, 20.0 ],
 									"rounded" : 60.0,
 									"text" : "1",
 									"textcolor" : [ 0.34902, 0.34902, 0.34902, 1.0 ]
@@ -454,7 +454,7 @@
 									"maxclass" : "comment",
 									"numinlets" : 1,
 									"numoutlets" : 0,
-									"patching_rect" : [ 86.0, 150.0, 247.0, 25.0 ],
+									"patching_rect" : [ 66.0, 110.0, 247.0, 25.0 ],
 									"text" : "Generate some example data to query",
 									"textcolor" : [ 0.0, 0.0, 0.0, 1.0 ]
 								}
@@ -468,7 +468,7 @@
 									"numoutlets" : 1,
 									"outlettype" : [ "bang" ],
 									"parameter_enable" : 0,
-									"patching_rect" : [ 60.0, 150.0, 24.0, 24.0 ]
+									"patching_rect" : [ 40.0, 110.0, 24.0, 24.0 ]
 								}
 
 							}
@@ -478,7 +478,7 @@
 									"maxclass" : "dict.view",
 									"numinlets" : 1,
 									"numoutlets" : 0,
-									"patching_rect" : [ 370.0, 480.0, 168.0, 110.0 ],
+									"patching_rect" : [ 350.0, 440.0, 168.0, 110.0 ],
 									"textcolor" : [ 0.995808, 0.800103, 0.399985, 1.0 ]
 								}
 
@@ -489,7 +489,7 @@
 									"maxclass" : "dict.view",
 									"numinlets" : 1,
 									"numoutlets" : 0,
-									"patching_rect" : [ 60.0, 307.5, 220.0, 129.5 ]
+									"patching_rect" : [ 40.0, 267.5, 220.0, 129.5 ]
 								}
 
 							}
@@ -500,7 +500,7 @@
 									"numinlets" : 2,
 									"numoutlets" : 2,
 									"outlettype" : [ "", "" ],
-									"patching_rect" : [ 60.0, 270.0, 74.0, 23.0 ],
+									"patching_rect" : [ 40.0, 230.0, 74.0, 23.0 ],
 									"text" : "route dump"
 								}
 
@@ -512,7 +512,7 @@
 									"numinlets" : 1,
 									"numoutlets" : 2,
 									"outlettype" : [ "", "" ],
-									"patching_rect" : [ 60.0, 230.0, 160.0, 23.0 ],
+									"patching_rect" : [ 40.0, 190.0, 160.0, 23.0 ],
 									"text" : "fluid.dataset~ dsq.help.src"
 								}
 
@@ -910,7 +910,7 @@
  ]
 									}
 ,
-									"patching_rect" : [ 60.0, 190.0, 80.0, 23.0 ],
+									"patching_rect" : [ 40.0, 150.0, 80.0, 23.0 ],
 									"saved_object_attributes" : 									{
 										"description" : "",
 										"digest" : "",
@@ -929,7 +929,7 @@
 									"numinlets" : 2,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 510.0, 330.0, 218.0, 23.0 ],
+									"patching_rect" : [ 490.0, 290.0, 218.0, 23.0 ],
 									"text" : "transform dsq.help.src dsq.help.dest"
 								}
 
@@ -941,7 +941,7 @@
 									"numinlets" : 2,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 450.0, 260.0, 85.0, 23.0 ],
+									"patching_rect" : [ 430.0, 220.0, 85.0, 23.0 ],
 									"text" : "addrange 1 2"
 								}
 
@@ -953,7 +953,7 @@
 									"numinlets" : 2,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 409.0, 190.0, 66.0, 23.0 ],
+									"patching_rect" : [ 389.0, 150.0, 66.0, 23.0 ],
 									"text" : "filter 0 < 3"
 								}
 
@@ -965,7 +965,7 @@
 									"numinlets" : 1,
 									"numoutlets" : 2,
 									"outlettype" : [ "", "" ],
-									"patching_rect" : [ 370.0, 400.0, 121.0, 23.0 ],
+									"patching_rect" : [ 350.0, 360.0, 121.0, 23.0 ],
 									"text" : "fluid.datasetquery~"
 								}
 
@@ -998,7 +998,7 @@
 									"mode" : 0,
 									"numinlets" : 1,
 									"numoutlets" : 0,
-									"patching_rect" : [ 440.0, 230.0, 315.5, 83.0 ],
+									"patching_rect" : [ 420.0, 190.0, 315.5, 83.0 ],
 									"proportion" : 0.5
 								}
 
@@ -1021,7 +1021,7 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-1", 0 ],
-									"midpoints" : [ 459.5, 341.0, 379.5, 341.0 ],
+									"midpoints" : [ 439.5, 301.0, 359.5, 301.0 ],
 									"source" : [ "obj-18", 0 ]
 								}
 
@@ -1029,7 +1029,7 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-1", 0 ],
-									"midpoints" : [ 519.5, 376.0, 379.5, 376.0 ],
+									"midpoints" : [ 499.5, 336.0, 359.5, 336.0 ],
 									"source" : [ "obj-22", 0 ]
 								}
 
@@ -1044,7 +1044,7 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-1", 0 ],
-									"midpoints" : [ 379.5, 286.0, 379.5, 286.0 ],
+									"midpoints" : [ 359.5, 246.0, 359.5, 246.0 ],
 									"source" : [ "obj-31", 0 ]
 								}
 
@@ -1052,7 +1052,7 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-9", 0 ],
-									"midpoints" : [ 210.5, 261.0, 69.5, 261.0 ],
+									"midpoints" : [ 190.5, 221.0, 49.5, 221.0 ],
 									"source" : [ "obj-40", 1 ]
 								}
 
@@ -1067,7 +1067,7 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-1", 0 ],
-									"midpoints" : [ 418.5, 306.0, 379.5, 306.0 ],
+									"midpoints" : [ 398.5, 266.0, 359.5, 266.0 ],
 									"source" : [ "obj-8", 0 ]
 								}
 
@@ -2402,7 +2402,7 @@
 						}
 ,
 						"classnamespace" : "box",
-						"rect" : [ 35.0, 114.0, 995.0, 751.0 ],
+						"rect" : [ 0.0, 26.0, 995.0, 751.0 ],
 						"bglocked" : 0,
 						"openinpresentation" : 0,
 						"default_fontsize" : 13.0,
@@ -3789,7 +3789,7 @@
 									"numoutlets" : 3,
 									"outlettype" : [ "", "", "int" ],
 									"parameter_enable" : 0,
-									"patching_rect" : [ 890.0, 486.5, 20.0, 20.0 ],
+									"patching_rect" : [ 890.0, 446.5, 20.0, 20.0 ],
 									"rounded" : 60.0,
 									"text" : "5",
 									"textcolor" : [ 0.34902, 0.34902, 0.34902, 1.0 ]
@@ -3809,7 +3809,7 @@
 									"numoutlets" : 3,
 									"outlettype" : [ "", "", "int" ],
 									"parameter_enable" : 0,
-									"patching_rect" : [ 872.5, 408.0, 20.0, 20.0 ],
+									"patching_rect" : [ 872.5, 368.0, 20.0, 20.0 ],
 									"rounded" : 60.0,
 									"text" : "4",
 									"textcolor" : [ 0.34902, 0.34902, 0.34902, 1.0 ]
@@ -3829,7 +3829,7 @@
 									"numoutlets" : 3,
 									"outlettype" : [ "", "", "int" ],
 									"parameter_enable" : 0,
-									"patching_rect" : [ 689.5, 316.5, 20.0, 20.0 ],
+									"patching_rect" : [ 689.5, 276.5, 20.0, 20.0 ],
 									"rounded" : 60.0,
 									"text" : "3",
 									"textcolor" : [ 0.34902, 0.34902, 0.34902, 1.0 ]
@@ -3849,7 +3849,7 @@
 									"numoutlets" : 3,
 									"outlettype" : [ "", "", "int" ],
 									"parameter_enable" : 0,
-									"patching_rect" : [ 660.0, 212.5, 20.0, 20.0 ],
+									"patching_rect" : [ 660.0, 172.5, 20.0, 20.0 ],
 									"rounded" : 60.0,
 									"text" : "2",
 									"textcolor" : [ 0.34902, 0.34902, 0.34902, 1.0 ]
@@ -4014,7 +4014,7 @@
  ]
 									}
 ,
-									"patching_rect" : [ 370.0, 560.0, 96.0, 23.0 ],
+									"patching_rect" : [ 370.0, 520.0, 96.0, 23.0 ],
 									"saved_object_attributes" : 									{
 										"description" : "",
 										"digest" : "",
@@ -4033,7 +4033,7 @@
 									"maxclass" : "comment",
 									"numinlets" : 1,
 									"numoutlets" : 0,
-									"patching_rect" : [ 480.5, 617.5, 207.0, 65.0 ],
+									"patching_rect" : [ 480.5, 577.5, 207.0, 65.0 ],
 									"text" : "The result is such that only the first column (0th) of each point is copied over if the value in this column is less than 0.5.",
 									"textcolor" : [ 0.129412, 0.129412, 0.129412, 0.5 ]
 								}
@@ -4047,7 +4047,7 @@
 									"maxclass" : "comment",
 									"numinlets" : 1,
 									"numoutlets" : 0,
-									"patching_rect" : [ 729.5, 476.5, 158.0, 40.0 ],
+									"patching_rect" : [ 729.5, 436.5, 158.0, 40.0 ],
 									"text" : "Composing the query as one message",
 									"textcolor" : [ 0.0, 0.0, 0.0, 1.0 ]
 								}
@@ -4060,7 +4060,7 @@
 									"maxclass" : "comment",
 									"numinlets" : 1,
 									"numoutlets" : 0,
-									"patching_rect" : [ 711.5, 294.0, 207.0, 65.0 ],
+									"patching_rect" : [ 711.5, 254.0, 207.0, 65.0 ],
 									"text" : "In effect, we are saying, for each point where the filter is satisfied copy THIS column to our destination.",
 									"textcolor" : [ 0.129412, 0.129412, 0.129412, 0.5 ]
 								}
@@ -4074,7 +4074,7 @@
 									"maxclass" : "comment",
 									"numinlets" : 1,
 									"numoutlets" : 0,
-									"patching_rect" : [ 675.0, 383.5, 197.0, 69.0 ],
+									"patching_rect" : [ 675.0, 343.5, 197.0, 69.0 ],
 									"text" : "Calling transform executes the query and copies the results from the source to the destination.",
 									"textcolor" : [ 0.0, 0.0, 0.0, 1.0 ]
 								}
@@ -4088,7 +4088,7 @@
 									"maxclass" : "comment",
 									"numinlets" : 1,
 									"numoutlets" : 0,
-									"patching_rect" : [ 496.0, 301.0, 191.5, 54.0 ],
+									"patching_rect" : [ 496.0, 261.0, 191.5, 54.0 ],
 									"text" : "Then we specify which columns we would like to copy if they satisfy the filter.",
 									"textcolor" : [ 0.0, 0.0, 0.0, 1.0 ]
 								}
@@ -4107,7 +4107,7 @@
 									"numoutlets" : 3,
 									"outlettype" : [ "", "", "int" ],
 									"parameter_enable" : 0,
-									"patching_rect" : [ 325.0, 210.0, 20.0, 20.0 ],
+									"patching_rect" : [ 325.0, 170.0, 20.0, 20.0 ],
 									"rounded" : 60.0,
 									"text" : "1",
 									"textcolor" : [ 0.34902, 0.34902, 0.34902, 1.0 ]
@@ -4121,7 +4121,7 @@
 									"maxclass" : "comment",
 									"numinlets" : 1,
 									"numoutlets" : 0,
-									"patching_rect" : [ 76.0, 210.0, 247.0, 25.0 ],
+									"patching_rect" : [ 76.0, 170.0, 247.0, 25.0 ],
 									"text" : "Generate some example data to query",
 									"textcolor" : [ 0.0, 0.0, 0.0, 1.0 ]
 								}
@@ -4135,7 +4135,7 @@
 									"numoutlets" : 1,
 									"outlettype" : [ "bang" ],
 									"parameter_enable" : 0,
-									"patching_rect" : [ 50.0, 210.0, 24.0, 24.0 ]
+									"patching_rect" : [ 50.0, 170.0, 24.0, 24.0 ]
 								}
 
 							}
@@ -4147,7 +4147,7 @@
 									"numinlets" : 2,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 496.0, 476.5, 224.0, 38.0 ],
+									"patching_rect" : [ 496.0, 436.5, 224.0, 38.0 ],
 									"text" : "clear, filter 1 < 3, addcolumn 1, transform dsq.help.src dsq.help.dest"
 								}
 
@@ -4158,7 +4158,7 @@
 									"maxclass" : "dict.view",
 									"numinlets" : 1,
 									"numoutlets" : 0,
-									"patching_rect" : [ 370.0, 600.0, 108.0, 100.0 ],
+									"patching_rect" : [ 370.0, 560.0, 108.0, 100.0 ],
 									"textcolor" : [ 0.995808, 0.800103, 0.399985, 1.0 ]
 								}
 
@@ -4169,7 +4169,7 @@
 									"maxclass" : "dict.view",
 									"numinlets" : 1,
 									"numoutlets" : 0,
-									"patching_rect" : [ 50.0, 367.5, 220.0, 129.5 ]
+									"patching_rect" : [ 50.0, 327.5, 220.0, 129.5 ]
 								}
 
 							}
@@ -4180,7 +4180,7 @@
 									"numinlets" : 2,
 									"numoutlets" : 2,
 									"outlettype" : [ "", "" ],
-									"patching_rect" : [ 50.0, 330.0, 74.0, 23.0 ],
+									"patching_rect" : [ 50.0, 290.0, 74.0, 23.0 ],
 									"text" : "route dump"
 								}
 
@@ -4192,7 +4192,7 @@
 									"numinlets" : 1,
 									"numoutlets" : 2,
 									"outlettype" : [ "", "" ],
-									"patching_rect" : [ 50.0, 290.0, 160.0, 23.0 ],
+									"patching_rect" : [ 50.0, 250.0, 160.0, 23.0 ],
 									"text" : "fluid.dataset~ dsq.help.src"
 								}
 
@@ -4590,7 +4590,7 @@
  ]
 									}
 ,
-									"patching_rect" : [ 50.0, 250.0, 80.0, 23.0 ],
+									"patching_rect" : [ 50.0, 210.0, 80.0, 23.0 ],
 									"saved_object_attributes" : 									{
 										"description" : "",
 										"digest" : "",
@@ -4608,7 +4608,7 @@
 									"maxclass" : "comment",
 									"numinlets" : 1,
 									"numoutlets" : 0,
-									"patching_rect" : [ 461.5, 431.5, 207.0, 21.0 ],
+									"patching_rect" : [ 461.5, 391.5, 207.0, 21.0 ],
 									"text" : "transform <source> <destination> ",
 									"textcolor" : [ 0.129412, 0.129412, 0.129412, 0.5 ]
 								}
@@ -4621,7 +4621,7 @@
 									"numinlets" : 2,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 449.5, 406.5, 218.0, 23.0 ],
+									"patching_rect" : [ 449.5, 366.5, 218.0, 23.0 ],
 									"text" : "transform dsq.help.src dsq.help.dest"
 								}
 
@@ -4633,7 +4633,7 @@
 									"numinlets" : 2,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 408.0, 316.5, 83.0, 23.0 ],
+									"patching_rect" : [ 408.0, 276.5, 83.0, 23.0 ],
 									"text" : "addcolumn 0"
 								}
 
@@ -4645,7 +4645,7 @@
 									"maxclass" : "comment",
 									"numinlets" : 1,
 									"numoutlets" : 0,
-									"patching_rect" : [ 682.0, 183.0, 253.0, 79.0 ],
+									"patching_rect" : [ 682.0, 143.0, 253.0, 79.0 ],
 									"text" : "filter <column index> <operator> <value> \n\nIn this case this says that we are only interested in points in the dataset where the first column is less than 3",
 									"textcolor" : [ 0.129412, 0.129412, 0.129412, 0.5 ]
 								}
@@ -4658,7 +4658,7 @@
 									"numinlets" : 2,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 370.0, 210.0, 66.0, 23.0 ],
+									"patching_rect" : [ 370.0, 170.0, 66.0, 23.0 ],
 									"text" : "filter 0 < 3"
 								}
 
@@ -4670,7 +4670,7 @@
 									"maxclass" : "comment",
 									"numinlets" : 1,
 									"numoutlets" : 0,
-									"patching_rect" : [ 440.0, 210.0, 212.0, 25.0 ],
+									"patching_rect" : [ 440.0, 170.0, 212.0, 25.0 ],
 									"text" : "Queries always start with a filter.",
 									"textcolor" : [ 0.0, 0.0, 0.0, 1.0 ]
 								}
@@ -4683,7 +4683,7 @@
 									"numinlets" : 1,
 									"numoutlets" : 2,
 									"outlettype" : [ "", "" ],
-									"patching_rect" : [ 370.0, 528.0, 121.0, 23.0 ],
+									"patching_rect" : [ 370.0, 488.0, 121.0, 23.0 ],
 									"text" : "fluid.datasetquery~"
 								}
 
@@ -4722,7 +4722,7 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-1", 0 ],
-									"midpoints" : [ 417.5, 433.25, 379.5, 433.25 ],
+									"midpoints" : [ 417.5, 393.25, 379.5, 393.25 ],
 									"source" : [ "obj-18", 0 ]
 								}
 
@@ -4730,7 +4730,7 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-1", 0 ],
-									"midpoints" : [ 459.0, 478.25, 379.5, 478.25 ],
+									"midpoints" : [ 459.0, 438.25, 379.5, 438.25 ],
 									"source" : [ "obj-22", 0 ]
 								}
 
@@ -4745,7 +4745,7 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-1", 0 ],
-									"midpoints" : [ 505.5, 520.75, 379.5, 520.75 ],
+									"midpoints" : [ 505.5, 480.75, 379.5, 480.75 ],
 									"source" : [ "obj-34", 0 ]
 								}
 
@@ -4753,7 +4753,7 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-9", 0 ],
-									"midpoints" : [ 200.5, 321.0, 59.5, 321.0 ],
+									"midpoints" : [ 200.5, 281.0, 59.5, 281.0 ],
 									"source" : [ "obj-40", 1 ]
 								}
 
@@ -4768,7 +4768,7 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-1", 0 ],
-									"midpoints" : [ 379.5, 380.0, 379.5, 380.0 ],
+									"midpoints" : [ 379.5, 340.0, 379.5, 340.0 ],
 									"source" : [ "obj-8", 0 ]
 								}
 

--- a/help/fluid.datasetquery~.maxhelp
+++ b/help/fluid.datasetquery~.maxhelp
@@ -255,7 +255,7 @@
 										}
 ,
 										"classnamespace" : "box",
-										"rect" : [ 0.0, 0.0, 640.0, 480.0 ],
+										"rect" : [ 59.0, 106.0, 264.0, 227.0 ],
 										"bglocked" : 0,
 										"openinpresentation" : 0,
 										"default_fontsize" : 12.0,
@@ -290,7 +290,7 @@
 													"numinlets" : 2,
 													"numoutlets" : 1,
 													"outlettype" : [ "" ],
-													"patching_rect" : [ 50.0, 129.75, 41.0, 23.0 ],
+													"patching_rect" : [ 19.0, 85.75, 41.0, 22.0 ],
 													"text" : "dump"
 												}
 
@@ -302,7 +302,7 @@
 													"numinlets" : 2,
 													"numoutlets" : 2,
 													"outlettype" : [ "", "" ],
-													"patching_rect" : [ 198.0, 190.5, 74.0, 23.0 ],
+													"patching_rect" : [ 167.0, 146.5, 74.0, 22.0 ],
 													"text" : "route dump"
 												}
 
@@ -314,7 +314,7 @@
 													"numinlets" : 2,
 													"numoutlets" : 2,
 													"outlettype" : [ "", "" ],
-													"patching_rect" : [ 50.0, 100.0, 97.0, 23.0 ],
+													"patching_rect" : [ 19.0, 56.0, 97.0, 22.0 ],
 													"text" : "route transform"
 												}
 
@@ -324,9 +324,9 @@
 													"id" : "obj-27",
 													"maxclass" : "newobj",
 													"numinlets" : 1,
-													"numoutlets" : 3,
-													"outlettype" : [ "bang", "float", "" ],
-													"patching_rect" : [ 50.0, 159.5, 167.0, 23.0 ],
+													"numoutlets" : 2,
+													"outlettype" : [ "", "" ],
+													"patching_rect" : [ 19.0, 115.5, 167.0, 22.0 ],
 													"text" : "fluid.dataset~ dsq.help.dest"
 												}
 
@@ -340,7 +340,7 @@
 													"numinlets" : 0,
 													"numoutlets" : 1,
 													"outlettype" : [ "" ],
-													"patching_rect" : [ 50.0, 40.0, 30.0, 30.0 ]
+													"patching_rect" : [ 19.0, 10.0, 30.0, 30.0 ]
 												}
 
 											}
@@ -352,7 +352,7 @@
 													"maxclass" : "outlet",
 													"numinlets" : 1,
 													"numoutlets" : 0,
-													"patching_rect" : [ 198.0, 273.5, 30.0, 30.0 ]
+													"patching_rect" : [ 167.0, 180.5, 30.0, 30.0 ]
 												}
 
 											}
@@ -367,7 +367,7 @@
 , 											{
 												"patchline" : 												{
 													"destination" : [ "obj-32", 0 ],
-													"source" : [ "obj-27", 2 ]
+													"source" : [ "obj-27", 1 ]
 												}
 
 											}
@@ -395,7 +395,7 @@
  ]
 									}
 ,
-									"patching_rect" : [ 422.0, 460.0, 96.0, 23.0 ],
+									"patching_rect" : [ 320.0, 460.0, 96.0, 23.0 ],
 									"saved_object_attributes" : 									{
 										"description" : "",
 										"digest" : "",
@@ -499,7 +499,7 @@
 									"maxclass" : "dict.view",
 									"numinlets" : 1,
 									"numoutlets" : 0,
-									"patching_rect" : [ 422.0, 500.0, 168.0, 110.0 ],
+									"patching_rect" : [ 320.0, 500.0, 168.0, 110.0 ],
 									"textcolor" : [ 0.995808, 0.800103, 0.399985, 1.0 ]
 								}
 
@@ -531,8 +531,8 @@
 									"id" : "obj-40",
 									"maxclass" : "newobj",
 									"numinlets" : 1,
-									"numoutlets" : 3,
-									"outlettype" : [ "bang", "float", "" ],
+									"numoutlets" : 2,
+									"outlettype" : [ "", "" ],
 									"patching_rect" : [ 10.0, 250.0, 160.0, 23.0 ],
 									"text" : "fluid.dataset~ dsq.help.src"
 								}
@@ -662,8 +662,8 @@
 													"id" : "obj-40",
 													"maxclass" : "newobj",
 													"numinlets" : 1,
-													"numoutlets" : 3,
-													"outlettype" : [ "bang", "float", "" ],
+													"numoutlets" : 2,
+													"outlettype" : [ "", "" ],
 													"patching_rect" : [ 141.0, 90.0, 170.0, 22.0 ],
 													"text" : "fluid.dataset~ dsq.help.join.src"
 												}
@@ -699,8 +699,8 @@
 													"id" : "obj-30",
 													"maxclass" : "newobj",
 													"numinlets" : 1,
-													"numoutlets" : 3,
-													"outlettype" : [ "bang", "float", "" ],
+													"numoutlets" : 2,
+													"outlettype" : [ "", "" ],
 													"patching_rect" : [ 75.5, 510.0, 148.0, 22.0 ],
 													"text" : "fluid.dataset~ dsq.help.src"
 												}
@@ -904,13 +904,13 @@
 												"name" : "max6message",
 												"default" : 												{
 													"bgfillcolor" : 													{
-														"type" : "gradient",
+														"angle" : 270.0,
+														"autogradient" : 0,
+														"color" : [ 0.290196, 0.309804, 0.301961, 1.0 ],
 														"color1" : [ 0.866667, 0.866667, 0.866667, 1.0 ],
 														"color2" : [ 0.788235, 0.788235, 0.788235, 1.0 ],
-														"color" : [ 0.290196, 0.309804, 0.301961, 1.0 ],
-														"angle" : 270.0,
 														"proportion" : 0.39,
-														"autogradient" : 0
+														"type" : "gradient"
 													}
 ,
 													"textcolor_inverse" : [ 0.0, 0.0, 0.0, 1.0 ]
@@ -984,8 +984,8 @@
 									"id" : "obj-1",
 									"maxclass" : "newobj",
 									"numinlets" : 1,
-									"numoutlets" : 3,
-									"outlettype" : [ "bang", "float", "" ],
+									"numoutlets" : 2,
+									"outlettype" : [ "", "" ],
 									"patching_rect" : [ 320.0, 420.0, 121.0, 23.0 ],
 									"text" : "fluid.datasetquery~"
 								}
@@ -1028,7 +1028,7 @@
 						"lines" : [ 							{
 								"patchline" : 								{
 									"destination" : [ "obj-25", 0 ],
-									"source" : [ "obj-1", 2 ]
+									"source" : [ "obj-1", 0 ]
 								}
 
 							}
@@ -1073,8 +1073,8 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-9", 0 ],
-									"midpoints" : [ 160.5, 284.0, 19.5, 284.0 ],
-									"source" : [ "obj-40", 2 ]
+									"midpoints" : [ 160.5, 281.0, 19.5, 281.0 ],
+									"source" : [ "obj-40", 1 ]
 								}
 
 							}
@@ -1125,13 +1125,13 @@
 								"name" : "max6message",
 								"default" : 								{
 									"bgfillcolor" : 									{
-										"type" : "gradient",
+										"angle" : 270.0,
+										"autogradient" : 0,
+										"color" : [ 0.290196, 0.309804, 0.301961, 1.0 ],
 										"color1" : [ 0.866667, 0.866667, 0.866667, 1.0 ],
 										"color2" : [ 0.788235, 0.788235, 0.788235, 1.0 ],
-										"color" : [ 0.290196, 0.309804, 0.301961, 1.0 ],
-										"angle" : 270.0,
 										"proportion" : 0.39,
-										"autogradient" : 0
+										"type" : "gradient"
 									}
 ,
 									"textcolor_inverse" : [ 0.0, 0.0, 0.0, 1.0 ]
@@ -1475,7 +1475,7 @@
 										}
 ,
 										"classnamespace" : "box",
-										"rect" : [ 0.0, 0.0, 640.0, 480.0 ],
+										"rect" : [ 59.0, 106.0, 258.0, 229.0 ],
 										"bglocked" : 0,
 										"openinpresentation" : 0,
 										"default_fontsize" : 12.0,
@@ -1510,7 +1510,7 @@
 													"numinlets" : 2,
 													"numoutlets" : 1,
 													"outlettype" : [ "" ],
-													"patching_rect" : [ 50.0, 129.75, 41.0, 23.0 ],
+													"patching_rect" : [ 12.0, 87.75, 41.0, 22.0 ],
 													"text" : "dump"
 												}
 
@@ -1522,7 +1522,7 @@
 													"numinlets" : 2,
 													"numoutlets" : 2,
 													"outlettype" : [ "", "" ],
-													"patching_rect" : [ 198.0, 190.5, 74.0, 23.0 ],
+													"patching_rect" : [ 160.0, 148.5, 74.0, 22.0 ],
 													"text" : "route dump"
 												}
 
@@ -1534,7 +1534,7 @@
 													"numinlets" : 2,
 													"numoutlets" : 2,
 													"outlettype" : [ "", "" ],
-													"patching_rect" : [ 50.0, 100.0, 97.0, 23.0 ],
+													"patching_rect" : [ 12.0, 58.0, 97.0, 22.0 ],
 													"text" : "route transform"
 												}
 
@@ -1544,9 +1544,9 @@
 													"id" : "obj-27",
 													"maxclass" : "newobj",
 													"numinlets" : 1,
-													"numoutlets" : 3,
-													"outlettype" : [ "bang", "float", "" ],
-													"patching_rect" : [ 50.0, 159.5, 167.0, 23.0 ],
+													"numoutlets" : 2,
+													"outlettype" : [ "", "" ],
+													"patching_rect" : [ 12.0, 117.5, 167.0, 22.0 ],
 													"text" : "fluid.dataset~ dsq.help.dest"
 												}
 
@@ -1560,7 +1560,7 @@
 													"numinlets" : 0,
 													"numoutlets" : 1,
 													"outlettype" : [ "" ],
-													"patching_rect" : [ 50.0, 40.0, 30.0, 30.0 ]
+													"patching_rect" : [ 12.0, 13.0, 30.0, 30.0 ]
 												}
 
 											}
@@ -1572,7 +1572,7 @@
 													"maxclass" : "outlet",
 													"numinlets" : 1,
 													"numoutlets" : 0,
-													"patching_rect" : [ 198.0, 273.5, 30.0, 30.0 ]
+													"patching_rect" : [ 160.0, 181.5, 30.0, 30.0 ]
 												}
 
 											}
@@ -1587,7 +1587,7 @@
 , 											{
 												"patchline" : 												{
 													"destination" : [ "obj-32", 0 ],
-													"source" : [ "obj-27", 2 ]
+													"source" : [ "obj-27", 1 ]
 												}
 
 											}
@@ -1615,7 +1615,7 @@
  ]
 									}
 ,
-									"patching_rect" : [ 422.0, 560.0, 96.0, 23.0 ],
+									"patching_rect" : [ 320.0, 560.0, 96.0, 23.0 ],
 									"saved_object_attributes" : 									{
 										"description" : "",
 										"digest" : "",
@@ -1719,7 +1719,7 @@
 									"maxclass" : "dict.view",
 									"numinlets" : 1,
 									"numoutlets" : 0,
-									"patching_rect" : [ 422.0, 600.0, 158.0, 110.0 ],
+									"patching_rect" : [ 320.0, 600.0, 150.0, 130.0 ],
 									"textcolor" : [ 0.995808, 0.800103, 0.399985, 1.0 ]
 								}
 
@@ -1751,8 +1751,8 @@
 									"id" : "obj-40",
 									"maxclass" : "newobj",
 									"numinlets" : 1,
-									"numoutlets" : 3,
-									"outlettype" : [ "bang", "float", "" ],
+									"numoutlets" : 2,
+									"outlettype" : [ "", "" ],
 									"patching_rect" : [ 10.0, 250.0, 160.0, 23.0 ],
 									"text" : "fluid.dataset~ dsq.help.src"
 								}
@@ -1882,8 +1882,8 @@
 													"id" : "obj-40",
 													"maxclass" : "newobj",
 													"numinlets" : 1,
-													"numoutlets" : 3,
-													"outlettype" : [ "bang", "float", "" ],
+													"numoutlets" : 2,
+													"outlettype" : [ "", "" ],
 													"patching_rect" : [ 141.0, 90.0, 170.0, 22.0 ],
 													"text" : "fluid.dataset~ dsq.help.join.src"
 												}
@@ -1919,8 +1919,8 @@
 													"id" : "obj-30",
 													"maxclass" : "newobj",
 													"numinlets" : 1,
-													"numoutlets" : 3,
-													"outlettype" : [ "bang", "float", "" ],
+													"numoutlets" : 2,
+													"outlettype" : [ "", "" ],
 													"patching_rect" : [ 75.5, 510.0, 148.0, 22.0 ],
 													"text" : "fluid.dataset~ dsq.help.src"
 												}
@@ -2124,13 +2124,13 @@
 												"name" : "max6message",
 												"default" : 												{
 													"bgfillcolor" : 													{
-														"type" : "gradient",
+														"angle" : 270.0,
+														"autogradient" : 0,
+														"color" : [ 0.290196, 0.309804, 0.301961, 1.0 ],
 														"color1" : [ 0.866667, 0.866667, 0.866667, 1.0 ],
 														"color2" : [ 0.788235, 0.788235, 0.788235, 1.0 ],
-														"color" : [ 0.290196, 0.309804, 0.301961, 1.0 ],
-														"angle" : 270.0,
 														"proportion" : 0.39,
-														"autogradient" : 0
+														"type" : "gradient"
 													}
 ,
 													"textcolor_inverse" : [ 0.0, 0.0, 0.0, 1.0 ]
@@ -2204,8 +2204,8 @@
 									"id" : "obj-1",
 									"maxclass" : "newobj",
 									"numinlets" : 1,
-									"numoutlets" : 3,
-									"outlettype" : [ "bang", "float", "" ],
+									"numoutlets" : 2,
+									"outlettype" : [ "", "" ],
 									"patching_rect" : [ 320.0, 520.0, 121.0, 23.0 ],
 									"text" : "fluid.datasetquery~"
 								}
@@ -2265,7 +2265,7 @@
 						"lines" : [ 							{
 								"patchline" : 								{
 									"destination" : [ "obj-25", 0 ],
-									"source" : [ "obj-1", 2 ]
+									"source" : [ "obj-1", 0 ]
 								}
 
 							}
@@ -2326,8 +2326,8 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-9", 0 ],
-									"midpoints" : [ 160.5, 284.0, 19.5, 284.0 ],
-									"source" : [ "obj-40", 2 ]
+									"midpoints" : [ 160.5, 281.0, 19.5, 281.0 ],
+									"source" : [ "obj-40", 1 ]
 								}
 
 							}
@@ -2386,13 +2386,13 @@
 								"name" : "max6message",
 								"default" : 								{
 									"bgfillcolor" : 									{
-										"type" : "gradient",
+										"angle" : 270.0,
+										"autogradient" : 0,
+										"color" : [ 0.290196, 0.309804, 0.301961, 1.0 ],
 										"color1" : [ 0.866667, 0.866667, 0.866667, 1.0 ],
 										"color2" : [ 0.788235, 0.788235, 0.788235, 1.0 ],
-										"color" : [ 0.290196, 0.309804, 0.301961, 1.0 ],
-										"angle" : 270.0,
 										"proportion" : 0.39,
-										"autogradient" : 0
+										"type" : "gradient"
 									}
 ,
 									"textcolor_inverse" : [ 0.0, 0.0, 0.0, 1.0 ]
@@ -2512,7 +2512,7 @@
 										}
 ,
 										"classnamespace" : "box",
-										"rect" : [ 0.0, 0.0, 640.0, 480.0 ],
+										"rect" : [ 59.0, 106.0, 640.0, 480.0 ],
 										"bglocked" : 0,
 										"openinpresentation" : 0,
 										"default_fontsize" : 12.0,
@@ -2547,7 +2547,7 @@
 													"numinlets" : 2,
 													"numoutlets" : 2,
 													"outlettype" : [ "", "" ],
-													"patching_rect" : [ 50.0, 193.0, 74.0, 23.0 ],
+													"patching_rect" : [ 13.0, 175.0, 74.0, 22.0 ],
 													"text" : "route dump"
 												}
 
@@ -2559,7 +2559,7 @@
 													"numinlets" : 2,
 													"numoutlets" : 2,
 													"outlettype" : [ "", "" ],
-													"patching_rect" : [ 50.0, 100.0, 117.0, 23.0 ],
+													"patching_rect" : [ 13.0, 61.0, 117.0, 22.0 ],
 													"text" : "route transformjoin"
 												}
 
@@ -2571,7 +2571,7 @@
 													"numinlets" : 2,
 													"numoutlets" : 1,
 													"outlettype" : [ "" ],
-													"patching_rect" : [ 50.0, 131.0, 41.0, 23.0 ],
+													"patching_rect" : [ 13.0, 97.0, 41.0, 22.0 ],
 													"text" : "dump"
 												}
 
@@ -2581,9 +2581,9 @@
 													"id" : "obj-22",
 													"maxclass" : "newobj",
 													"numinlets" : 1,
-													"numoutlets" : 3,
-													"outlettype" : [ "bang", "float", "" ],
-													"patching_rect" : [ 50.0, 160.0, 184.0, 23.0 ],
+													"numoutlets" : 2,
+													"outlettype" : [ "", "" ],
+													"patching_rect" : [ 13.0, 136.0, 184.0, 22.0 ],
 													"text" : "fluid.dataset~ dsq.help.join.out"
 												}
 
@@ -2597,7 +2597,7 @@
 													"numinlets" : 0,
 													"numoutlets" : 1,
 													"outlettype" : [ "" ],
-													"patching_rect" : [ 50.0, 40.0, 30.0, 30.0 ]
+													"patching_rect" : [ 13.0, 10.0, 30.0, 30.0 ]
 												}
 
 											}
@@ -2609,7 +2609,7 @@
 													"maxclass" : "outlet",
 													"numinlets" : 1,
 													"numoutlets" : 0,
-													"patching_rect" : [ 50.0, 276.0, 30.0, 30.0 ]
+													"patching_rect" : [ 13.0, 208.0, 30.0, 30.0 ]
 												}
 
 											}
@@ -2617,8 +2617,8 @@
 										"lines" : [ 											{
 												"patchline" : 												{
 													"destination" : [ "obj-30", 0 ],
-													"midpoints" : [ 224.5, 186.0, 59.5, 186.0 ],
-													"source" : [ "obj-22", 2 ]
+													"midpoints" : [ 187.5, 163.0, 22.5, 163.0 ],
+													"source" : [ "obj-22", 1 ]
 												}
 
 											}
@@ -2653,7 +2653,7 @@
  ]
 									}
 ,
-									"patching_rect" : [ 519.0, 580.0, 52.0, 23.0 ],
+									"patching_rect" : [ 419.0, 580.0, 52.0, 23.0 ],
 									"saved_object_attributes" : 									{
 										"description" : "",
 										"digest" : "",
@@ -2725,11 +2725,11 @@
 , 							{
 								"box" : 								{
 									"id" : "obj-19",
-									"linecount" : 10,
+									"linecount" : 9,
 									"maxclass" : "comment",
 									"numinlets" : 1,
 									"numoutlets" : 0,
-									"patching_rect" : [ 620.0, 384.25, 230.0, 152.0 ],
+									"patching_rect" : [ 620.0, 384.25, 234.0, 137.0 ],
 									"text" : "When a column is manually added with addcolumn, the filter only respects the contents of dataset A. Any points that satisfy the filter have the respective column merged with that of dataset B. In this case, any point where the first column is equal to 6000 has the corresponding column for that point in dataset B's merged with dataset A.",
 									"textcolor" : [ 0.129412, 0.129412, 0.129412, 0.5 ]
 								}
@@ -2875,7 +2875,7 @@
 									"maxclass" : "dict.view",
 									"numinlets" : 1,
 									"numoutlets" : 0,
-									"patching_rect" : [ 519.0, 610.0, 241.0, 80.0 ],
+									"patching_rect" : [ 419.0, 610.0, 241.0, 80.0 ],
 									"textcolor" : [ 0.996078, 0.898039, 0.031373, 1.0 ]
 								}
 
@@ -2897,8 +2897,8 @@
 									"id" : "obj-23",
 									"maxclass" : "newobj",
 									"numinlets" : 1,
-									"numoutlets" : 3,
-									"outlettype" : [ "bang", "float", "" ],
+									"numoutlets" : 2,
+									"outlettype" : [ "", "" ],
 									"patching_rect" : [ 419.0, 550.0, 119.0, 23.0 ],
 									"text" : "fluid.datasetquery~"
 								}
@@ -2967,8 +2967,8 @@
 									"id" : "obj-40",
 									"maxclass" : "newobj",
 									"numinlets" : 1,
-									"numoutlets" : 3,
-									"outlettype" : [ "bang", "float", "" ],
+									"numoutlets" : 2,
+									"outlettype" : [ "", "" ],
 									"patching_rect" : [ 10.0, 281.5, 175.0, 23.0 ],
 									"text" : "fluid.dataset~ dsq.help.join.A"
 								}
@@ -2979,8 +2979,8 @@
 									"id" : "obj-41",
 									"maxclass" : "newobj",
 									"numinlets" : 1,
-									"numoutlets" : 3,
-									"outlettype" : [ "bang", "float", "" ],
+									"numoutlets" : 2,
+									"outlettype" : [ "", "" ],
 									"patching_rect" : [ 193.0, 281.5, 175.0, 23.0 ],
 									"text" : "fluid.dataset~ dsq.help.join.B"
 								}
@@ -3073,8 +3073,8 @@
 													"id" : "obj-40",
 													"maxclass" : "newobj",
 													"numinlets" : 1,
-													"numoutlets" : 3,
-													"outlettype" : [ "bang", "float", "" ],
+													"numoutlets" : 2,
+													"outlettype" : [ "", "" ],
 													"patching_rect" : [ 102.5, 97.0, 162.0, 22.0 ],
 													"text" : "fluid.dataset~ dsq.help.join.A"
 												}
@@ -3085,8 +3085,8 @@
 													"id" : "obj-41",
 													"maxclass" : "newobj",
 													"numinlets" : 1,
-													"numoutlets" : 3,
-													"outlettype" : [ "bang", "float", "" ],
+													"numoutlets" : 2,
+													"outlettype" : [ "", "" ],
 													"patching_rect" : [ 276.5, 97.0, 162.0, 22.0 ],
 													"text" : "fluid.dataset~ dsq.help.join.B"
 												}
@@ -3122,8 +3122,8 @@
 													"id" : "obj-30",
 													"maxclass" : "newobj",
 													"numinlets" : 1,
-													"numoutlets" : 3,
-													"outlettype" : [ "bang", "float", "" ],
+													"numoutlets" : 2,
+													"outlettype" : [ "", "" ],
 													"patching_rect" : [ 83.5, 505.0, 162.0, 22.0 ],
 													"text" : "fluid.dataset~ dsq.help.join.A"
 												}
@@ -3194,8 +3194,8 @@
 													"id" : "obj-25",
 													"maxclass" : "newobj",
 													"numinlets" : 1,
-													"numoutlets" : 3,
-													"outlettype" : [ "bang", "float", "" ],
+													"numoutlets" : 2,
+													"outlettype" : [ "", "" ],
 													"patching_rect" : [ 257.5, 505.0, 162.0, 22.0 ],
 													"text" : "fluid.dataset~ dsq.help.join.B"
 												}
@@ -3532,13 +3532,13 @@
 												"name" : "max6message",
 												"default" : 												{
 													"bgfillcolor" : 													{
-														"type" : "gradient",
+														"angle" : 270.0,
+														"autogradient" : 0,
+														"color" : [ 0.290196, 0.309804, 0.301961, 1.0 ],
 														"color1" : [ 0.866667, 0.866667, 0.866667, 1.0 ],
 														"color2" : [ 0.788235, 0.788235, 0.788235, 1.0 ],
-														"color" : [ 0.290196, 0.309804, 0.301961, 1.0 ],
-														"angle" : 270.0,
 														"proportion" : 0.39,
-														"autogradient" : 0
+														"type" : "gradient"
 													}
 ,
 													"textcolor_inverse" : [ 0.0, 0.0, 0.0, 1.0 ]
@@ -3624,7 +3624,7 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-49", 0 ],
-									"source" : [ "obj-23", 2 ]
+									"source" : [ "obj-23", 0 ]
 								}
 
 							}
@@ -3662,16 +3662,16 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-9", 0 ],
-									"midpoints" : [ 175.5, 320.5, 19.5, 320.5 ],
-									"source" : [ "obj-40", 2 ]
+									"midpoints" : [ 175.5, 314.75, 19.5, 314.75 ],
+									"source" : [ "obj-40", 1 ]
 								}
 
 							}
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-18", 0 ],
-									"midpoints" : [ 358.5, 320.5, 202.5, 320.5 ],
-									"source" : [ "obj-41", 2 ]
+									"midpoints" : [ 358.5, 314.75, 202.5, 314.75 ],
+									"source" : [ "obj-41", 1 ]
 								}
 
 							}
@@ -3732,13 +3732,13 @@
 								"name" : "max6message",
 								"default" : 								{
 									"bgfillcolor" : 									{
-										"type" : "gradient",
+										"angle" : 270.0,
+										"autogradient" : 0,
+										"color" : [ 0.290196, 0.309804, 0.301961, 1.0 ],
 										"color1" : [ 0.866667, 0.866667, 0.866667, 1.0 ],
 										"color2" : [ 0.788235, 0.788235, 0.788235, 1.0 ],
-										"color" : [ 0.290196, 0.309804, 0.301961, 1.0 ],
-										"angle" : 270.0,
 										"proportion" : 0.39,
-										"autogradient" : 0
+										"type" : "gradient"
 									}
 ,
 									"textcolor_inverse" : [ 0.0, 0.0, 0.0, 1.0 ]
@@ -3938,7 +3938,7 @@
 										}
 ,
 										"classnamespace" : "box",
-										"rect" : [ 0.0, 0.0, 640.0, 480.0 ],
+										"rect" : [ 59.0, 106.0, 280.0, 274.0 ],
 										"bglocked" : 0,
 										"openinpresentation" : 0,
 										"default_fontsize" : 12.0,
@@ -3973,7 +3973,7 @@
 													"numinlets" : 2,
 													"numoutlets" : 1,
 													"outlettype" : [ "" ],
-													"patching_rect" : [ 50.0, 129.75, 41.0, 23.0 ],
+													"patching_rect" : [ 19.0, 101.75, 41.0, 22.0 ],
 													"text" : "dump"
 												}
 
@@ -3985,7 +3985,7 @@
 													"numinlets" : 2,
 													"numoutlets" : 2,
 													"outlettype" : [ "", "" ],
-													"patching_rect" : [ 198.0, 190.5, 74.0, 23.0 ],
+													"patching_rect" : [ 167.0, 162.5, 74.0, 22.0 ],
 													"text" : "route dump"
 												}
 
@@ -3997,7 +3997,7 @@
 													"numinlets" : 2,
 													"numoutlets" : 2,
 													"outlettype" : [ "", "" ],
-													"patching_rect" : [ 50.0, 100.0, 97.0, 23.0 ],
+													"patching_rect" : [ 19.0, 72.0, 97.0, 22.0 ],
 													"text" : "route transform"
 												}
 
@@ -4007,9 +4007,9 @@
 													"id" : "obj-27",
 													"maxclass" : "newobj",
 													"numinlets" : 1,
-													"numoutlets" : 3,
-													"outlettype" : [ "bang", "float", "" ],
-													"patching_rect" : [ 50.0, 159.5, 167.0, 23.0 ],
+													"numoutlets" : 2,
+													"outlettype" : [ "", "" ],
+													"patching_rect" : [ 19.0, 131.5, 167.0, 22.0 ],
 													"text" : "fluid.dataset~ dsq.help.dest"
 												}
 
@@ -4023,7 +4023,7 @@
 													"numinlets" : 0,
 													"numoutlets" : 1,
 													"outlettype" : [ "" ],
-													"patching_rect" : [ 50.0, 40.0, 30.0, 30.0 ]
+													"patching_rect" : [ 19.0, 12.0, 30.0, 30.0 ]
 												}
 
 											}
@@ -4035,7 +4035,7 @@
 													"maxclass" : "outlet",
 													"numinlets" : 1,
 													"numoutlets" : 0,
-													"patching_rect" : [ 198.0, 273.5, 30.0, 30.0 ]
+													"patching_rect" : [ 167.0, 200.5, 30.0, 30.0 ]
 												}
 
 											}
@@ -4050,7 +4050,7 @@
 , 											{
 												"patchline" : 												{
 													"destination" : [ "obj-32", 0 ],
-													"source" : [ "obj-27", 2 ]
+													"source" : [ "obj-27", 1 ]
 												}
 
 											}
@@ -4078,7 +4078,7 @@
  ]
 									}
 ,
-									"patching_rect" : [ 432.0, 508.0, 96.0, 23.0 ],
+									"patching_rect" : [ 330.0, 500.0, 96.0, 23.0 ],
 									"saved_object_attributes" : 									{
 										"description" : "",
 										"digest" : "",
@@ -4097,7 +4097,7 @@
 									"maxclass" : "comment",
 									"numinlets" : 1,
 									"numoutlets" : 0,
-									"patching_rect" : [ 544.5, 548.0, 207.0, 65.0 ],
+									"patching_rect" : [ 440.5, 557.5, 207.0, 65.0 ],
 									"text" : "The result is such that only the first column (0th) of each point is copied over if the value in this column is less than 0.5.",
 									"textcolor" : [ 0.129412, 0.129412, 0.129412, 0.5 ]
 								}
@@ -4222,7 +4222,7 @@
 									"maxclass" : "dict.view",
 									"numinlets" : 1,
 									"numoutlets" : 0,
-									"patching_rect" : [ 432.0, 548.0, 108.0, 100.0 ],
+									"patching_rect" : [ 330.0, 540.0, 108.0, 100.0 ],
 									"textcolor" : [ 0.995808, 0.800103, 0.399985, 1.0 ]
 								}
 
@@ -4254,8 +4254,8 @@
 									"id" : "obj-40",
 									"maxclass" : "newobj",
 									"numinlets" : 1,
-									"numoutlets" : 3,
-									"outlettype" : [ "bang", "float", "" ],
+									"numoutlets" : 2,
+									"outlettype" : [ "", "" ],
 									"patching_rect" : [ 10.0, 230.0, 160.0, 23.0 ],
 									"text" : "fluid.dataset~ dsq.help.src"
 								}
@@ -4385,8 +4385,8 @@
 													"id" : "obj-40",
 													"maxclass" : "newobj",
 													"numinlets" : 1,
-													"numoutlets" : 3,
-													"outlettype" : [ "bang", "float", "" ],
+													"numoutlets" : 2,
+													"outlettype" : [ "", "" ],
 													"patching_rect" : [ 141.0, 90.0, 170.0, 22.0 ],
 													"text" : "fluid.dataset~ dsq.help.join.src"
 												}
@@ -4422,8 +4422,8 @@
 													"id" : "obj-30",
 													"maxclass" : "newobj",
 													"numinlets" : 1,
-													"numoutlets" : 3,
-													"outlettype" : [ "bang", "float", "" ],
+													"numoutlets" : 2,
+													"outlettype" : [ "", "" ],
 													"patching_rect" : [ 75.5, 510.0, 148.0, 22.0 ],
 													"text" : "fluid.dataset~ dsq.help.src"
 												}
@@ -4627,13 +4627,13 @@
 												"name" : "max6message",
 												"default" : 												{
 													"bgfillcolor" : 													{
-														"type" : "gradient",
+														"angle" : 270.0,
+														"autogradient" : 0,
+														"color" : [ 0.290196, 0.309804, 0.301961, 1.0 ],
 														"color1" : [ 0.866667, 0.866667, 0.866667, 1.0 ],
 														"color2" : [ 0.788235, 0.788235, 0.788235, 1.0 ],
-														"color" : [ 0.290196, 0.309804, 0.301961, 1.0 ],
-														"angle" : 270.0,
 														"proportion" : 0.39,
-														"autogradient" : 0
+														"type" : "gradient"
 													}
 ,
 													"textcolor_inverse" : [ 0.0, 0.0, 0.0, 1.0 ]
@@ -4745,8 +4745,8 @@
 									"id" : "obj-1",
 									"maxclass" : "newobj",
 									"numinlets" : 1,
-									"numoutlets" : 3,
-									"outlettype" : [ "bang", "float", "" ],
+									"numoutlets" : 2,
+									"outlettype" : [ "", "" ],
 									"patching_rect" : [ 330.0, 468.0, 121.0, 23.0 ],
 									"text" : "fluid.datasetquery~"
 								}
@@ -4772,7 +4772,7 @@
 						"lines" : [ 							{
 								"patchline" : 								{
 									"destination" : [ "obj-25", 0 ],
-									"source" : [ "obj-1", 2 ]
+									"source" : [ "obj-1", 0 ]
 								}
 
 							}
@@ -4817,8 +4817,8 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-9", 0 ],
-									"midpoints" : [ 160.5, 264.0, 19.5, 264.0 ],
-									"source" : [ "obj-40", 2 ]
+									"midpoints" : [ 160.5, 261.0, 19.5, 261.0 ],
+									"source" : [ "obj-40", 1 ]
 								}
 
 							}
@@ -4869,13 +4869,13 @@
 								"name" : "max6message",
 								"default" : 								{
 									"bgfillcolor" : 									{
-										"type" : "gradient",
+										"angle" : 270.0,
+										"autogradient" : 0,
+										"color" : [ 0.290196, 0.309804, 0.301961, 1.0 ],
 										"color1" : [ 0.866667, 0.866667, 0.866667, 1.0 ],
 										"color2" : [ 0.788235, 0.788235, 0.788235, 1.0 ],
-										"color" : [ 0.290196, 0.309804, 0.301961, 1.0 ],
-										"angle" : 270.0,
 										"proportion" : 0.39,
-										"autogradient" : 0
+										"type" : "gradient"
 									}
 ,
 									"textcolor_inverse" : [ 0.0, 0.0, 0.0, 1.0 ]
@@ -4991,41 +4991,6 @@
 			}
  ],
 		"lines" : [  ],
-		"dependency_cache" : [ 			{
-				"name" : "fluid.flucomaorg.maxpat",
-				"bootpath" : "~/dev/flucoma/max/help",
-				"patcherrelativepath" : ".",
-				"type" : "JSON",
-				"implicit" : 1
-			}
-, 			{
-				"name" : "fluid.learn.maxpat",
-				"bootpath" : "~/dev/flucoma/max/help",
-				"patcherrelativepath" : ".",
-				"type" : "JSON",
-				"implicit" : 1
-			}
-, 			{
-				"name" : "fluid.libmanipulation.mxo",
-				"type" : "iLaX"
-			}
-, 			{
-				"name" : "fluid.list2buf.mxo",
-				"type" : "iLaX"
-			}
-, 			{
-				"name" : "helpdetails.js",
-				"bootpath" : "C74:/help/resources",
-				"type" : "TEXT",
-				"implicit" : 1
-			}
-, 			{
-				"name" : "helpname.js",
-				"bootpath" : "C74:/help/resources",
-				"type" : "TEXT",
-				"implicit" : 1
-			}
- ],
 		"autosave" : 0
 	}
 

--- a/help/fluid.datasetquery~.maxhelp
+++ b/help/fluid.datasetquery~.maxhelp
@@ -88,33 +88,12 @@
 						"assistshowspatchername" : 0,
 						"boxes" : [ 							{
 								"box" : 								{
-									"args" : [ "datasetquery" ],
-									"bgmode" : 0,
-									"border" : 0,
-									"clickthrough" : 0,
-									"enablehscroll" : 0,
-									"enablevscroll" : 0,
-									"id" : "obj-20",
-									"lockeddragscroll" : 0,
-									"lockedsize" : 0,
-									"maxclass" : "bpatcher",
-									"name" : "fluid.learn.maxpat",
-									"numinlets" : 0,
-									"numoutlets" : 0,
-									"offset" : [ 0.0, 0.0 ],
-									"patching_rect" : [ 560.0, 10.0, 260.0, 100.0 ],
-									"viewvisibility" : 1
-								}
-
-							}
-, 							{
-								"box" : 								{
 									"id" : "obj-42",
 									"maxclass" : "comment",
 									"numinlets" : 1,
 									"numoutlets" : 0,
-									"patching_rect" : [ 10.0, 140.0, 430.0, 21.0 ],
-									"text" : "We can also combine multiple operators to refine the filter for the query.",
+									"patching_rect" : [ 10.0, 62.0, 430.0, 21.0 ],
+									"text" : "Only copy a range of columns using addrange",
 									"textcolor" : [ 0.501960784313725, 0.501960784313725, 0.501960784313725, 1.0 ]
 								}
 
@@ -132,7 +111,7 @@
 									"numoutlets" : 3,
 									"outlettype" : [ "", "", "int" ],
 									"parameter_enable" : 0,
-									"patching_rect" : [ 877.0, 350.0, 20.0, 20.0 ],
+									"patching_rect" : [ 927.0, 330.0, 20.0, 20.0 ],
 									"rounded" : 60.0,
 									"text" : "5",
 									"textcolor" : [ 0.34902, 0.34902, 0.34902, 1.0 ]
@@ -146,7 +125,7 @@
 									"maxclass" : "comment",
 									"numinlets" : 1,
 									"numoutlets" : 0,
-									"patching_rect" : [ 359.0, 170.0, 212.0, 25.0 ],
+									"patching_rect" : [ 409.0, 150.0, 212.0, 25.0 ],
 									"text" : "Clear the filters so we start fresh",
 									"textcolor" : [ 0.0, 0.0, 0.0, 1.0 ]
 								}
@@ -159,7 +138,7 @@
 									"numinlets" : 2,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 320.0, 170.0, 37.0, 23.0 ],
+									"patching_rect" : [ 370.0, 150.0, 37.0, 23.0 ],
 									"text" : "clear"
 								}
 
@@ -177,7 +156,7 @@
 									"numoutlets" : 3,
 									"outlettype" : [ "", "", "int" ],
 									"parameter_enable" : 0,
-									"patching_rect" : [ 577.5, 170.0, 20.0, 20.0 ],
+									"patching_rect" : [ 627.5, 150.0, 20.0, 20.0 ],
 									"rounded" : 60.0,
 									"text" : "2",
 									"textcolor" : [ 0.34902, 0.34902, 0.34902, 1.0 ]
@@ -191,7 +170,7 @@
 									"maxclass" : "comment",
 									"numinlets" : 1,
 									"numoutlets" : 0,
-									"patching_rect" : [ 430.5, 210.0, 165.0, 25.0 ],
+									"patching_rect" : [ 480.5, 190.0, 165.0, 25.0 ],
 									"text" : "Now add our basic filter",
 									"textcolor" : [ 0.0, 0.0, 0.0, 1.0 ]
 								}
@@ -210,7 +189,7 @@
 									"numoutlets" : 3,
 									"outlettype" : [ "", "", "int" ],
 									"parameter_enable" : 0,
-									"patching_rect" : [ 867.0, 280.0, 20.0, 20.0 ],
+									"patching_rect" : [ 917.0, 260.0, 20.0, 20.0 ],
 									"rounded" : 60.0,
 									"text" : "4",
 									"textcolor" : [ 0.34902, 0.34902, 0.34902, 1.0 ]
@@ -230,7 +209,7 @@
 									"numoutlets" : 3,
 									"outlettype" : [ "", "", "int" ],
 									"parameter_enable" : 0,
-									"patching_rect" : [ 602.0, 212.5, 20.0, 20.0 ],
+									"patching_rect" : [ 652.0, 192.5, 20.0, 20.0 ],
 									"rounded" : 60.0,
 									"text" : "3",
 									"textcolor" : [ 0.34902, 0.34902, 0.34902, 1.0 ]
@@ -395,7 +374,7 @@
  ]
 									}
 ,
-									"patching_rect" : [ 320.0, 460.0, 96.0, 23.0 ],
+									"patching_rect" : [ 370.0, 440.0, 96.0, 23.0 ],
 									"saved_object_attributes" : 									{
 										"description" : "",
 										"digest" : "",
@@ -414,7 +393,7 @@
 									"maxclass" : "comment",
 									"numinlets" : 1,
 									"numoutlets" : 0,
-									"patching_rect" : [ 487.0, 261.0, 215.0, 65.0 ],
+									"patching_rect" : [ 537.0, 241.0, 215.0, 65.0 ],
 									"text" : "Add a range of columns in the format <start> <number of columns>. This will add two columns starting from the second.",
 									"textcolor" : [ 0.129412, 0.129412, 0.129412, 0.5 ]
 								}
@@ -428,7 +407,7 @@
 									"maxclass" : "comment",
 									"numinlets" : 1,
 									"numoutlets" : 0,
-									"patching_rect" : [ 680.0, 341.5, 195.0, 40.0 ],
+									"patching_rect" : [ 730.0, 321.5, 195.0, 40.0 ],
 									"text" : "Transform to do the query and copy",
 									"textcolor" : [ 0.0, 0.0, 0.0, 1.0 ]
 								}
@@ -442,7 +421,7 @@
 									"maxclass" : "comment",
 									"numinlets" : 1,
 									"numoutlets" : 0,
-									"patching_rect" : [ 710.0, 271.5, 155.0, 40.0 ],
+									"patching_rect" : [ 760.0, 251.5, 155.0, 40.0 ],
 									"text" : "Add a range of columns to copy",
 									"textcolor" : [ 0.0, 0.0, 0.0, 1.0 ]
 								}
@@ -461,7 +440,7 @@
 									"numoutlets" : 3,
 									"outlettype" : [ "", "", "int" ],
 									"parameter_enable" : 0,
-									"patching_rect" : [ 285.0, 170.0, 20.0, 20.0 ],
+									"patching_rect" : [ 335.0, 150.0, 20.0, 20.0 ],
 									"rounded" : 60.0,
 									"text" : "1",
 									"textcolor" : [ 0.34902, 0.34902, 0.34902, 1.0 ]
@@ -475,7 +454,7 @@
 									"maxclass" : "comment",
 									"numinlets" : 1,
 									"numoutlets" : 0,
-									"patching_rect" : [ 36.0, 170.0, 247.0, 25.0 ],
+									"patching_rect" : [ 86.0, 150.0, 247.0, 25.0 ],
 									"text" : "Generate some example data to query",
 									"textcolor" : [ 0.0, 0.0, 0.0, 1.0 ]
 								}
@@ -489,7 +468,7 @@
 									"numoutlets" : 1,
 									"outlettype" : [ "bang" ],
 									"parameter_enable" : 0,
-									"patching_rect" : [ 10.0, 170.0, 24.0, 24.0 ]
+									"patching_rect" : [ 60.0, 150.0, 24.0, 24.0 ]
 								}
 
 							}
@@ -499,7 +478,7 @@
 									"maxclass" : "dict.view",
 									"numinlets" : 1,
 									"numoutlets" : 0,
-									"patching_rect" : [ 320.0, 500.0, 168.0, 110.0 ],
+									"patching_rect" : [ 370.0, 480.0, 168.0, 110.0 ],
 									"textcolor" : [ 0.995808, 0.800103, 0.399985, 1.0 ]
 								}
 
@@ -510,7 +489,7 @@
 									"maxclass" : "dict.view",
 									"numinlets" : 1,
 									"numoutlets" : 0,
-									"patching_rect" : [ 10.0, 327.5, 220.0, 129.5 ]
+									"patching_rect" : [ 60.0, 307.5, 220.0, 129.5 ]
 								}
 
 							}
@@ -521,7 +500,7 @@
 									"numinlets" : 2,
 									"numoutlets" : 2,
 									"outlettype" : [ "", "" ],
-									"patching_rect" : [ 10.0, 290.0, 74.0, 23.0 ],
+									"patching_rect" : [ 60.0, 270.0, 74.0, 23.0 ],
 									"text" : "route dump"
 								}
 
@@ -533,7 +512,7 @@
 									"numinlets" : 1,
 									"numoutlets" : 2,
 									"outlettype" : [ "", "" ],
-									"patching_rect" : [ 10.0, 250.0, 160.0, 23.0 ],
+									"patching_rect" : [ 60.0, 230.0, 160.0, 23.0 ],
 									"text" : "fluid.dataset~ dsq.help.src"
 								}
 
@@ -931,7 +910,7 @@
  ]
 									}
 ,
-									"patching_rect" : [ 10.0, 210.0, 80.0, 23.0 ],
+									"patching_rect" : [ 60.0, 190.0, 80.0, 23.0 ],
 									"saved_object_attributes" : 									{
 										"description" : "",
 										"digest" : "",
@@ -950,7 +929,7 @@
 									"numinlets" : 2,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 460.0, 350.0, 218.0, 23.0 ],
+									"patching_rect" : [ 510.0, 330.0, 218.0, 23.0 ],
 									"text" : "transform dsq.help.src dsq.help.dest"
 								}
 
@@ -962,7 +941,7 @@
 									"numinlets" : 2,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 400.0, 280.0, 85.0, 23.0 ],
+									"patching_rect" : [ 450.0, 260.0, 85.0, 23.0 ],
 									"text" : "addrange 1 2"
 								}
 
@@ -974,7 +953,7 @@
 									"numinlets" : 2,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 359.0, 210.0, 66.0, 23.0 ],
+									"patching_rect" : [ 409.0, 190.0, 66.0, 23.0 ],
 									"text" : "filter 0 < 3"
 								}
 
@@ -986,7 +965,7 @@
 									"numinlets" : 1,
 									"numoutlets" : 2,
 									"outlettype" : [ "", "" ],
-									"patching_rect" : [ 320.0, 420.0, 121.0, 23.0 ],
+									"patching_rect" : [ 370.0, 400.0, 121.0, 23.0 ],
 									"text" : "fluid.datasetquery~"
 								}
 
@@ -1003,7 +982,7 @@
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
 									"parameter_enable" : 0,
-									"patching_rect" : [ 10.0, 10.0, 545.0, 121.0 ]
+									"patching_rect" : [ 10.0, 10.0, 415.0, 50.0 ]
 								}
 
 							}
@@ -1019,7 +998,7 @@
 									"mode" : 0,
 									"numinlets" : 1,
 									"numoutlets" : 0,
-									"patching_rect" : [ 390.0, 250.0, 315.5, 83.0 ],
+									"patching_rect" : [ 440.0, 230.0, 315.5, 83.0 ],
 									"proportion" : 0.5
 								}
 
@@ -1042,7 +1021,7 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-1", 0 ],
-									"midpoints" : [ 409.5, 361.0, 329.5, 361.0 ],
+									"midpoints" : [ 459.5, 341.0, 379.5, 341.0 ],
 									"source" : [ "obj-18", 0 ]
 								}
 
@@ -1050,7 +1029,7 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-1", 0 ],
-									"midpoints" : [ 469.5, 396.0, 329.5, 396.0 ],
+									"midpoints" : [ 519.5, 376.0, 379.5, 376.0 ],
 									"source" : [ "obj-22", 0 ]
 								}
 
@@ -1065,7 +1044,7 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-1", 0 ],
-									"midpoints" : [ 329.5, 306.0, 329.5, 306.0 ],
+									"midpoints" : [ 379.5, 286.0, 379.5, 286.0 ],
 									"source" : [ "obj-31", 0 ]
 								}
 
@@ -1073,7 +1052,7 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-9", 0 ],
-									"midpoints" : [ 160.5, 281.0, 19.5, 281.0 ],
+									"midpoints" : [ 210.5, 261.0, 69.5, 261.0 ],
 									"source" : [ "obj-40", 1 ]
 								}
 
@@ -1088,7 +1067,7 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-1", 0 ],
-									"midpoints" : [ 368.5, 326.0, 329.5, 326.0 ],
+									"midpoints" : [ 418.5, 306.0, 379.5, 306.0 ],
 									"source" : [ "obj-8", 0 ]
 								}
 
@@ -1214,32 +1193,11 @@
 						"assistshowspatchername" : 0,
 						"boxes" : [ 							{
 								"box" : 								{
-									"args" : [ "datasetquery" ],
-									"bgmode" : 0,
-									"border" : 0,
-									"clickthrough" : 0,
-									"enablehscroll" : 0,
-									"enablevscroll" : 0,
-									"id" : "obj-43",
-									"lockeddragscroll" : 0,
-									"lockedsize" : 0,
-									"maxclass" : "bpatcher",
-									"name" : "fluid.learn.maxpat",
-									"numinlets" : 0,
-									"numoutlets" : 0,
-									"offset" : [ 0.0, 0.0 ],
-									"patching_rect" : [ 560.0, 10.0, 260.0, 100.0 ],
-									"viewvisibility" : 1
-								}
-
-							}
-, 							{
-								"box" : 								{
 									"id" : "obj-42",
 									"maxclass" : "comment",
 									"numinlets" : 1,
 									"numoutlets" : 0,
-									"patching_rect" : [ 10.0, 133.0, 430.0, 21.0 ],
+									"patching_rect" : [ 10.0, 62.0, 430.0, 21.0 ],
 									"text" : "We can also combine multiple operators to refine the filter for the query.",
 									"textcolor" : [ 0.501960784313725, 0.501960784313725, 0.501960784313725, 1.0 ]
 								}
@@ -1258,7 +1216,7 @@
 									"numoutlets" : 3,
 									"outlettype" : [ "", "", "int" ],
 									"parameter_enable" : 0,
-									"patching_rect" : [ 880.0, 481.5, 20.0, 20.0 ],
+									"patching_rect" : [ 900.0, 461.5, 20.0, 20.0 ],
 									"rounded" : 60.0,
 									"text" : "6",
 									"textcolor" : [ 0.34902, 0.34902, 0.34902, 1.0 ]
@@ -1278,7 +1236,7 @@
 									"numoutlets" : 3,
 									"outlettype" : [ "", "", "int" ],
 									"parameter_enable" : 0,
-									"patching_rect" : [ 825.0, 417.5, 20.0, 20.0 ],
+									"patching_rect" : [ 845.0, 397.5, 20.0, 20.0 ],
 									"rounded" : 60.0,
 									"text" : "5",
 									"textcolor" : [ 0.34902, 0.34902, 0.34902, 1.0 ]
@@ -1292,7 +1250,7 @@
 									"maxclass" : "comment",
 									"numinlets" : 1,
 									"numoutlets" : 0,
-									"patching_rect" : [ 359.0, 170.0, 212.0, 25.0 ],
+									"patching_rect" : [ 379.0, 150.0, 212.0, 25.0 ],
 									"text" : "Clear the filters so we start fresh",
 									"textcolor" : [ 0.0, 0.0, 0.0, 1.0 ]
 								}
@@ -1304,7 +1262,7 @@
 									"maxclass" : "comment",
 									"numinlets" : 1,
 									"numoutlets" : 0,
-									"patching_rect" : [ 527.5, 328.0, 250.0, 21.0 ],
+									"patching_rect" : [ 547.5, 308.0, 250.0, 21.0 ],
 									"text" : "OR Last column is equal to 3000",
 									"textcolor" : [ 0.129412, 0.129412, 0.129412, 0.5 ]
 								}
@@ -1316,7 +1274,7 @@
 									"maxclass" : "comment",
 									"numinlets" : 1,
 									"numoutlets" : 0,
-									"patching_rect" : [ 490.0, 288.0, 281.0, 21.0 ],
+									"patching_rect" : [ 510.0, 268.0, 281.0, 21.0 ],
 									"text" : "AND Second column is less than or equal to 20",
 									"textcolor" : [ 0.129412, 0.129412, 0.129412, 0.5 ]
 								}
@@ -1329,7 +1287,7 @@
 									"numinlets" : 2,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 320.0, 170.0, 37.0, 23.0 ],
+									"patching_rect" : [ 340.0, 150.0, 37.0, 23.0 ],
 									"text" : "clear"
 								}
 
@@ -1341,7 +1299,7 @@
 									"numinlets" : 2,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 435.5, 428.0, 83.0, 23.0 ],
+									"patching_rect" : [ 455.5, 408.0, 83.0, 23.0 ],
 									"text" : "addcolumn 3"
 								}
 
@@ -1353,7 +1311,7 @@
 									"numinlets" : 2,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 434.5, 328.0, 82.0, 23.0 ],
+									"patching_rect" : [ 454.5, 308.0, 82.0, 23.0 ],
 									"text" : "or 3 <= 5000"
 								}
 
@@ -1366,7 +1324,7 @@
 									"maxclass" : "comment",
 									"numinlets" : 1,
 									"numoutlets" : 0,
-									"patching_rect" : [ 799.5, 288.0, 147.0, 69.0 ],
+									"patching_rect" : [ 819.5, 268.0, 147.0, 69.0 ],
 									"text" : "Optionally add any number of additional opeartors to constrain the search",
 									"textcolor" : [ 0.0, 0.0, 0.0, 1.0 ]
 								}
@@ -1379,7 +1337,7 @@
 									"numinlets" : 2,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 407.5, 288.0, 78.0, 23.0 ],
+									"patching_rect" : [ 427.5, 268.0, 78.0, 23.0 ],
 									"text" : "and 1 <= 10"
 								}
 
@@ -1397,7 +1355,7 @@
 									"numoutlets" : 3,
 									"outlettype" : [ "", "", "int" ],
 									"parameter_enable" : 0,
-									"patching_rect" : [ 577.5, 170.0, 20.0, 20.0 ],
+									"patching_rect" : [ 597.5, 150.0, 20.0, 20.0 ],
 									"rounded" : 60.0,
 									"text" : "2",
 									"textcolor" : [ 0.34902, 0.34902, 0.34902, 1.0 ]
@@ -1411,7 +1369,7 @@
 									"maxclass" : "comment",
 									"numinlets" : 1,
 									"numoutlets" : 0,
-									"patching_rect" : [ 414.5, 230.0, 165.0, 25.0 ],
+									"patching_rect" : [ 434.5, 210.0, 165.0, 25.0 ],
 									"text" : "Now add our basic filter",
 									"textcolor" : [ 0.0, 0.0, 0.0, 1.0 ]
 								}
@@ -1430,7 +1388,7 @@
 									"numoutlets" : 3,
 									"outlettype" : [ "", "", "int" ],
 									"parameter_enable" : 0,
-									"patching_rect" : [ 946.0, 312.5, 20.0, 20.0 ],
+									"patching_rect" : [ 966.0, 292.5, 20.0, 20.0 ],
 									"rounded" : 60.0,
 									"text" : "4",
 									"textcolor" : [ 0.34902, 0.34902, 0.34902, 1.0 ]
@@ -1450,7 +1408,7 @@
 									"numoutlets" : 3,
 									"outlettype" : [ "", "", "int" ],
 									"parameter_enable" : 0,
-									"patching_rect" : [ 586.0, 232.5, 20.0, 20.0 ],
+									"patching_rect" : [ 606.0, 212.5, 20.0, 20.0 ],
 									"rounded" : 60.0,
 									"text" : "3",
 									"textcolor" : [ 0.34902, 0.34902, 0.34902, 1.0 ]
@@ -1615,7 +1573,7 @@
  ]
 									}
 ,
-									"patching_rect" : [ 320.0, 560.0, 96.0, 23.0 ],
+									"patching_rect" : [ 340.0, 540.0, 96.0, 23.0 ],
 									"saved_object_attributes" : 									{
 										"description" : "",
 										"digest" : "",
@@ -1634,7 +1592,7 @@
 									"maxclass" : "comment",
 									"numinlets" : 1,
 									"numoutlets" : 0,
-									"patching_rect" : [ 527.5, 388.0, 124.0, 65.0 ],
+									"patching_rect" : [ 547.5, 368.0, 124.0, 65.0 ],
 									"text" : "Add columns that we want to copy for points where the filter is satisfied",
 									"textcolor" : [ 0.129412, 0.129412, 0.129412, 0.5 ]
 								}
@@ -1648,7 +1606,7 @@
 									"maxclass" : "comment",
 									"numinlets" : 1,
 									"numoutlets" : 0,
-									"patching_rect" : [ 680.0, 471.5, 195.0, 40.0 ],
+									"patching_rect" : [ 700.0, 451.5, 195.0, 40.0 ],
 									"text" : "Transform to do the query and copy",
 									"textcolor" : [ 0.0, 0.0, 0.0, 1.0 ]
 								}
@@ -1662,7 +1620,7 @@
 									"maxclass" : "comment",
 									"numinlets" : 1,
 									"numoutlets" : 0,
-									"patching_rect" : [ 668.0, 407.5, 156.0, 40.0 ],
+									"patching_rect" : [ 688.0, 387.5, 156.0, 40.0 ],
 									"text" : "Then add columns we want to copy",
 									"textcolor" : [ 0.0, 0.0, 0.0, 1.0 ]
 								}
@@ -1681,7 +1639,7 @@
 									"numoutlets" : 3,
 									"outlettype" : [ "", "", "int" ],
 									"parameter_enable" : 0,
-									"patching_rect" : [ 285.0, 170.0, 20.0, 20.0 ],
+									"patching_rect" : [ 305.0, 150.0, 20.0, 20.0 ],
 									"rounded" : 60.0,
 									"text" : "1",
 									"textcolor" : [ 0.34902, 0.34902, 0.34902, 1.0 ]
@@ -1695,7 +1653,7 @@
 									"maxclass" : "comment",
 									"numinlets" : 1,
 									"numoutlets" : 0,
-									"patching_rect" : [ 36.0, 170.0, 247.0, 25.0 ],
+									"patching_rect" : [ 56.0, 150.0, 247.0, 25.0 ],
 									"text" : "Generate some example data to query",
 									"textcolor" : [ 0.0, 0.0, 0.0, 1.0 ]
 								}
@@ -1709,7 +1667,7 @@
 									"numoutlets" : 1,
 									"outlettype" : [ "bang" ],
 									"parameter_enable" : 0,
-									"patching_rect" : [ 10.0, 170.0, 24.0, 24.0 ]
+									"patching_rect" : [ 30.0, 150.0, 24.0, 24.0 ]
 								}
 
 							}
@@ -1719,7 +1677,7 @@
 									"maxclass" : "dict.view",
 									"numinlets" : 1,
 									"numoutlets" : 0,
-									"patching_rect" : [ 320.0, 600.0, 150.0, 130.0 ],
+									"patching_rect" : [ 340.0, 580.0, 150.0, 130.0 ],
 									"textcolor" : [ 0.995808, 0.800103, 0.399985, 1.0 ]
 								}
 
@@ -1730,7 +1688,7 @@
 									"maxclass" : "dict.view",
 									"numinlets" : 1,
 									"numoutlets" : 0,
-									"patching_rect" : [ 10.0, 327.5, 220.0, 129.5 ]
+									"patching_rect" : [ 30.0, 307.5, 220.0, 129.5 ]
 								}
 
 							}
@@ -1741,7 +1699,7 @@
 									"numinlets" : 2,
 									"numoutlets" : 2,
 									"outlettype" : [ "", "" ],
-									"patching_rect" : [ 10.0, 290.0, 74.0, 23.0 ],
+									"patching_rect" : [ 30.0, 270.0, 74.0, 23.0 ],
 									"text" : "route dump"
 								}
 
@@ -1753,7 +1711,7 @@
 									"numinlets" : 1,
 									"numoutlets" : 2,
 									"outlettype" : [ "", "" ],
-									"patching_rect" : [ 10.0, 250.0, 160.0, 23.0 ],
+									"patching_rect" : [ 30.0, 230.0, 160.0, 23.0 ],
 									"text" : "fluid.dataset~ dsq.help.src"
 								}
 
@@ -2151,7 +2109,7 @@
  ]
 									}
 ,
-									"patching_rect" : [ 10.0, 210.0, 80.0, 23.0 ],
+									"patching_rect" : [ 30.0, 190.0, 80.0, 23.0 ],
 									"saved_object_attributes" : 									{
 										"description" : "",
 										"digest" : "",
@@ -2170,7 +2128,7 @@
 									"numinlets" : 2,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 460.0, 480.0, 218.0, 23.0 ],
+									"patching_rect" : [ 480.0, 460.0, 218.0, 23.0 ],
 									"text" : "transform dsq.help.src dsq.help.dest"
 								}
 
@@ -2182,7 +2140,7 @@
 									"numinlets" : 2,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 407.5, 388.0, 83.0, 23.0 ],
+									"patching_rect" : [ 427.5, 368.0, 83.0, 23.0 ],
 									"text" : "addcolumn 0"
 								}
 
@@ -2194,7 +2152,7 @@
 									"numinlets" : 2,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 343.0, 230.0, 66.0, 23.0 ],
+									"patching_rect" : [ 363.0, 210.0, 66.0, 23.0 ],
 									"text" : "filter 0 < 3"
 								}
 
@@ -2206,7 +2164,7 @@
 									"numinlets" : 1,
 									"numoutlets" : 2,
 									"outlettype" : [ "", "" ],
-									"patching_rect" : [ 320.0, 520.0, 121.0, 23.0 ],
+									"patching_rect" : [ 340.0, 500.0, 121.0, 23.0 ],
 									"text" : "fluid.datasetquery~"
 								}
 
@@ -2223,7 +2181,7 @@
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
 									"parameter_enable" : 0,
-									"patching_rect" : [ 10.0, 10.0, 545.0, 121.0 ]
+									"patching_rect" : [ 10.0, 10.0, 420.0, 50.0 ]
 								}
 
 							}
@@ -2239,7 +2197,7 @@
 									"mode" : 0,
 									"numinlets" : 1,
 									"numoutlets" : 0,
-									"patching_rect" : [ 394.5, 378.0, 273.0, 84.0 ],
+									"patching_rect" : [ 414.5, 358.0, 273.0, 84.0 ],
 									"proportion" : 0.5
 								}
 
@@ -2256,7 +2214,7 @@
 									"mode" : 0,
 									"numinlets" : 1,
 									"numoutlets" : 0,
-									"patching_rect" : [ 394.5, 275.5, 403.0, 92.5 ],
+									"patching_rect" : [ 414.5, 255.5, 403.0, 92.5 ],
 									"proportion" : 0.5
 								}
 
@@ -2279,7 +2237,7 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-1", 0 ],
-									"midpoints" : [ 417.0, 507.0, 329.5, 507.0 ],
+									"midpoints" : [ 437.0, 487.0, 349.5, 487.0 ],
 									"source" : [ "obj-18", 0 ]
 								}
 
@@ -2287,7 +2245,7 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-1", 0 ],
-									"midpoints" : [ 444.0, 363.0, 329.5, 363.0 ],
+									"midpoints" : [ 464.0, 343.0, 349.5, 343.0 ],
 									"source" : [ "obj-21", 0 ]
 								}
 
@@ -2295,7 +2253,7 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-1", 0 ],
-									"midpoints" : [ 469.5, 507.0, 329.5, 507.0 ],
+									"midpoints" : [ 489.5, 487.0, 349.5, 487.0 ],
 									"source" : [ "obj-22", 0 ]
 								}
 
@@ -2303,7 +2261,7 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-1", 0 ],
-									"midpoints" : [ 445.0, 507.0, 329.5, 507.0 ],
+									"midpoints" : [ 465.0, 487.0, 349.5, 487.0 ],
 									"source" : [ "obj-24", 0 ]
 								}
 
@@ -2318,7 +2276,7 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-1", 0 ],
-									"midpoints" : [ 329.5, 195.0, 329.5, 195.0 ],
+									"midpoints" : [ 349.5, 175.0, 349.5, 175.0 ],
 									"source" : [ "obj-31", 0 ]
 								}
 
@@ -2326,7 +2284,7 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-9", 0 ],
-									"midpoints" : [ 160.5, 281.0, 19.5, 281.0 ],
+									"midpoints" : [ 180.5, 261.0, 39.5, 261.0 ],
 									"source" : [ "obj-40", 1 ]
 								}
 
@@ -2341,7 +2299,7 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-1", 0 ],
-									"midpoints" : [ 417.0, 363.0, 329.5, 363.0 ],
+									"midpoints" : [ 437.0, 343.0, 349.5, 343.0 ],
 									"source" : [ "obj-7", 0 ]
 								}
 
@@ -2349,7 +2307,7 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-1", 0 ],
-									"midpoints" : [ 352.5, 507.0, 329.5, 507.0 ],
+									"midpoints" : [ 372.5, 487.0, 349.5, 487.0 ],
 									"source" : [ "obj-8", 0 ]
 								}
 
@@ -2444,7 +2402,7 @@
 						}
 ,
 						"classnamespace" : "box",
-						"rect" : [ 0.0, 26.0, 995.0, 751.0 ],
+						"rect" : [ 35.0, 114.0, 995.0, 751.0 ],
 						"bglocked" : 0,
 						"openinpresentation" : 0,
 						"default_fontsize" : 13.0,
@@ -2474,27 +2432,6 @@
 						"showontab" : 1,
 						"assistshowspatchername" : 0,
 						"boxes" : [ 							{
-								"box" : 								{
-									"args" : [ "datasetquery" ],
-									"bgmode" : 0,
-									"border" : 0,
-									"clickthrough" : 0,
-									"enablehscroll" : 0,
-									"enablevscroll" : 0,
-									"id" : "obj-50",
-									"lockeddragscroll" : 0,
-									"lockedsize" : 0,
-									"maxclass" : "bpatcher",
-									"name" : "fluid.learn.maxpat",
-									"numinlets" : 0,
-									"numoutlets" : 0,
-									"offset" : [ 0.0, 0.0 ],
-									"patching_rect" : [ 560.0, 10.0, 260.0, 100.0 ],
-									"viewvisibility" : 1
-								}
-
-							}
-, 							{
 								"box" : 								{
 									"id" : "obj-49",
 									"maxclass" : "newobj",
@@ -2653,7 +2590,7 @@
  ]
 									}
 ,
-									"patching_rect" : [ 419.0, 580.0, 52.0, 23.0 ],
+									"patching_rect" : [ 459.0, 520.0, 52.0, 23.0 ],
 									"saved_object_attributes" : 									{
 										"description" : "",
 										"digest" : "",
@@ -2678,7 +2615,7 @@
 									"numoutlets" : 3,
 									"outlettype" : [ "", "", "int" ],
 									"parameter_enable" : 0,
-									"patching_rect" : [ 862.0, 441.75, 20.0, 20.0 ],
+									"patching_rect" : [ 902.0, 381.75, 20.0, 20.0 ],
 									"rounded" : 60.0,
 									"text" : "5",
 									"textcolor" : [ 0.34902, 0.34902, 0.34902, 1.0 ]
@@ -2688,11 +2625,10 @@
 , 							{
 								"box" : 								{
 									"id" : "obj-38",
-									"linecount" : 2,
 									"maxclass" : "comment",
 									"numinlets" : 1,
 									"numoutlets" : 0,
-									"patching_rect" : [ 10.0, 140.0, 426.0, 36.0 ],
+									"patching_rect" : [ 10.0, 62.0, 650.0, 21.0 ],
 									"text" : "The transformjoin message allows filtering the contents of a dataset based on the contents found in another. ",
 									"textcolor" : [ 0.501960784313725, 0.501960784313725, 0.501960784313725, 1.0 ]
 								}
@@ -2705,7 +2641,7 @@
 									"maxclass" : "comment",
 									"numinlets" : 1,
 									"numoutlets" : 0,
-									"patching_rect" : [ 36.0, 190.0, 338.0, 25.0 ],
+									"patching_rect" : [ 76.0, 130.0, 338.0, 25.0 ],
 									"text" : "Generate two datasets with some overlap of identifiers"
 								}
 
@@ -2718,7 +2654,7 @@
 									"numoutlets" : 1,
 									"outlettype" : [ "bang" ],
 									"parameter_enable" : 0,
-									"patching_rect" : [ 10.0, 190.0, 24.0, 24.0 ]
+									"patching_rect" : [ 50.0, 130.0, 24.0, 24.0 ]
 								}
 
 							}
@@ -2729,7 +2665,7 @@
 									"maxclass" : "comment",
 									"numinlets" : 1,
 									"numoutlets" : 0,
-									"patching_rect" : [ 620.0, 384.25, 234.0, 137.0 ],
+									"patching_rect" : [ 660.0, 324.25, 238.0, 137.0 ],
 									"text" : "When a column is manually added with addcolumn, the filter only respects the contents of dataset A. Any points that satisfy the filter have the respective column merged with that of dataset B. In this case, any point where the first column is equal to 6000 has the corresponding column for that point in dataset B's merged with dataset A.",
 									"textcolor" : [ 0.129412, 0.129412, 0.129412, 0.5 ]
 								}
@@ -2747,7 +2683,7 @@
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
 									"parameter_enable" : 0,
-									"patching_rect" : [ 10.0, 10.0, 545.0, 121.0 ]
+									"patching_rect" : [ 10.0, 10.0, 420.0, 50.0 ]
 								}
 
 							}
@@ -2764,7 +2700,7 @@
 									"numoutlets" : 3,
 									"outlettype" : [ "", "", "int" ],
 									"parameter_enable" : 0,
-									"patching_rect" : [ 673.0, 352.25, 20.0, 20.0 ],
+									"patching_rect" : [ 713.0, 292.25, 20.0, 20.0 ],
 									"rounded" : 60.0,
 									"text" : "4",
 									"textcolor" : [ 0.34902, 0.34902, 0.34902, 1.0 ]
@@ -2784,7 +2720,7 @@
 									"numoutlets" : 3,
 									"outlettype" : [ "", "", "int" ],
 									"parameter_enable" : 0,
-									"patching_rect" : [ 793.0, 234.0, 20.0, 20.0 ],
+									"patching_rect" : [ 833.0, 174.0, 20.0, 20.0 ],
 									"rounded" : 60.0,
 									"text" : "3",
 									"textcolor" : [ 0.34902, 0.34902, 0.34902, 1.0 ]
@@ -2804,7 +2740,7 @@
 									"numoutlets" : 3,
 									"outlettype" : [ "", "", "int" ],
 									"parameter_enable" : 0,
-									"patching_rect" : [ 556.5, 201.5, 20.0, 20.0 ],
+									"patching_rect" : [ 596.5, 141.5, 20.0, 20.0 ],
 									"rounded" : 60.0,
 									"text" : "2",
 									"textcolor" : [ 0.34902, 0.34902, 0.34902, 1.0 ]
@@ -2824,7 +2760,7 @@
 									"numoutlets" : 3,
 									"outlettype" : [ "", "", "int" ],
 									"parameter_enable" : 0,
-									"patching_rect" : [ 376.0, 192.5, 20.0, 20.0 ],
+									"patching_rect" : [ 416.0, 132.5, 20.0, 20.0 ],
 									"rounded" : 60.0,
 									"text" : "1",
 									"textcolor" : [ 0.34902, 0.34902, 0.34902, 1.0 ]
@@ -2839,7 +2775,7 @@
 									"numinlets" : 2,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 432.0, 232.5, 359.0, 23.0 ],
+									"patching_rect" : [ 472.0, 172.5, 359.0, 23.0 ],
 									"text" : "transformjoin dsq.help.join.A dsq.help.join.B dsq.help.join.out"
 								}
 
@@ -2851,7 +2787,7 @@
 									"maxclass" : "comment",
 									"numinlets" : 1,
 									"numoutlets" : 0,
-									"patching_rect" : [ 458.0, 268.0, 355.0, 65.0 ],
+									"patching_rect" : [ 498.0, 208.0, 355.0, 65.0 ],
 									"text" : "Unlike transform, we're not obliged to add columns to the query. In this case, we can just filter dataset B based on conditions in dataset A. It is important to note that it merges the second provided dataset with the first for each identifier.",
 									"textcolor" : [ 0.129412, 0.129412, 0.129412, 0.5 ]
 								}
@@ -2864,7 +2800,7 @@
 									"numinlets" : 2,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 419.0, 200.0, 130.0, 23.0 ],
+									"patching_rect" : [ 459.0, 140.0, 130.0, 23.0 ],
 									"text" : "clear, filter 0 >= 3000"
 								}
 
@@ -2875,7 +2811,7 @@
 									"maxclass" : "dict.view",
 									"numinlets" : 1,
 									"numoutlets" : 0,
-									"patching_rect" : [ 419.0, 610.0, 241.0, 80.0 ],
+									"patching_rect" : [ 459.0, 550.0, 241.0, 80.0 ],
 									"textcolor" : [ 0.996078, 0.898039, 0.031373, 1.0 ]
 								}
 
@@ -2887,7 +2823,7 @@
 									"numinlets" : 2,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 458.0, 351.75, 212.0, 23.0 ],
+									"patching_rect" : [ 498.0, 291.75, 212.0, 23.0 ],
 									"text" : "clear, filter 0 == 6000, addcolumn 0"
 								}
 
@@ -2899,7 +2835,7 @@
 									"numinlets" : 1,
 									"numoutlets" : 2,
 									"outlettype" : [ "", "" ],
-									"patching_rect" : [ 419.0, 550.0, 119.0, 23.0 ],
+									"patching_rect" : [ 459.0, 490.0, 119.0, 23.0 ],
 									"text" : "fluid.datasetquery~"
 								}
 
@@ -2913,7 +2849,7 @@
 									"numinlets" : 2,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 500.0, 411.75, 108.736022999999932, 67.0 ],
+									"patching_rect" : [ 540.0, 351.75, 108.736022999999932, 67.0 ],
 									"text" : "transformjoin dsq.help.join.A dsq.help.join.B dsq.help.join.out"
 								}
 
@@ -2924,7 +2860,7 @@
 									"maxclass" : "dict.view",
 									"numinlets" : 1,
 									"numoutlets" : 0,
-									"patching_rect" : [ 193.0, 359.787234000000012, 170.0, 152.159995999999978 ]
+									"patching_rect" : [ 233.0, 299.787234000000012, 170.0, 152.159995999999978 ]
 								}
 
 							}
@@ -2935,7 +2871,7 @@
 									"numinlets" : 2,
 									"numoutlets" : 2,
 									"outlettype" : [ "", "" ],
-									"patching_rect" : [ 193.0, 326.0, 74.0, 23.0 ],
+									"patching_rect" : [ 233.0, 266.0, 74.0, 23.0 ],
 									"text" : "route dump"
 								}
 
@@ -2946,7 +2882,7 @@
 									"maxclass" : "dict.view",
 									"numinlets" : 1,
 									"numoutlets" : 0,
-									"patching_rect" : [ 10.0, 359.787234000000012, 175.0, 228.0 ]
+									"patching_rect" : [ 50.0, 299.787234000000012, 175.0, 228.0 ]
 								}
 
 							}
@@ -2957,7 +2893,7 @@
 									"numinlets" : 2,
 									"numoutlets" : 2,
 									"outlettype" : [ "", "" ],
-									"patching_rect" : [ 10.0, 326.0, 74.0, 23.0 ],
+									"patching_rect" : [ 50.0, 266.0, 74.0, 23.0 ],
 									"text" : "route dump"
 								}
 
@@ -2969,7 +2905,7 @@
 									"numinlets" : 1,
 									"numoutlets" : 2,
 									"outlettype" : [ "", "" ],
-									"patching_rect" : [ 10.0, 281.5, 175.0, 23.0 ],
+									"patching_rect" : [ 50.0, 221.5, 175.0, 23.0 ],
 									"text" : "fluid.dataset~ dsq.help.join.A"
 								}
 
@@ -2981,7 +2917,7 @@
 									"numinlets" : 1,
 									"numoutlets" : 2,
 									"outlettype" : [ "", "" ],
-									"patching_rect" : [ 193.0, 281.5, 175.0, 23.0 ],
+									"patching_rect" : [ 233.0, 221.5, 175.0, 23.0 ],
 									"text" : "fluid.dataset~ dsq.help.join.B"
 								}
 
@@ -3559,7 +3495,7 @@
  ]
 									}
 ,
-									"patching_rect" : [ 10.0, 232.5, 80.0, 23.0 ],
+									"patching_rect" : [ 50.0, 172.5, 80.0, 23.0 ],
 									"saved_object_attributes" : 									{
 										"description" : "",
 										"digest" : "",
@@ -3583,7 +3519,7 @@
 									"mode" : 0,
 									"numinlets" : 1,
 									"numoutlets" : 0,
-									"patching_rect" : [ 410.0, 342.0, 480.0, 206.25 ],
+									"patching_rect" : [ 450.0, 282.0, 480.0, 206.25 ],
 									"proportion" : 0.5
 								}
 
@@ -3600,7 +3536,7 @@
 									"mode" : 0,
 									"numinlets" : 1,
 									"numoutlets" : 0,
-									"patching_rect" : [ 410.0, 190.0, 410.0, 150.0 ],
+									"patching_rect" : [ 450.0, 130.0, 410.0, 150.0 ],
 									"proportion" : 0.5
 								}
 
@@ -3616,7 +3552,7 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-23", 0 ],
-									"midpoints" : [ 509.5, 537.0, 428.5, 537.0 ],
+									"midpoints" : [ 549.5, 477.0, 468.5, 477.0 ],
 									"source" : [ "obj-21", 0 ]
 								}
 
@@ -3638,7 +3574,7 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-23", 0 ],
-									"midpoints" : [ 467.5, 537.0, 428.5, 537.0 ],
+									"midpoints" : [ 507.5, 477.0, 468.5, 477.0 ],
 									"source" : [ "obj-25", 0 ]
 								}
 
@@ -3646,7 +3582,7 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-23", 0 ],
-									"midpoints" : [ 428.5, 386.0, 428.5, 386.0 ],
+									"midpoints" : [ 468.5, 326.0, 468.5, 326.0 ],
 									"source" : [ "obj-32", 0 ]
 								}
 
@@ -3654,7 +3590,7 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-23", 0 ],
-									"midpoints" : [ 441.5, 402.25, 428.5, 402.25 ],
+									"midpoints" : [ 481.5, 342.25, 468.5, 342.25 ],
 									"source" : [ "obj-34", 0 ]
 								}
 
@@ -3662,7 +3598,7 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-9", 0 ],
-									"midpoints" : [ 175.5, 314.75, 19.5, 314.75 ],
+									"midpoints" : [ 215.5, 254.75, 59.5, 254.75 ],
 									"source" : [ "obj-40", 1 ]
 								}
 
@@ -3670,7 +3606,7 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-18", 0 ],
-									"midpoints" : [ 358.5, 314.75, 202.5, 314.75 ],
+									"midpoints" : [ 398.5, 254.75, 242.5, 254.75 ],
 									"source" : [ "obj-41", 1 ]
 								}
 
@@ -3685,7 +3621,7 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-40", 0 ],
-									"midpoints" : [ 19.5, 257.5, 19.5, 257.5 ],
+									"midpoints" : [ 59.5, 197.5, 59.5, 197.5 ],
 									"order" : 1,
 									"source" : [ "obj-8", 0 ]
 								}
@@ -3694,7 +3630,7 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-41", 0 ],
-									"midpoints" : [ 19.5, 266.5, 202.5, 266.5 ],
+									"midpoints" : [ 59.5, 206.5, 242.5, 206.5 ],
 									"order" : 0,
 									"source" : [ "obj-8", 0 ]
 								}
@@ -3790,7 +3726,7 @@
 						}
 ,
 						"classnamespace" : "box",
-						"rect" : [ 35.0, 114.0, 995.0, 751.0 ],
+						"rect" : [ 0.0, 26.0, 995.0, 751.0 ],
 						"bglocked" : 0,
 						"openinpresentation" : 0,
 						"default_fontsize" : 13.0,
@@ -3853,7 +3789,7 @@
 									"numoutlets" : 3,
 									"outlettype" : [ "", "", "int" ],
 									"parameter_enable" : 0,
-									"patching_rect" : [ 850.0, 426.5, 20.0, 20.0 ],
+									"patching_rect" : [ 890.0, 486.5, 20.0, 20.0 ],
 									"rounded" : 60.0,
 									"text" : "5",
 									"textcolor" : [ 0.34902, 0.34902, 0.34902, 1.0 ]
@@ -3873,7 +3809,7 @@
 									"numoutlets" : 3,
 									"outlettype" : [ "", "", "int" ],
 									"parameter_enable" : 0,
-									"patching_rect" : [ 832.5, 348.0, 20.0, 20.0 ],
+									"patching_rect" : [ 872.5, 408.0, 20.0, 20.0 ],
 									"rounded" : 60.0,
 									"text" : "4",
 									"textcolor" : [ 0.34902, 0.34902, 0.34902, 1.0 ]
@@ -3893,7 +3829,7 @@
 									"numoutlets" : 3,
 									"outlettype" : [ "", "", "int" ],
 									"parameter_enable" : 0,
-									"patching_rect" : [ 649.5, 256.5, 20.0, 20.0 ],
+									"patching_rect" : [ 689.5, 316.5, 20.0, 20.0 ],
 									"rounded" : 60.0,
 									"text" : "3",
 									"textcolor" : [ 0.34902, 0.34902, 0.34902, 1.0 ]
@@ -3913,7 +3849,7 @@
 									"numoutlets" : 3,
 									"outlettype" : [ "", "", "int" ],
 									"parameter_enable" : 0,
-									"patching_rect" : [ 620.0, 152.5, 20.0, 20.0 ],
+									"patching_rect" : [ 660.0, 212.5, 20.0, 20.0 ],
 									"rounded" : 60.0,
 									"text" : "2",
 									"textcolor" : [ 0.34902, 0.34902, 0.34902, 1.0 ]
@@ -4078,7 +4014,7 @@
  ]
 									}
 ,
-									"patching_rect" : [ 330.0, 500.0, 96.0, 23.0 ],
+									"patching_rect" : [ 370.0, 560.0, 96.0, 23.0 ],
 									"saved_object_attributes" : 									{
 										"description" : "",
 										"digest" : "",
@@ -4097,7 +4033,7 @@
 									"maxclass" : "comment",
 									"numinlets" : 1,
 									"numoutlets" : 0,
-									"patching_rect" : [ 440.5, 557.5, 207.0, 65.0 ],
+									"patching_rect" : [ 480.5, 617.5, 207.0, 65.0 ],
 									"text" : "The result is such that only the first column (0th) of each point is copied over if the value in this column is less than 0.5.",
 									"textcolor" : [ 0.129412, 0.129412, 0.129412, 0.5 ]
 								}
@@ -4111,7 +4047,7 @@
 									"maxclass" : "comment",
 									"numinlets" : 1,
 									"numoutlets" : 0,
-									"patching_rect" : [ 689.5, 416.5, 158.0, 40.0 ],
+									"patching_rect" : [ 729.5, 476.5, 158.0, 40.0 ],
 									"text" : "Composing the query as one message",
 									"textcolor" : [ 0.0, 0.0, 0.0, 1.0 ]
 								}
@@ -4124,7 +4060,7 @@
 									"maxclass" : "comment",
 									"numinlets" : 1,
 									"numoutlets" : 0,
-									"patching_rect" : [ 671.5, 234.0, 207.0, 65.0 ],
+									"patching_rect" : [ 711.5, 294.0, 207.0, 65.0 ],
 									"text" : "In effect, we are saying, for each point where the filter is satisfied copy THIS column to our destination.",
 									"textcolor" : [ 0.129412, 0.129412, 0.129412, 0.5 ]
 								}
@@ -4138,7 +4074,7 @@
 									"maxclass" : "comment",
 									"numinlets" : 1,
 									"numoutlets" : 0,
-									"patching_rect" : [ 635.0, 323.5, 197.0, 69.0 ],
+									"patching_rect" : [ 675.0, 383.5, 197.0, 69.0 ],
 									"text" : "Calling transform executes the query and copies the results from the source to the destination.",
 									"textcolor" : [ 0.0, 0.0, 0.0, 1.0 ]
 								}
@@ -4152,7 +4088,7 @@
 									"maxclass" : "comment",
 									"numinlets" : 1,
 									"numoutlets" : 0,
-									"patching_rect" : [ 456.0, 241.0, 191.5, 54.0 ],
+									"patching_rect" : [ 496.0, 301.0, 191.5, 54.0 ],
 									"text" : "Then we specify which columns we would like to copy if they satisfy the filter.",
 									"textcolor" : [ 0.0, 0.0, 0.0, 1.0 ]
 								}
@@ -4171,7 +4107,7 @@
 									"numoutlets" : 3,
 									"outlettype" : [ "", "", "int" ],
 									"parameter_enable" : 0,
-									"patching_rect" : [ 285.0, 150.0, 20.0, 20.0 ],
+									"patching_rect" : [ 325.0, 210.0, 20.0, 20.0 ],
 									"rounded" : 60.0,
 									"text" : "1",
 									"textcolor" : [ 0.34902, 0.34902, 0.34902, 1.0 ]
@@ -4185,7 +4121,7 @@
 									"maxclass" : "comment",
 									"numinlets" : 1,
 									"numoutlets" : 0,
-									"patching_rect" : [ 36.0, 150.0, 247.0, 25.0 ],
+									"patching_rect" : [ 76.0, 210.0, 247.0, 25.0 ],
 									"text" : "Generate some example data to query",
 									"textcolor" : [ 0.0, 0.0, 0.0, 1.0 ]
 								}
@@ -4199,7 +4135,7 @@
 									"numoutlets" : 1,
 									"outlettype" : [ "bang" ],
 									"parameter_enable" : 0,
-									"patching_rect" : [ 10.0, 150.0, 24.0, 24.0 ]
+									"patching_rect" : [ 50.0, 210.0, 24.0, 24.0 ]
 								}
 
 							}
@@ -4211,7 +4147,7 @@
 									"numinlets" : 2,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 456.0, 416.5, 224.0, 38.0 ],
+									"patching_rect" : [ 496.0, 476.5, 224.0, 38.0 ],
 									"text" : "clear, filter 1 < 3, addcolumn 1, transform dsq.help.src dsq.help.dest"
 								}
 
@@ -4222,7 +4158,7 @@
 									"maxclass" : "dict.view",
 									"numinlets" : 1,
 									"numoutlets" : 0,
-									"patching_rect" : [ 330.0, 540.0, 108.0, 100.0 ],
+									"patching_rect" : [ 370.0, 600.0, 108.0, 100.0 ],
 									"textcolor" : [ 0.995808, 0.800103, 0.399985, 1.0 ]
 								}
 
@@ -4233,7 +4169,7 @@
 									"maxclass" : "dict.view",
 									"numinlets" : 1,
 									"numoutlets" : 0,
-									"patching_rect" : [ 10.0, 307.5, 220.0, 129.5 ]
+									"patching_rect" : [ 50.0, 367.5, 220.0, 129.5 ]
 								}
 
 							}
@@ -4244,7 +4180,7 @@
 									"numinlets" : 2,
 									"numoutlets" : 2,
 									"outlettype" : [ "", "" ],
-									"patching_rect" : [ 10.0, 270.0, 74.0, 23.0 ],
+									"patching_rect" : [ 50.0, 330.0, 74.0, 23.0 ],
 									"text" : "route dump"
 								}
 
@@ -4256,7 +4192,7 @@
 									"numinlets" : 1,
 									"numoutlets" : 2,
 									"outlettype" : [ "", "" ],
-									"patching_rect" : [ 10.0, 230.0, 160.0, 23.0 ],
+									"patching_rect" : [ 50.0, 290.0, 160.0, 23.0 ],
 									"text" : "fluid.dataset~ dsq.help.src"
 								}
 
@@ -4654,7 +4590,7 @@
  ]
 									}
 ,
-									"patching_rect" : [ 10.0, 190.0, 80.0, 23.0 ],
+									"patching_rect" : [ 50.0, 250.0, 80.0, 23.0 ],
 									"saved_object_attributes" : 									{
 										"description" : "",
 										"digest" : "",
@@ -4672,7 +4608,7 @@
 									"maxclass" : "comment",
 									"numinlets" : 1,
 									"numoutlets" : 0,
-									"patching_rect" : [ 421.5, 371.5, 207.0, 21.0 ],
+									"patching_rect" : [ 461.5, 431.5, 207.0, 21.0 ],
 									"text" : "transform <source> <destination> ",
 									"textcolor" : [ 0.129412, 0.129412, 0.129412, 0.5 ]
 								}
@@ -4685,7 +4621,7 @@
 									"numinlets" : 2,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 409.5, 346.5, 218.0, 23.0 ],
+									"patching_rect" : [ 449.5, 406.5, 218.0, 23.0 ],
 									"text" : "transform dsq.help.src dsq.help.dest"
 								}
 
@@ -4697,7 +4633,7 @@
 									"numinlets" : 2,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 368.0, 256.5, 83.0, 23.0 ],
+									"patching_rect" : [ 408.0, 316.5, 83.0, 23.0 ],
 									"text" : "addcolumn 0"
 								}
 
@@ -4709,7 +4645,7 @@
 									"maxclass" : "comment",
 									"numinlets" : 1,
 									"numoutlets" : 0,
-									"patching_rect" : [ 642.0, 123.0, 253.0, 79.0 ],
+									"patching_rect" : [ 682.0, 183.0, 253.0, 79.0 ],
 									"text" : "filter <column index> <operator> <value> \n\nIn this case this says that we are only interested in points in the dataset where the first column is less than 3",
 									"textcolor" : [ 0.129412, 0.129412, 0.129412, 0.5 ]
 								}
@@ -4722,7 +4658,7 @@
 									"numinlets" : 2,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 330.0, 150.0, 66.0, 23.0 ],
+									"patching_rect" : [ 370.0, 210.0, 66.0, 23.0 ],
 									"text" : "filter 0 < 3"
 								}
 
@@ -4734,7 +4670,7 @@
 									"maxclass" : "comment",
 									"numinlets" : 1,
 									"numoutlets" : 0,
-									"patching_rect" : [ 400.0, 150.0, 212.0, 25.0 ],
+									"patching_rect" : [ 440.0, 210.0, 212.0, 25.0 ],
 									"text" : "Queries always start with a filter.",
 									"textcolor" : [ 0.0, 0.0, 0.0, 1.0 ]
 								}
@@ -4747,7 +4683,7 @@
 									"numinlets" : 1,
 									"numoutlets" : 2,
 									"outlettype" : [ "", "" ],
-									"patching_rect" : [ 330.0, 468.0, 121.0, 23.0 ],
+									"patching_rect" : [ 370.0, 528.0, 121.0, 23.0 ],
 									"text" : "fluid.datasetquery~"
 								}
 
@@ -4786,7 +4722,7 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-1", 0 ],
-									"midpoints" : [ 377.5, 373.25, 339.5, 373.25 ],
+									"midpoints" : [ 417.5, 433.25, 379.5, 433.25 ],
 									"source" : [ "obj-18", 0 ]
 								}
 
@@ -4794,7 +4730,7 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-1", 0 ],
-									"midpoints" : [ 419.0, 418.25, 339.5, 418.25 ],
+									"midpoints" : [ 459.0, 478.25, 379.5, 478.25 ],
 									"source" : [ "obj-22", 0 ]
 								}
 
@@ -4809,7 +4745,7 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-1", 0 ],
-									"midpoints" : [ 465.5, 460.75, 339.5, 460.75 ],
+									"midpoints" : [ 505.5, 520.75, 379.5, 520.75 ],
 									"source" : [ "obj-34", 0 ]
 								}
 
@@ -4817,7 +4753,7 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-9", 0 ],
-									"midpoints" : [ 160.5, 261.0, 19.5, 261.0 ],
+									"midpoints" : [ 200.5, 321.0, 59.5, 321.0 ],
 									"source" : [ "obj-40", 1 ]
 								}
 
@@ -4832,7 +4768,7 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-1", 0 ],
-									"midpoints" : [ 339.5, 320.0, 339.5, 320.0 ],
+									"midpoints" : [ 379.5, 380.0, 379.5, 380.0 ],
 									"source" : [ "obj-8", 0 ]
 								}
 

--- a/help/fluid.dataset~.maxhelp
+++ b/help/fluid.dataset~.maxhelp
@@ -10,7 +10,7 @@
 		}
 ,
 		"classnamespace" : "box",
-		"rect" : [ 34.0, 87.0, 1049.0, 779.0 ],
+		"rect" : [ 35.0, 88.0, 995.0, 777.0 ],
 		"bglocked" : 0,
 		"openinpresentation" : 0,
 		"default_fontsize" : 13.0,
@@ -57,7 +57,7 @@
 						}
 ,
 						"classnamespace" : "box",
-						"rect" : [ 0.0, 26.0, 1049.0, 753.0 ],
+						"rect" : [ 0.0, 26.0, 995.0, 751.0 ],
 						"bglocked" : 0,
 						"openinpresentation" : 0,
 						"default_fontsize" : 13.0,
@@ -236,7 +236,7 @@
 									"maxclass" : "comment",
 									"numinlets" : 1,
 									"numoutlets" : 0,
-									"patching_rect" : [ 615.0, 238.5, 170.0, 36.0 ],
+									"patching_rect" : [ 654.699999675154686, 238.5, 170.0, 36.0 ],
 									"text" : "Compure the stats across each spectral shape feature",
 									"textcolor" : [ 0.501960784313725, 0.501960784313725, 0.501960784313725, 1.0 ]
 								}
@@ -249,7 +249,7 @@
 									"maxclass" : "comment",
 									"numinlets" : 1,
 									"numoutlets" : 0,
-									"patching_rect" : [ 715.0, 188.5, 150.0, 36.0 ],
+									"patching_rect" : [ 755.0, 188.5, 150.0, 36.0 ],
 									"text" : "Analyse spectral shape features of the source",
 									"textcolor" : [ 0.501960784313725, 0.501960784313725, 0.501960784313725, 1.0 ]
 								}
@@ -309,7 +309,7 @@
 									"numinlets" : 1,
 									"numoutlets" : 2,
 									"outlettype" : [ "float", "bang" ],
-									"patching_rect" : [ 440.300000324845314, 245.0, 169.0, 23.0 ],
+									"patching_rect" : [ 480.0, 245.0, 169.0, 23.0 ],
 									"text" : "buffer~ help.ds.buffers.stats"
 								}
 
@@ -319,9 +319,9 @@
 									"color" : [ 1.0, 0.43921568627451, 0.662745098039216, 1.0 ],
 									"id" : "obj-9",
 									"maxclass" : "newobj",
-									"numinlets" : 1,
-									"numoutlets" : 3,
-									"outlettype" : [ "bang", "float", "" ],
+									"numinlets" : 2,
+									"numoutlets" : 2,
+									"outlettype" : [ "", "" ],
 									"patching_rect" : [ 20.0, 245.0, 448.0, 23.0 ],
 									"text" : "fluid.bufstats~ @source help.ds.buffers.features @stats help.ds.buffers.stats"
 								}
@@ -345,8 +345,8 @@
 									"id" : "obj-6",
 									"maxclass" : "newobj",
 									"numinlets" : 1,
-									"numoutlets" : 3,
-									"outlettype" : [ "bang", "float", "" ],
+									"numoutlets" : 2,
+									"outlettype" : [ "", "" ],
 									"patching_rect" : [ 20.0, 195.0, 533.0, 23.0 ],
 									"text" : "fluid.bufspectralshape~ @source help.ds.buffers.source @features help.ds.buffers.features"
 								}
@@ -372,7 +372,7 @@
 									"numinlets" : 1,
 									"numoutlets" : 2,
 									"outlettype" : [ "float", "bang" ],
-									"patching_rect" : [ 520.0, 195.0, 188.0, 23.0 ],
+									"patching_rect" : [ 560.0, 195.0, 188.0, 23.0 ],
 									"text" : "buffer~ help.ds.buffers.features"
 								}
 
@@ -382,8 +382,8 @@
 									"id" : "obj-1",
 									"maxclass" : "newobj",
 									"numinlets" : 1,
-									"numoutlets" : 3,
-									"outlettype" : [ "bang", "float", "" ],
+									"numoutlets" : 2,
+									"outlettype" : [ "", "" ],
 									"patching_rect" : [ 20.0, 415.0, 175.0, 23.0 ],
 									"text" : "fluid.dataset~ help.ds.buffers"
 								}
@@ -431,7 +431,7 @@
 								"patchline" : 								{
 									"destination" : [ "obj-16", 0 ],
 									"midpoints" : [ 185.5, 450.0, 29.5, 450.0 ],
-									"source" : [ "obj-1", 2 ]
+									"source" : [ "obj-1", 1 ]
 								}
 
 							}
@@ -496,13 +496,13 @@
 								"name" : "max6message",
 								"default" : 								{
 									"bgfillcolor" : 									{
-										"type" : "gradient",
+										"angle" : 270.0,
+										"autogradient" : 0,
+										"color" : [ 0.290196, 0.309804, 0.301961, 1.0 ],
 										"color1" : [ 0.866667, 0.866667, 0.866667, 1.0 ],
 										"color2" : [ 0.788235, 0.788235, 0.788235, 1.0 ],
-										"color" : [ 0.290196, 0.309804, 0.301961, 1.0 ],
-										"angle" : 270.0,
 										"proportion" : 0.39,
-										"autogradient" : 0
+										"type" : "gradient"
 									}
 ,
 									"textcolor_inverse" : [ 0.0, 0.0, 0.0, 1.0 ]
@@ -523,7 +523,7 @@
  ]
 					}
 ,
-					"patching_rect" : [ 151.0, 341.0, 137.0, 23.0 ],
+					"patching_rect" : [ 262.0, 367.0, 137.0, 23.0 ],
 					"saved_object_attributes" : 					{
 						"description" : "",
 						"digest" : "",
@@ -553,7 +553,7 @@
 						}
 ,
 						"classnamespace" : "box",
-						"rect" : [ 0.0, 26.0, 1049.0, 753.0 ],
+						"rect" : [ 0.0, 26.0, 995.0, 751.0 ],
 						"bglocked" : 0,
 						"openinpresentation" : 0,
 						"default_fontsize" : 13.0,
@@ -583,6 +583,1084 @@
 						"showontab" : 1,
 						"assistshowspatchername" : 0,
 						"boxes" : [ 							{
+								"box" : 								{
+									"id" : "obj-14",
+									"linecount" : 6,
+									"maxclass" : "comment",
+									"numinlets" : 1,
+									"numoutlets" : 0,
+									"patching_rect" : [ 700.0, 430.0, 150.0, 94.0 ],
+									"text" : "Notice after clicking merge that some new kills will appear in this dictionary (a representation of the dataset).",
+									"textcolor" : [ 0.501960784313725, 0.501960784313725, 0.501960784313725, 1.0 ]
+								}
+
+							}
+, 							{
+								"box" : 								{
+									"bgcolor" : [ 1.0, 0.788235, 0.470588, 1.0 ],
+									"fontname" : "Arial Bold",
+									"hint" : "",
+									"id" : "obj-12",
+									"ignoreclick" : 1,
+									"legacytextcolor" : 1,
+									"maxclass" : "textbutton",
+									"numinlets" : 1,
+									"numoutlets" : 3,
+									"outlettype" : [ "", "", "int" ],
+									"parameter_enable" : 0,
+									"patching_rect" : [ 890.0, 310.0, 20.0, 20.0 ],
+									"rounded" : 60.0,
+									"text" : "2",
+									"textcolor" : [ 0.34902, 0.34902, 0.34902, 1.0 ]
+								}
+
+							}
+, 							{
+								"box" : 								{
+									"bubble" : 1,
+									"id" : "obj-11",
+									"maxclass" : "comment",
+									"numinlets" : 1,
+									"numoutlets" : 0,
+									"patching_rect" : [ 80.0, 260.0, 213.0, 25.0 ],
+									"text" : "generate some random data first"
+								}
+
+							}
+, 							{
+								"box" : 								{
+									"id" : "obj-9",
+									"maxclass" : "button",
+									"numinlets" : 1,
+									"numoutlets" : 1,
+									"outlettype" : [ "bang" ],
+									"parameter_enable" : 0,
+									"patching_rect" : [ 50.0, 260.0, 24.0, 24.0 ]
+								}
+
+							}
+, 							{
+								"box" : 								{
+									"id" : "obj-15",
+									"maxclass" : "newobj",
+									"numinlets" : 1,
+									"numoutlets" : 1,
+									"outlettype" : [ "" ],
+									"patcher" : 									{
+										"fileversion" : 1,
+										"appversion" : 										{
+											"major" : 8,
+											"minor" : 3,
+											"revision" : 0,
+											"architecture" : "x64",
+											"modernui" : 1
+										}
+,
+										"classnamespace" : "box",
+										"rect" : [ 84.0, 131.0, 640.0, 480.0 ],
+										"bglocked" : 0,
+										"openinpresentation" : 0,
+										"default_fontsize" : 12.0,
+										"default_fontface" : 0,
+										"default_fontname" : "Arial",
+										"gridonopen" : 1,
+										"gridsize" : [ 15.0, 15.0 ],
+										"gridsnaponopen" : 1,
+										"objectsnaponopen" : 1,
+										"statusbarvisible" : 2,
+										"toolbarvisible" : 1,
+										"lefttoolbarpinned" : 0,
+										"toptoolbarpinned" : 0,
+										"righttoolbarpinned" : 0,
+										"bottomtoolbarpinned" : 0,
+										"toolbars_unpinned_last_save" : 0,
+										"tallnewobj" : 0,
+										"boxanimatetime" : 200,
+										"enablehscroll" : 1,
+										"enablevscroll" : 1,
+										"devicewidth" : 0.0,
+										"description" : "",
+										"digest" : "",
+										"tags" : "",
+										"style" : "",
+										"subpatcher_template" : "",
+										"assistshowspatchername" : 0,
+										"boxes" : [ 											{
+												"box" : 												{
+													"id" : "obj-20",
+													"maxclass" : "newobj",
+													"numinlets" : 1,
+													"numoutlets" : 1,
+													"outlettype" : [ "" ],
+													"patcher" : 													{
+														"fileversion" : 1,
+														"appversion" : 														{
+															"major" : 8,
+															"minor" : 3,
+															"revision" : 0,
+															"architecture" : "x64",
+															"modernui" : 1
+														}
+,
+														"classnamespace" : "box",
+														"rect" : [ 84.0, 131.0, 466.0, 372.0 ],
+														"bglocked" : 0,
+														"openinpresentation" : 0,
+														"default_fontsize" : 13.0,
+														"default_fontface" : 0,
+														"default_fontname" : "Arial",
+														"gridonopen" : 1,
+														"gridsize" : [ 10.0, 10.0 ],
+														"gridsnaponopen" : 1,
+														"objectsnaponopen" : 1,
+														"statusbarvisible" : 2,
+														"toolbarvisible" : 1,
+														"lefttoolbarpinned" : 0,
+														"toptoolbarpinned" : 0,
+														"righttoolbarpinned" : 0,
+														"bottomtoolbarpinned" : 0,
+														"toolbars_unpinned_last_save" : 0,
+														"tallnewobj" : 0,
+														"boxanimatetime" : 200,
+														"enablehscroll" : 1,
+														"enablevscroll" : 1,
+														"devicewidth" : 0.0,
+														"description" : "",
+														"digest" : "",
+														"tags" : "",
+														"style" : "",
+														"subpatcher_template" : "",
+														"assistshowspatchername" : 0,
+														"boxes" : [ 															{
+																"box" : 																{
+																	"comment" : "",
+																	"id" : "obj-1",
+																	"index" : 1,
+																	"maxclass" : "outlet",
+																	"numinlets" : 1,
+																	"numoutlets" : 0,
+																	"patching_rect" : [ 21.5, 253.0, 30.0, 30.0 ]
+																}
+
+															}
+, 															{
+																"box" : 																{
+																	"id" : "obj-14",
+																	"maxclass" : "newobj",
+																	"numinlets" : 2,
+																	"numoutlets" : 1,
+																	"outlettype" : [ "" ],
+																	"patching_rect" : [ 21.5, 217.0, 88.0, 23.0 ],
+																	"text" : "sprintf %s-%s"
+																}
+
+															}
+, 															{
+																"box" : 																{
+																	"id" : "obj-8",
+																	"maxclass" : "newobj",
+																	"numinlets" : 2,
+																	"numoutlets" : 2,
+																	"outlettype" : [ "", "" ],
+																	"patching_rect" : [ 21.5, 187.0, 55.0, 23.0 ],
+																	"text" : "zl group"
+																}
+
+															}
+, 															{
+																"box" : 																{
+																	"id" : "obj-7",
+																	"maxclass" : "newobj",
+																	"numinlets" : 2,
+																	"numoutlets" : 2,
+																	"outlettype" : [ "", "" ],
+																	"patching_rect" : [ 21.5, 152.0, 50.0, 23.0 ],
+																	"text" : "zl nth 1"
+																}
+
+															}
+, 															{
+																"box" : 																{
+																	"id" : "obj-6",
+																	"maxclass" : "newobj",
+																	"numinlets" : 2,
+																	"numoutlets" : 2,
+																	"outlettype" : [ "", "" ],
+																	"patching_rect" : [ 21.5, 122.0, 74.0, 23.0 ],
+																	"text" : "zl scramble"
+																}
+
+															}
+, 															{
+																"box" : 																{
+																	"id" : "obj-5",
+																	"maxclass" : "newobj",
+																	"numinlets" : 2,
+																	"numoutlets" : 3,
+																	"outlettype" : [ "bang", "bang", "int" ],
+																	"patching_rect" : [ 21.5, 57.0, 40.0, 23.0 ],
+																	"text" : "uzi 2"
+																}
+
+															}
+, 															{
+																"box" : 																{
+																	"id" : "obj-3",
+																	"maxclass" : "newobj",
+																	"numinlets" : 2,
+																	"numoutlets" : 2,
+																	"outlettype" : [ "", "" ],
+																	"patching_rect" : [ 21.5, 92.0, 191.0, 23.0 ],
+																	"text" : "zl reg pretty cat dog yellow blue"
+																}
+
+															}
+, 															{
+																"box" : 																{
+																	"comment" : "",
+																	"id" : "obj-15",
+																	"index" : 1,
+																	"maxclass" : "inlet",
+																	"numinlets" : 0,
+																	"numoutlets" : 1,
+																	"outlettype" : [ "bang" ],
+																	"patching_rect" : [ 21.5, 14.0, 30.0, 30.0 ]
+																}
+
+															}
+ ],
+														"lines" : [ 															{
+																"patchline" : 																{
+																	"destination" : [ "obj-1", 0 ],
+																	"source" : [ "obj-14", 0 ]
+																}
+
+															}
+, 															{
+																"patchline" : 																{
+																	"destination" : [ "obj-5", 0 ],
+																	"source" : [ "obj-15", 0 ]
+																}
+
+															}
+, 															{
+																"patchline" : 																{
+																	"destination" : [ "obj-6", 0 ],
+																	"source" : [ "obj-3", 0 ]
+																}
+
+															}
+, 															{
+																"patchline" : 																{
+																	"destination" : [ "obj-3", 0 ],
+																	"source" : [ "obj-5", 0 ]
+																}
+
+															}
+, 															{
+																"patchline" : 																{
+																	"destination" : [ "obj-8", 0 ],
+																	"midpoints" : [ 41.5, 80.0, 7.5, 80.0, 7.5, 182.0, 31.0, 182.0 ],
+																	"source" : [ "obj-5", 1 ]
+																}
+
+															}
+, 															{
+																"patchline" : 																{
+																	"destination" : [ "obj-7", 0 ],
+																	"source" : [ "obj-6", 0 ]
+																}
+
+															}
+, 															{
+																"patchline" : 																{
+																	"destination" : [ "obj-8", 0 ],
+																	"source" : [ "obj-7", 0 ]
+																}
+
+															}
+, 															{
+																"patchline" : 																{
+																	"destination" : [ "obj-14", 0 ],
+																	"source" : [ "obj-8", 0 ]
+																}
+
+															}
+ ]
+													}
+,
+													"patching_rect" : [ 105.5, 213.0, 102.0, 22.0 ],
+													"saved_object_attributes" : 													{
+														"description" : "",
+														"digest" : "",
+														"fontsize" : 13.0,
+														"globalpatchername" : "",
+														"tags" : ""
+													}
+,
+													"text" : "p semi-random-id"
+												}
+
+											}
+, 											{
+												"box" : 												{
+													"id" : "obj-24",
+													"maxclass" : "newobj",
+													"numinlets" : 1,
+													"numoutlets" : 2,
+													"outlettype" : [ "bang", "bang" ],
+													"patching_rect" : [ 105.5, 175.0, 138.5, 22.0 ],
+													"text" : "t b b"
+												}
+
+											}
+, 											{
+												"box" : 												{
+													"id" : "obj-25",
+													"maxclass" : "newobj",
+													"numinlets" : 2,
+													"numoutlets" : 1,
+													"outlettype" : [ "" ],
+													"patching_rect" : [ 105.5, 253.0, 79.0, 22.0 ],
+													"text" : "sprintf %s %f"
+												}
+
+											}
+, 											{
+												"box" : 												{
+													"id" : "obj-26",
+													"maxclass" : "newobj",
+													"numinlets" : 1,
+													"numoutlets" : 1,
+													"outlettype" : [ "" ],
+													"patching_rect" : [ 225.0, 213.0, 175.0, 22.0 ],
+													"text" : "expr random(-100\\, 100) / 1000."
+												}
+
+											}
+, 											{
+												"box" : 												{
+													"id" : "obj-27",
+													"maxclass" : "newobj",
+													"numinlets" : 2,
+													"numoutlets" : 3,
+													"outlettype" : [ "bang", "bang", "int" ],
+													"patching_rect" : [ 50.0, 135.0, 75.0, 22.0 ],
+													"text" : "uzi 30"
+												}
+
+											}
+, 											{
+												"box" : 												{
+													"id" : "obj-28",
+													"maxclass" : "newobj",
+													"numinlets" : 2,
+													"numoutlets" : 1,
+													"outlettype" : [ "dictionary" ],
+													"patching_rect" : [ 77.75, 333.0, 121.0, 22.0 ],
+													"text" : "dict.pack data: cols:1"
+												}
+
+											}
+, 											{
+												"box" : 												{
+													"id" : "obj-29",
+													"maxclass" : "newobj",
+													"numinlets" : 1,
+													"numoutlets" : 1,
+													"outlettype" : [ "dictionary" ],
+													"patching_rect" : [ 77.75, 294.0, 61.0, 22.0 ],
+													"text" : "dict.group"
+												}
+
+											}
+, 											{
+												"box" : 												{
+													"color" : [ 1.0, 0.392156862745098, 0.0, 1.0 ],
+													"id" : "obj-31",
+													"maxclass" : "newobj",
+													"numinlets" : 1,
+													"numoutlets" : 2,
+													"outlettype" : [ "", "" ],
+													"patching_rect" : [ 149.5, 135.0, 114.0, 22.0 ],
+													"text" : "fluid.dataset~ data2"
+												}
+
+											}
+, 											{
+												"box" : 												{
+													"id" : "obj-32",
+													"maxclass" : "newobj",
+													"numinlets" : 1,
+													"numoutlets" : 2,
+													"outlettype" : [ "bang", "clear" ],
+													"patching_rect" : [ 50.0, 100.0, 118.5, 22.0 ],
+													"text" : "t b clear"
+												}
+
+											}
+, 											{
+												"box" : 												{
+													"id" : "obj-33",
+													"maxclass" : "message",
+													"numinlets" : 2,
+													"numoutlets" : 1,
+													"outlettype" : [ "" ],
+													"patching_rect" : [ 77.75, 365.0, 139.0, 22.0 ],
+													"text" : "load dictionary $2, dump"
+												}
+
+											}
+, 											{
+												"box" : 												{
+													"comment" : "",
+													"id" : "obj-13",
+													"index" : 1,
+													"maxclass" : "inlet",
+													"numinlets" : 0,
+													"numoutlets" : 1,
+													"outlettype" : [ "bang" ],
+													"patching_rect" : [ 50.0, 40.0, 30.0, 30.0 ]
+												}
+
+											}
+, 											{
+												"box" : 												{
+													"comment" : "",
+													"id" : "obj-14",
+													"index" : 1,
+													"maxclass" : "outlet",
+													"numinlets" : 1,
+													"numoutlets" : 0,
+													"patching_rect" : [ 77.75, 413.0, 30.0, 30.0 ]
+												}
+
+											}
+ ],
+										"lines" : [ 											{
+												"patchline" : 												{
+													"destination" : [ "obj-32", 0 ],
+													"midpoints" : [ 59.5, 72.0, 59.5, 72.0 ],
+													"source" : [ "obj-13", 0 ]
+												}
+
+											}
+, 											{
+												"patchline" : 												{
+													"destination" : [ "obj-25", 0 ],
+													"midpoints" : [ 115.0, 237.0, 115.0, 237.0 ],
+													"source" : [ "obj-20", 0 ]
+												}
+
+											}
+, 											{
+												"patchline" : 												{
+													"destination" : [ "obj-20", 0 ],
+													"midpoints" : [ 115.0, 198.0, 115.0, 198.0 ],
+													"source" : [ "obj-24", 0 ]
+												}
+
+											}
+, 											{
+												"patchline" : 												{
+													"destination" : [ "obj-26", 0 ],
+													"midpoints" : [ 234.5, 198.0, 234.5, 198.0 ],
+													"source" : [ "obj-24", 1 ]
+												}
+
+											}
+, 											{
+												"patchline" : 												{
+													"destination" : [ "obj-29", 0 ],
+													"midpoints" : [ 115.0, 276.0, 87.25, 276.0 ],
+													"source" : [ "obj-25", 0 ]
+												}
+
+											}
+, 											{
+												"patchline" : 												{
+													"destination" : [ "obj-25", 1 ],
+													"midpoints" : [ 234.5, 249.0, 175.0, 249.0 ],
+													"source" : [ "obj-26", 0 ]
+												}
+
+											}
+, 											{
+												"patchline" : 												{
+													"destination" : [ "obj-24", 0 ],
+													"midpoints" : [ 115.5, 159.0, 115.0, 159.0 ],
+													"source" : [ "obj-27", 2 ]
+												}
+
+											}
+, 											{
+												"patchline" : 												{
+													"destination" : [ "obj-29", 0 ],
+													"midpoints" : [ 87.5, 159.0, 87.25, 159.0 ],
+													"source" : [ "obj-27", 1 ]
+												}
+
+											}
+, 											{
+												"patchline" : 												{
+													"destination" : [ "obj-33", 0 ],
+													"midpoints" : [ 87.25, 357.0, 87.25, 357.0 ],
+													"source" : [ "obj-28", 0 ]
+												}
+
+											}
+, 											{
+												"patchline" : 												{
+													"destination" : [ "obj-28", 0 ],
+													"midpoints" : [ 87.25, 318.0, 87.25, 318.0 ],
+													"source" : [ "obj-29", 0 ]
+												}
+
+											}
+, 											{
+												"patchline" : 												{
+													"destination" : [ "obj-27", 0 ],
+													"midpoints" : [ 59.5, 123.0, 59.5, 123.0 ],
+													"source" : [ "obj-32", 0 ]
+												}
+
+											}
+, 											{
+												"patchline" : 												{
+													"destination" : [ "obj-31", 0 ],
+													"midpoints" : [ 159.0, 123.0, 159.0, 123.0 ],
+													"source" : [ "obj-32", 1 ]
+												}
+
+											}
+, 											{
+												"patchline" : 												{
+													"destination" : [ "obj-14", 0 ],
+													"midpoints" : [ 87.25, 390.0, 87.25, 390.0 ],
+													"source" : [ "obj-33", 0 ]
+												}
+
+											}
+ ]
+									}
+,
+									"patching_rect" : [ 390.0, 310.0, 96.0, 23.0 ],
+									"saved_object_attributes" : 									{
+										"description" : "",
+										"digest" : "",
+										"globalpatchername" : "",
+										"tags" : ""
+									}
+,
+									"text" : "p random_data"
+								}
+
+							}
+, 							{
+								"box" : 								{
+									"id" : "obj-7",
+									"maxclass" : "newobj",
+									"numinlets" : 1,
+									"numoutlets" : 1,
+									"outlettype" : [ "" ],
+									"patcher" : 									{
+										"fileversion" : 1,
+										"appversion" : 										{
+											"major" : 8,
+											"minor" : 3,
+											"revision" : 0,
+											"architecture" : "x64",
+											"modernui" : 1
+										}
+,
+										"classnamespace" : "box",
+										"rect" : [ 84.0, 131.0, 640.0, 480.0 ],
+										"bglocked" : 0,
+										"openinpresentation" : 0,
+										"default_fontsize" : 12.0,
+										"default_fontface" : 0,
+										"default_fontname" : "Arial",
+										"gridonopen" : 1,
+										"gridsize" : [ 15.0, 15.0 ],
+										"gridsnaponopen" : 1,
+										"objectsnaponopen" : 1,
+										"statusbarvisible" : 2,
+										"toolbarvisible" : 1,
+										"lefttoolbarpinned" : 0,
+										"toptoolbarpinned" : 0,
+										"righttoolbarpinned" : 0,
+										"bottomtoolbarpinned" : 0,
+										"toolbars_unpinned_last_save" : 0,
+										"tallnewobj" : 0,
+										"boxanimatetime" : 200,
+										"enablehscroll" : 1,
+										"enablevscroll" : 1,
+										"devicewidth" : 0.0,
+										"description" : "",
+										"digest" : "",
+										"tags" : "",
+										"style" : "",
+										"subpatcher_template" : "",
+										"assistshowspatchername" : 0,
+										"boxes" : [ 											{
+												"box" : 												{
+													"id" : "obj-2",
+													"maxclass" : "message",
+													"numinlets" : 2,
+													"numoutlets" : 1,
+													"outlettype" : [ "" ],
+													"patching_rect" : [ 77.75, 339.0, 139.0, 22.0 ],
+													"text" : "load dictionary $2, dump"
+												}
+
+											}
+, 											{
+												"box" : 												{
+													"id" : "obj-16",
+													"maxclass" : "newobj",
+													"numinlets" : 1,
+													"numoutlets" : 1,
+													"outlettype" : [ "" ],
+													"patcher" : 													{
+														"fileversion" : 1,
+														"appversion" : 														{
+															"major" : 8,
+															"minor" : 3,
+															"revision" : 0,
+															"architecture" : "x64",
+															"modernui" : 1
+														}
+,
+														"classnamespace" : "box",
+														"rect" : [ 84.0, 131.0, 466.0, 372.0 ],
+														"bglocked" : 0,
+														"openinpresentation" : 0,
+														"default_fontsize" : 13.0,
+														"default_fontface" : 0,
+														"default_fontname" : "Arial",
+														"gridonopen" : 1,
+														"gridsize" : [ 10.0, 10.0 ],
+														"gridsnaponopen" : 1,
+														"objectsnaponopen" : 1,
+														"statusbarvisible" : 2,
+														"toolbarvisible" : 1,
+														"lefttoolbarpinned" : 0,
+														"toptoolbarpinned" : 0,
+														"righttoolbarpinned" : 0,
+														"bottomtoolbarpinned" : 0,
+														"toolbars_unpinned_last_save" : 0,
+														"tallnewobj" : 0,
+														"boxanimatetime" : 200,
+														"enablehscroll" : 1,
+														"enablevscroll" : 1,
+														"devicewidth" : 0.0,
+														"description" : "",
+														"digest" : "",
+														"tags" : "",
+														"style" : "",
+														"subpatcher_template" : "",
+														"assistshowspatchername" : 0,
+														"boxes" : [ 															{
+																"box" : 																{
+																	"comment" : "",
+																	"id" : "obj-1",
+																	"index" : 1,
+																	"maxclass" : "outlet",
+																	"numinlets" : 1,
+																	"numoutlets" : 0,
+																	"patching_rect" : [ 21.5, 253.0, 30.0, 30.0 ]
+																}
+
+															}
+, 															{
+																"box" : 																{
+																	"id" : "obj-14",
+																	"maxclass" : "newobj",
+																	"numinlets" : 2,
+																	"numoutlets" : 1,
+																	"outlettype" : [ "" ],
+																	"patching_rect" : [ 21.5, 217.0, 88.0, 23.0 ],
+																	"text" : "sprintf %s-%s"
+																}
+
+															}
+, 															{
+																"box" : 																{
+																	"id" : "obj-8",
+																	"maxclass" : "newobj",
+																	"numinlets" : 2,
+																	"numoutlets" : 2,
+																	"outlettype" : [ "", "" ],
+																	"patching_rect" : [ 21.5, 187.0, 55.0, 23.0 ],
+																	"text" : "zl group"
+																}
+
+															}
+, 															{
+																"box" : 																{
+																	"id" : "obj-7",
+																	"maxclass" : "newobj",
+																	"numinlets" : 2,
+																	"numoutlets" : 2,
+																	"outlettype" : [ "", "" ],
+																	"patching_rect" : [ 21.5, 152.0, 50.0, 23.0 ],
+																	"text" : "zl nth 1"
+																}
+
+															}
+, 															{
+																"box" : 																{
+																	"id" : "obj-6",
+																	"maxclass" : "newobj",
+																	"numinlets" : 2,
+																	"numoutlets" : 2,
+																	"outlettype" : [ "", "" ],
+																	"patching_rect" : [ 21.5, 122.0, 74.0, 23.0 ],
+																	"text" : "zl scramble"
+																}
+
+															}
+, 															{
+																"box" : 																{
+																	"id" : "obj-5",
+																	"maxclass" : "newobj",
+																	"numinlets" : 2,
+																	"numoutlets" : 3,
+																	"outlettype" : [ "bang", "bang", "int" ],
+																	"patching_rect" : [ 21.5, 57.0, 40.0, 23.0 ],
+																	"text" : "uzi 2"
+																}
+
+															}
+, 															{
+																"box" : 																{
+																	"id" : "obj-3",
+																	"maxclass" : "newobj",
+																	"numinlets" : 2,
+																	"numoutlets" : 2,
+																	"outlettype" : [ "", "" ],
+																	"patching_rect" : [ 21.5, 92.0, 191.0, 23.0 ],
+																	"text" : "zl reg pretty cat dog yellow blue"
+																}
+
+															}
+, 															{
+																"box" : 																{
+																	"comment" : "",
+																	"id" : "obj-15",
+																	"index" : 1,
+																	"maxclass" : "inlet",
+																	"numinlets" : 0,
+																	"numoutlets" : 1,
+																	"outlettype" : [ "bang" ],
+																	"patching_rect" : [ 21.5, 14.0, 30.0, 30.0 ]
+																}
+
+															}
+ ],
+														"lines" : [ 															{
+																"patchline" : 																{
+																	"destination" : [ "obj-1", 0 ],
+																	"source" : [ "obj-14", 0 ]
+																}
+
+															}
+, 															{
+																"patchline" : 																{
+																	"destination" : [ "obj-5", 0 ],
+																	"source" : [ "obj-15", 0 ]
+																}
+
+															}
+, 															{
+																"patchline" : 																{
+																	"destination" : [ "obj-6", 0 ],
+																	"source" : [ "obj-3", 0 ]
+																}
+
+															}
+, 															{
+																"patchline" : 																{
+																	"destination" : [ "obj-3", 0 ],
+																	"source" : [ "obj-5", 0 ]
+																}
+
+															}
+, 															{
+																"patchline" : 																{
+																	"destination" : [ "obj-8", 0 ],
+																	"midpoints" : [ 41.5, 80.0, 7.5, 80.0, 7.5, 182.0, 31.0, 182.0 ],
+																	"source" : [ "obj-5", 1 ]
+																}
+
+															}
+, 															{
+																"patchline" : 																{
+																	"destination" : [ "obj-7", 0 ],
+																	"source" : [ "obj-6", 0 ]
+																}
+
+															}
+, 															{
+																"patchline" : 																{
+																	"destination" : [ "obj-8", 0 ],
+																	"source" : [ "obj-7", 0 ]
+																}
+
+															}
+, 															{
+																"patchline" : 																{
+																	"destination" : [ "obj-14", 0 ],
+																	"source" : [ "obj-8", 0 ]
+																}
+
+															}
+ ]
+													}
+,
+													"patching_rect" : [ 105.5, 205.0, 102.0, 22.0 ],
+													"saved_object_attributes" : 													{
+														"description" : "",
+														"digest" : "",
+														"fontsize" : 13.0,
+														"globalpatchername" : "",
+														"tags" : ""
+													}
+,
+													"text" : "p semi-random-id"
+												}
+
+											}
+, 											{
+												"box" : 												{
+													"id" : "obj-103",
+													"maxclass" : "newobj",
+													"numinlets" : 1,
+													"numoutlets" : 2,
+													"outlettype" : [ "bang", "bang" ],
+													"patching_rect" : [ 105.5, 175.0, 133.5, 22.0 ],
+													"text" : "t b b"
+												}
+
+											}
+, 											{
+												"box" : 												{
+													"id" : "obj-102",
+													"maxclass" : "newobj",
+													"numinlets" : 2,
+													"numoutlets" : 1,
+													"outlettype" : [ "" ],
+													"patching_rect" : [ 105.5, 235.0, 133.5, 22.0 ],
+													"text" : "sprintf %s %i"
+												}
+
+											}
+, 											{
+												"box" : 												{
+													"id" : "obj-86",
+													"maxclass" : "newobj",
+													"numinlets" : 2,
+													"numoutlets" : 1,
+													"outlettype" : [ "int" ],
+													"patching_rect" : [ 220.0, 205.0, 78.0, 22.0 ],
+													"text" : "random 100"
+												}
+
+											}
+, 											{
+												"box" : 												{
+													"id" : "obj-74",
+													"maxclass" : "newobj",
+													"numinlets" : 2,
+													"numoutlets" : 3,
+													"outlettype" : [ "bang", "bang", "int" ],
+													"patching_rect" : [ 50.0, 135.0, 75.0, 22.0 ],
+													"text" : "uzi 30"
+												}
+
+											}
+, 											{
+												"box" : 												{
+													"id" : "obj-71",
+													"maxclass" : "newobj",
+													"numinlets" : 2,
+													"numoutlets" : 1,
+													"outlettype" : [ "dictionary" ],
+													"patching_rect" : [ 77.75, 300.0, 130.0, 22.0 ],
+													"text" : "dict.pack data: cols:1"
+												}
+
+											}
+, 											{
+												"box" : 												{
+													"id" : "obj-70",
+													"maxclass" : "newobj",
+													"numinlets" : 1,
+													"numoutlets" : 1,
+													"outlettype" : [ "dictionary" ],
+													"patching_rect" : [ 77.75, 270.0, 66.0, 22.0 ],
+													"text" : "dict.group"
+												}
+
+											}
+, 											{
+												"box" : 												{
+													"color" : [ 0.427450980392157, 0.843137254901961, 1.0, 1.0 ],
+													"id" : "obj-54",
+													"maxclass" : "newobj",
+													"numinlets" : 1,
+													"numoutlets" : 2,
+													"outlettype" : [ "", "" ],
+													"patching_rect" : [ 149.5, 135.0, 122.0, 22.0 ],
+													"text" : "fluid.dataset~ data1"
+												}
+
+											}
+, 											{
+												"box" : 												{
+													"id" : "obj-52",
+													"maxclass" : "newobj",
+													"numinlets" : 1,
+													"numoutlets" : 2,
+													"outlettype" : [ "bang", "clear" ],
+													"patching_rect" : [ 50.0, 100.0, 118.5, 22.0 ],
+													"text" : "t b clear"
+												}
+
+											}
+, 											{
+												"box" : 												{
+													"comment" : "",
+													"id" : "obj-5",
+													"index" : 1,
+													"maxclass" : "inlet",
+													"numinlets" : 0,
+													"numoutlets" : 1,
+													"outlettype" : [ "bang" ],
+													"patching_rect" : [ 50.0, 40.0, 30.0, 30.0 ]
+												}
+
+											}
+, 											{
+												"box" : 												{
+													"comment" : "",
+													"id" : "obj-6",
+													"index" : 1,
+													"maxclass" : "outlet",
+													"numinlets" : 1,
+													"numoutlets" : 0,
+													"patching_rect" : [ 77.75, 386.0, 30.0, 30.0 ]
+												}
+
+											}
+ ],
+										"lines" : [ 											{
+												"patchline" : 												{
+													"destination" : [ "obj-70", 0 ],
+													"source" : [ "obj-102", 0 ]
+												}
+
+											}
+, 											{
+												"patchline" : 												{
+													"destination" : [ "obj-16", 0 ],
+													"source" : [ "obj-103", 0 ]
+												}
+
+											}
+, 											{
+												"patchline" : 												{
+													"destination" : [ "obj-86", 0 ],
+													"source" : [ "obj-103", 1 ]
+												}
+
+											}
+, 											{
+												"patchline" : 												{
+													"destination" : [ "obj-102", 0 ],
+													"source" : [ "obj-16", 0 ]
+												}
+
+											}
+, 											{
+												"patchline" : 												{
+													"destination" : [ "obj-6", 0 ],
+													"source" : [ "obj-2", 0 ]
+												}
+
+											}
+, 											{
+												"patchline" : 												{
+													"destination" : [ "obj-52", 0 ],
+													"source" : [ "obj-5", 0 ]
+												}
+
+											}
+, 											{
+												"patchline" : 												{
+													"destination" : [ "obj-54", 0 ],
+													"source" : [ "obj-52", 1 ]
+												}
+
+											}
+, 											{
+												"patchline" : 												{
+													"destination" : [ "obj-74", 0 ],
+													"source" : [ "obj-52", 0 ]
+												}
+
+											}
+, 											{
+												"patchline" : 												{
+													"destination" : [ "obj-71", 0 ],
+													"source" : [ "obj-70", 0 ]
+												}
+
+											}
+, 											{
+												"patchline" : 												{
+													"destination" : [ "obj-2", 0 ],
+													"source" : [ "obj-71", 0 ]
+												}
+
+											}
+, 											{
+												"patchline" : 												{
+													"destination" : [ "obj-103", 0 ],
+													"source" : [ "obj-74", 2 ]
+												}
+
+											}
+, 											{
+												"patchline" : 												{
+													"destination" : [ "obj-70", 0 ],
+													"source" : [ "obj-74", 1 ]
+												}
+
+											}
+, 											{
+												"patchline" : 												{
+													"destination" : [ "obj-102", 1 ],
+													"source" : [ "obj-86", 0 ]
+												}
+
+											}
+ ]
+									}
+,
+									"patching_rect" : [ 50.0, 310.0, 96.0, 23.0 ],
+									"saved_object_attributes" : 									{
+										"description" : "",
+										"digest" : "",
+										"globalpatchername" : "",
+										"tags" : ""
+									}
+,
+									"text" : "p random_data"
+								}
+
+							}
+, 							{
 								"box" : 								{
 									"args" : [ "dataset" ],
 									"bgmode" : 0,
@@ -636,8 +1714,8 @@
 									"numinlets" : 2,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 565.0, 400.0, 81.0, 23.0 ],
-									"text" : "merge data1"
+									"patching_rect" : [ 505.0, 310.0, 121.0, 23.0 ],
+									"text" : "merge data1, dump"
 								}
 
 							}
@@ -654,7 +1732,7 @@
 									"numoutlets" : 3,
 									"outlettype" : [ "", "", "int" ],
 									"parameter_enable" : 0,
-									"patching_rect" : [ 912.0, 408.5, 20.0, 20.0 ],
+									"patching_rect" : [ 300.0, 262.5, 20.0, 20.0 ],
 									"rounded" : 60.0,
 									"text" : "1",
 									"textcolor" : [ 0.34902, 0.34902, 0.34902, 1.0 ]
@@ -665,234 +1743,12 @@
 								"box" : 								{
 									"bubble" : 1,
 									"id" : "obj-37",
-									"linecount" : 5,
+									"linecount" : 3,
 									"maxclass" : "comment",
 									"numinlets" : 1,
 									"numoutlets" : 0,
-									"patching_rect" : [ 650.0, 377.0, 260.0, 83.0 ],
-									"text" : "Merge the contents of fluid.dataset~ named \"data1\" into \"data2\". \"dump\" is automatically called after by routing the merge message from fluid.dataset~ demonstrating how the data changes."
-								}
-
-							}
-, 							{
-								"box" : 								{
-									"id" : "obj-20",
-									"maxclass" : "newobj",
-									"numinlets" : 1,
-									"numoutlets" : 1,
-									"outlettype" : [ "" ],
-									"patcher" : 									{
-										"fileversion" : 1,
-										"appversion" : 										{
-											"major" : 8,
-											"minor" : 3,
-											"revision" : 0,
-											"architecture" : "x64",
-											"modernui" : 1
-										}
-,
-										"classnamespace" : "box",
-										"rect" : [ 84.0, 131.0, 355.0, 297.0 ],
-										"bglocked" : 0,
-										"openinpresentation" : 0,
-										"default_fontsize" : 13.0,
-										"default_fontface" : 0,
-										"default_fontname" : "Arial",
-										"gridonopen" : 1,
-										"gridsize" : [ 10.0, 10.0 ],
-										"gridsnaponopen" : 1,
-										"objectsnaponopen" : 1,
-										"statusbarvisible" : 2,
-										"toolbarvisible" : 1,
-										"lefttoolbarpinned" : 0,
-										"toptoolbarpinned" : 0,
-										"righttoolbarpinned" : 0,
-										"bottomtoolbarpinned" : 0,
-										"toolbars_unpinned_last_save" : 0,
-										"tallnewobj" : 0,
-										"boxanimatetime" : 200,
-										"enablehscroll" : 1,
-										"enablevscroll" : 1,
-										"devicewidth" : 0.0,
-										"description" : "",
-										"digest" : "",
-										"tags" : "",
-										"style" : "",
-										"subpatcher_template" : "",
-										"assistshowspatchername" : 0,
-										"boxes" : [ 											{
-												"box" : 												{
-													"comment" : "",
-													"id" : "obj-1",
-													"index" : 1,
-													"maxclass" : "outlet",
-													"numinlets" : 1,
-													"numoutlets" : 0,
-													"patching_rect" : [ 21.5, 253.0, 30.0, 30.0 ]
-												}
-
-											}
-, 											{
-												"box" : 												{
-													"id" : "obj-14",
-													"linecount" : 2,
-													"maxclass" : "newobj",
-													"numinlets" : 3,
-													"numoutlets" : 1,
-													"outlettype" : [ "" ],
-													"patching_rect" : [ 21.5, 217.0, 103.0, 22.0 ],
-													"text" : "sprintf %s-%s-%s"
-												}
-
-											}
-, 											{
-												"box" : 												{
-													"id" : "obj-8",
-													"linecount" : 2,
-													"maxclass" : "newobj",
-													"numinlets" : 2,
-													"numoutlets" : 2,
-													"outlettype" : [ "", "" ],
-													"patching_rect" : [ 21.5, 187.0, 51.0, 22.0 ],
-													"text" : "zl group"
-												}
-
-											}
-, 											{
-												"box" : 												{
-													"id" : "obj-7",
-													"linecount" : 2,
-													"maxclass" : "newobj",
-													"numinlets" : 2,
-													"numoutlets" : 2,
-													"outlettype" : [ "", "" ],
-													"patching_rect" : [ 21.5, 152.0, 47.0, 22.0 ],
-													"text" : "zl nth 1"
-												}
-
-											}
-, 											{
-												"box" : 												{
-													"id" : "obj-6",
-													"linecount" : 2,
-													"maxclass" : "newobj",
-													"numinlets" : 2,
-													"numoutlets" : 2,
-													"outlettype" : [ "", "" ],
-													"patching_rect" : [ 21.5, 122.0, 69.0, 22.0 ],
-													"text" : "zl scramble"
-												}
-
-											}
-, 											{
-												"box" : 												{
-													"id" : "obj-5",
-													"maxclass" : "newobj",
-													"numinlets" : 2,
-													"numoutlets" : 3,
-													"outlettype" : [ "bang", "bang", "int" ],
-													"patching_rect" : [ 21.5, 57.0, 40.0, 22.0 ],
-													"text" : "uzi 3"
-												}
-
-											}
-, 											{
-												"box" : 												{
-													"id" : "obj-3",
-													"linecount" : 2,
-													"maxclass" : "newobj",
-													"numinlets" : 2,
-													"numoutlets" : 2,
-													"outlettype" : [ "", "" ],
-													"patching_rect" : [ 21.5, 92.0, 323.0, 22.0 ],
-													"text" : "zl reg pretty chill wind tree gas forest road car dog cat plate"
-												}
-
-											}
-, 											{
-												"box" : 												{
-													"comment" : "",
-													"id" : "obj-15",
-													"index" : 1,
-													"maxclass" : "inlet",
-													"numinlets" : 0,
-													"numoutlets" : 1,
-													"outlettype" : [ "bang" ],
-													"patching_rect" : [ 21.5, 14.0, 30.0, 30.0 ]
-												}
-
-											}
- ],
-										"lines" : [ 											{
-												"patchline" : 												{
-													"destination" : [ "obj-1", 0 ],
-													"source" : [ "obj-14", 0 ]
-												}
-
-											}
-, 											{
-												"patchline" : 												{
-													"destination" : [ "obj-5", 0 ],
-													"source" : [ "obj-15", 0 ]
-												}
-
-											}
-, 											{
-												"patchline" : 												{
-													"destination" : [ "obj-6", 0 ],
-													"source" : [ "obj-3", 0 ]
-												}
-
-											}
-, 											{
-												"patchline" : 												{
-													"destination" : [ "obj-3", 0 ],
-													"source" : [ "obj-5", 0 ]
-												}
-
-											}
-, 											{
-												"patchline" : 												{
-													"destination" : [ "obj-8", 0 ],
-													"midpoints" : [ 41.5, 80.0, 7.5, 80.0, 7.5, 182.0, 31.0, 182.0 ],
-													"source" : [ "obj-5", 1 ]
-												}
-
-											}
-, 											{
-												"patchline" : 												{
-													"destination" : [ "obj-7", 0 ],
-													"source" : [ "obj-6", 0 ]
-												}
-
-											}
-, 											{
-												"patchline" : 												{
-													"destination" : [ "obj-8", 0 ],
-													"source" : [ "obj-7", 0 ]
-												}
-
-											}
-, 											{
-												"patchline" : 												{
-													"destination" : [ "obj-14", 0 ],
-													"source" : [ "obj-8", 0 ]
-												}
-
-											}
- ]
-									}
-,
-									"patching_rect" : [ 455.5, 305.0, 110.0, 23.0 ],
-									"saved_object_attributes" : 									{
-										"description" : "",
-										"digest" : "",
-										"fontsize" : 13.0,
-										"globalpatchername" : "",
-										"tags" : ""
-									}
-,
-									"text" : "p semi-random-id"
+									"patching_rect" : [ 628.0, 294.5, 260.0, 54.0 ],
+									"text" : "Merge the contents of fluid.dataset~ named \"data1\" into \"data2\". \"dump\" is automatically called afterwards."
 								}
 
 							}
@@ -902,20 +1758,8 @@
 									"maxclass" : "dict.view",
 									"numinlets" : 1,
 									"numoutlets" : 0,
-									"patching_rect" : [ 598.75, 530.0, 196.25, 195.0 ],
+									"patching_rect" : [ 493.0, 428.0, 196.25, 195.0 ],
 									"stripecolor" : [ 1.0, 0.392156862745098, 0.0, 0.54 ]
-								}
-
-							}
-, 							{
-								"box" : 								{
-									"id" : "obj-22",
-									"maxclass" : "message",
-									"numinlets" : 2,
-									"numoutlets" : 1,
-									"outlettype" : [ "" ],
-									"patching_rect" : [ 522.75, 540.0, 41.0, 23.0 ],
-									"text" : "dump"
 								}
 
 							}
@@ -923,132 +1767,11 @@
 								"box" : 								{
 									"id" : "obj-23",
 									"maxclass" : "newobj",
-									"numinlets" : 4,
-									"numoutlets" : 4,
-									"outlettype" : [ "", "", "", "" ],
-									"patching_rect" : [ 522.75, 500.0, 143.0, 23.0 ],
-									"text" : "route load merge dump"
-								}
-
-							}
-, 							{
-								"box" : 								{
-									"id" : "obj-24",
-									"maxclass" : "newobj",
-									"numinlets" : 1,
+									"numinlets" : 2,
 									"numoutlets" : 2,
-									"outlettype" : [ "bang", "bang" ],
-									"patching_rect" : [ 455.5, 275.0, 123.0, 23.0 ],
-									"text" : "t b b"
-								}
-
-							}
-, 							{
-								"box" : 								{
-									"id" : "obj-25",
-									"maxclass" : "newobj",
-									"numinlets" : 2,
-									"numoutlets" : 1,
-									"outlettype" : [ "" ],
-									"patching_rect" : [ 455.5, 335.0, 123.0, 23.0 ],
-									"text" : "sprintf %s %i"
-								}
-
-							}
-, 							{
-								"box" : 								{
-									"id" : "obj-26",
-									"maxclass" : "newobj",
-									"numinlets" : 1,
-									"numoutlets" : 1,
-									"outlettype" : [ "" ],
-									"patching_rect" : [ 559.5, 305.0, 188.0, 23.0 ],
-									"text" : "expr random(-100\\, 100) / 1000."
-								}
-
-							}
-, 							{
-								"box" : 								{
-									"id" : "obj-27",
-									"maxclass" : "newobj",
-									"numinlets" : 2,
-									"numoutlets" : 3,
-									"outlettype" : [ "bang", "bang", "int" ],
-									"patching_rect" : [ 400.0, 235.0, 74.5, 23.0 ],
-									"text" : "uzi 10"
-								}
-
-							}
-, 							{
-								"box" : 								{
-									"id" : "obj-28",
-									"maxclass" : "newobj",
-									"numinlets" : 2,
-									"numoutlets" : 1,
-									"outlettype" : [ "dictionary" ],
-									"patching_rect" : [ 427.75, 400.0, 130.0, 23.0 ],
-									"text" : "dict.pack data: cols:1"
-								}
-
-							}
-, 							{
-								"box" : 								{
-									"id" : "obj-29",
-									"maxclass" : "newobj",
-									"numinlets" : 1,
-									"numoutlets" : 1,
-									"outlettype" : [ "dictionary" ],
-									"patching_rect" : [ 427.75, 370.0, 66.0, 23.0 ],
-									"text" : "dict.group"
-								}
-
-							}
-, 							{
-								"box" : 								{
-									"id" : "obj-30",
-									"maxclass" : "newobj",
-									"numinlets" : 1,
-									"numoutlets" : 1,
-									"outlettype" : [ "bang" ],
-									"patching_rect" : [ 400.0, 160.0, 62.0, 23.0 ],
-									"text" : "loadbang"
-								}
-
-							}
-, 							{
-								"box" : 								{
-									"color" : [ 1.0, 0.392156862745098, 0.0, 1.0 ],
-									"id" : "obj-31",
-									"maxclass" : "newobj",
-									"numinlets" : 1,
-									"numoutlets" : 3,
-									"outlettype" : [ "bang", "float", "" ],
-									"patching_rect" : [ 499.5, 235.0, 122.0, 23.0 ],
-									"text" : "fluid.dataset~ data2"
-								}
-
-							}
-, 							{
-								"box" : 								{
-									"id" : "obj-32",
-									"maxclass" : "newobj",
-									"numinlets" : 1,
-									"numoutlets" : 2,
-									"outlettype" : [ "bang", "clear" ],
-									"patching_rect" : [ 400.0, 200.0, 118.5, 23.0 ],
-									"text" : "t b clear"
-								}
-
-							}
-, 							{
-								"box" : 								{
-									"id" : "obj-33",
-									"maxclass" : "newobj",
-									"numinlets" : 1,
-									"numoutlets" : 1,
-									"outlettype" : [ "" ],
-									"patching_rect" : [ 427.75, 430.0, 84.0, 23.0 ],
-									"text" : "prepend load"
+									"outlettype" : [ "", "" ],
+									"patching_rect" : [ 493.0, 393.0, 74.0, 23.0 ],
+									"text" : "route dump"
 								}
 
 							}
@@ -1058,232 +1781,10 @@
 									"id" : "obj-34",
 									"maxclass" : "newobj",
 									"numinlets" : 1,
-									"numoutlets" : 3,
-									"outlettype" : [ "bang", "float", "" ],
-									"patching_rect" : [ 427.75, 467.0, 122.0, 23.0 ],
+									"numoutlets" : 2,
+									"outlettype" : [ "", "" ],
+									"patching_rect" : [ 390.0, 360.0, 122.0, 23.0 ],
 									"text" : "fluid.dataset~ data2"
-								}
-
-							}
-, 							{
-								"box" : 								{
-									"id" : "obj-16",
-									"maxclass" : "newobj",
-									"numinlets" : 1,
-									"numoutlets" : 1,
-									"outlettype" : [ "" ],
-									"patcher" : 									{
-										"fileversion" : 1,
-										"appversion" : 										{
-											"major" : 8,
-											"minor" : 3,
-											"revision" : 0,
-											"architecture" : "x64",
-											"modernui" : 1
-										}
-,
-										"classnamespace" : "box",
-										"rect" : [ 84.0, 131.0, 355.0, 297.0 ],
-										"bglocked" : 0,
-										"openinpresentation" : 0,
-										"default_fontsize" : 13.0,
-										"default_fontface" : 0,
-										"default_fontname" : "Arial",
-										"gridonopen" : 1,
-										"gridsize" : [ 10.0, 10.0 ],
-										"gridsnaponopen" : 1,
-										"objectsnaponopen" : 1,
-										"statusbarvisible" : 2,
-										"toolbarvisible" : 1,
-										"lefttoolbarpinned" : 0,
-										"toptoolbarpinned" : 0,
-										"righttoolbarpinned" : 0,
-										"bottomtoolbarpinned" : 0,
-										"toolbars_unpinned_last_save" : 0,
-										"tallnewobj" : 0,
-										"boxanimatetime" : 200,
-										"enablehscroll" : 1,
-										"enablevscroll" : 1,
-										"devicewidth" : 0.0,
-										"description" : "",
-										"digest" : "",
-										"tags" : "",
-										"style" : "",
-										"subpatcher_template" : "",
-										"assistshowspatchername" : 0,
-										"boxes" : [ 											{
-												"box" : 												{
-													"comment" : "",
-													"id" : "obj-1",
-													"index" : 1,
-													"maxclass" : "outlet",
-													"numinlets" : 1,
-													"numoutlets" : 0,
-													"patching_rect" : [ 21.5, 253.0, 30.0, 30.0 ]
-												}
-
-											}
-, 											{
-												"box" : 												{
-													"id" : "obj-14",
-													"linecount" : 2,
-													"maxclass" : "newobj",
-													"numinlets" : 3,
-													"numoutlets" : 1,
-													"outlettype" : [ "" ],
-													"patching_rect" : [ 21.5, 217.0, 103.0, 22.0 ],
-													"text" : "sprintf %s-%s-%s"
-												}
-
-											}
-, 											{
-												"box" : 												{
-													"id" : "obj-8",
-													"linecount" : 2,
-													"maxclass" : "newobj",
-													"numinlets" : 2,
-													"numoutlets" : 2,
-													"outlettype" : [ "", "" ],
-													"patching_rect" : [ 21.5, 187.0, 51.0, 22.0 ],
-													"text" : "zl group"
-												}
-
-											}
-, 											{
-												"box" : 												{
-													"id" : "obj-7",
-													"linecount" : 2,
-													"maxclass" : "newobj",
-													"numinlets" : 2,
-													"numoutlets" : 2,
-													"outlettype" : [ "", "" ],
-													"patching_rect" : [ 21.5, 152.0, 47.0, 22.0 ],
-													"text" : "zl nth 1"
-												}
-
-											}
-, 											{
-												"box" : 												{
-													"id" : "obj-6",
-													"linecount" : 2,
-													"maxclass" : "newobj",
-													"numinlets" : 2,
-													"numoutlets" : 2,
-													"outlettype" : [ "", "" ],
-													"patching_rect" : [ 21.5, 122.0, 69.0, 22.0 ],
-													"text" : "zl scramble"
-												}
-
-											}
-, 											{
-												"box" : 												{
-													"id" : "obj-5",
-													"maxclass" : "newobj",
-													"numinlets" : 2,
-													"numoutlets" : 3,
-													"outlettype" : [ "bang", "bang", "int" ],
-													"patching_rect" : [ 21.5, 57.0, 40.0, 22.0 ],
-													"text" : "uzi 3"
-												}
-
-											}
-, 											{
-												"box" : 												{
-													"id" : "obj-3",
-													"linecount" : 2,
-													"maxclass" : "newobj",
-													"numinlets" : 2,
-													"numoutlets" : 2,
-													"outlettype" : [ "", "" ],
-													"patching_rect" : [ 21.5, 92.0, 323.0, 22.0 ],
-													"text" : "zl reg pretty chill wind tree gas forest road car dog cat plate"
-												}
-
-											}
-, 											{
-												"box" : 												{
-													"comment" : "",
-													"id" : "obj-15",
-													"index" : 1,
-													"maxclass" : "inlet",
-													"numinlets" : 0,
-													"numoutlets" : 1,
-													"outlettype" : [ "bang" ],
-													"patching_rect" : [ 21.5, 14.0, 30.0, 30.0 ]
-												}
-
-											}
- ],
-										"lines" : [ 											{
-												"patchline" : 												{
-													"destination" : [ "obj-1", 0 ],
-													"source" : [ "obj-14", 0 ]
-												}
-
-											}
-, 											{
-												"patchline" : 												{
-													"destination" : [ "obj-5", 0 ],
-													"source" : [ "obj-15", 0 ]
-												}
-
-											}
-, 											{
-												"patchline" : 												{
-													"destination" : [ "obj-6", 0 ],
-													"source" : [ "obj-3", 0 ]
-												}
-
-											}
-, 											{
-												"patchline" : 												{
-													"destination" : [ "obj-3", 0 ],
-													"source" : [ "obj-5", 0 ]
-												}
-
-											}
-, 											{
-												"patchline" : 												{
-													"destination" : [ "obj-8", 0 ],
-													"midpoints" : [ 41.5, 80.0, 7.5, 80.0, 7.5, 182.0, 31.0, 182.0 ],
-													"source" : [ "obj-5", 1 ]
-												}
-
-											}
-, 											{
-												"patchline" : 												{
-													"destination" : [ "obj-7", 0 ],
-													"source" : [ "obj-6", 0 ]
-												}
-
-											}
-, 											{
-												"patchline" : 												{
-													"destination" : [ "obj-8", 0 ],
-													"source" : [ "obj-7", 0 ]
-												}
-
-											}
-, 											{
-												"patchline" : 												{
-													"destination" : [ "obj-14", 0 ],
-													"source" : [ "obj-8", 0 ]
-												}
-
-											}
- ]
-									}
-,
-									"patching_rect" : [ 60.5, 305.0, 110.0, 23.0 ],
-									"saved_object_attributes" : 									{
-										"description" : "",
-										"digest" : "",
-										"fontsize" : 13.0,
-										"globalpatchername" : "",
-										"tags" : ""
-									}
-,
-									"text" : "p semi-random-id"
 								}
 
 							}
@@ -1293,20 +1794,8 @@
 									"maxclass" : "dict.view",
 									"numinlets" : 1,
 									"numoutlets" : 0,
-									"patching_rect" : [ 185.125, 535.0, 195.875, 190.0 ],
+									"patching_rect" : [ 153.0, 428.0, 195.875, 190.0 ],
 									"stripecolor" : [ 0.427450980392157, 0.843137254901961, 1.0, 0.45 ]
-								}
-
-							}
-, 							{
-								"box" : 								{
-									"id" : "obj-107",
-									"maxclass" : "message",
-									"numinlets" : 2,
-									"numoutlets" : 1,
-									"outlettype" : [ "" ],
-									"patching_rect" : [ 127.75, 535.0, 41.0, 23.0 ],
-									"text" : "dump"
 								}
 
 							}
@@ -1314,145 +1803,24 @@
 								"box" : 								{
 									"id" : "obj-104",
 									"maxclass" : "newobj",
-									"numinlets" : 3,
-									"numoutlets" : 3,
-									"outlettype" : [ "", "", "" ],
-									"patching_rect" : [ 127.75, 500.0, 133.75, 23.0 ],
-									"text" : "route load dump"
-								}
-
-							}
-, 							{
-								"box" : 								{
-									"id" : "obj-103",
-									"maxclass" : "newobj",
-									"numinlets" : 1,
+									"numinlets" : 2,
 									"numoutlets" : 2,
-									"outlettype" : [ "bang", "bang" ],
-									"patching_rect" : [ 60.5, 275.0, 123.0, 23.0 ],
-									"text" : "t b b"
-								}
-
-							}
-, 							{
-								"box" : 								{
-									"id" : "obj-102",
-									"maxclass" : "newobj",
-									"numinlets" : 2,
-									"numoutlets" : 1,
-									"outlettype" : [ "" ],
-									"patching_rect" : [ 60.5, 335.0, 123.0, 23.0 ],
-									"text" : "sprintf %s %i"
-								}
-
-							}
-, 							{
-								"box" : 								{
-									"id" : "obj-86",
-									"maxclass" : "newobj",
-									"numinlets" : 2,
-									"numoutlets" : 1,
-									"outlettype" : [ "int" ],
-									"patching_rect" : [ 164.5, 305.0, 78.0, 23.0 ],
-									"text" : "random 100"
-								}
-
-							}
-, 							{
-								"box" : 								{
-									"id" : "obj-74",
-									"maxclass" : "newobj",
-									"numinlets" : 2,
-									"numoutlets" : 3,
-									"outlettype" : [ "bang", "bang", "int" ],
-									"patching_rect" : [ 5.0, 235.0, 74.5, 23.0 ],
-									"text" : "uzi 10"
-								}
-
-							}
-, 							{
-								"box" : 								{
-									"id" : "obj-71",
-									"maxclass" : "newobj",
-									"numinlets" : 2,
-									"numoutlets" : 1,
-									"outlettype" : [ "dictionary" ],
-									"patching_rect" : [ 32.75, 400.0, 130.0, 23.0 ],
-									"text" : "dict.pack data: cols:1"
-								}
-
-							}
-, 							{
-								"box" : 								{
-									"id" : "obj-70",
-									"maxclass" : "newobj",
-									"numinlets" : 1,
-									"numoutlets" : 1,
-									"outlettype" : [ "dictionary" ],
-									"patching_rect" : [ 32.75, 370.0, 66.0, 23.0 ],
-									"text" : "dict.group"
-								}
-
-							}
-, 							{
-								"box" : 								{
-									"id" : "obj-56",
-									"maxclass" : "newobj",
-									"numinlets" : 1,
-									"numoutlets" : 1,
-									"outlettype" : [ "bang" ],
-									"patching_rect" : [ 5.0, 160.0, 62.0, 23.0 ],
-									"text" : "loadbang"
-								}
-
-							}
-, 							{
-								"box" : 								{
-									"color" : [ 0.427450980392157, 0.843137254901961, 1.0, 1.0 ],
-									"id" : "obj-54",
-									"maxclass" : "newobj",
-									"numinlets" : 1,
-									"numoutlets" : 3,
-									"outlettype" : [ "bang", "float", "" ],
-									"patching_rect" : [ 104.5, 235.0, 122.0, 23.0 ],
-									"text" : "fluid.dataset~ data1"
-								}
-
-							}
-, 							{
-								"box" : 								{
-									"id" : "obj-52",
-									"maxclass" : "newobj",
-									"numinlets" : 1,
-									"numoutlets" : 2,
-									"outlettype" : [ "bang", "clear" ],
-									"patching_rect" : [ 5.0, 200.0, 118.5, 23.0 ],
-									"text" : "t b clear"
+									"outlettype" : [ "", "" ],
+									"patching_rect" : [ 153.0, 393.0, 74.0, 23.0 ],
+									"text" : "route dump"
 								}
 
 							}
 , 							{
 								"box" : 								{
 									"id" : "obj-4",
-									"linecount" : 6,
+									"linecount" : 3,
 									"maxclass" : "comment",
 									"numinlets" : 1,
 									"numoutlets" : 0,
-									"patching_rect" : [ 630.0, 122.0, 380.0, 94.0 ],
-									"text" : "It is possible to merge the contents of one fluid.dataset~ with another. This process will overwrite the points where an identifier (key) is the same. For example if you merge \"dataset1\" with \"dataset2\" and they both share the \"numbers\" identifier, the value found in dataset1 will overwrite the value found in dataset2.",
+									"patching_rect" : [ 50.0, 150.0, 580.0, 50.0 ],
+									"text" : "You can merge the points in one dataset with another. If the dataset you call merge on already has a key existing in the dataset you want to merge, the caller's will be preserved. Any keys not found in the dataset to merge will be added to the caller.",
 									"textcolor" : [ 0.501960784313725, 0.501960784313725, 0.501960784313725, 1.0 ]
-								}
-
-							}
-, 							{
-								"box" : 								{
-									"id" : "obj-43",
-									"maxclass" : "newobj",
-									"numinlets" : 1,
-									"numoutlets" : 1,
-									"outlettype" : [ "" ],
-									"patching_rect" : [ 32.75, 430.0, 84.0, 23.0 ],
-									"text" : "prepend load"
 								}
 
 							}
@@ -1462,9 +1830,9 @@
 									"id" : "obj-1",
 									"maxclass" : "newobj",
 									"numinlets" : 1,
-									"numoutlets" : 3,
-									"outlettype" : [ "bang", "float", "" ],
-									"patching_rect" : [ 32.75, 467.0, 122.0, 23.0 ],
+									"numoutlets" : 2,
+									"outlettype" : [ "", "" ],
+									"patching_rect" : [ 50.0, 360.0, 122.0, 23.0 ],
 									"text" : "fluid.dataset~ data1"
 								}
 
@@ -1473,256 +1841,68 @@
 						"lines" : [ 							{
 								"patchline" : 								{
 									"destination" : [ "obj-104", 0 ],
-									"source" : [ "obj-1", 2 ]
-								}
-
-							}
-, 							{
-								"patchline" : 								{
-									"destination" : [ "obj-70", 0 ],
-									"source" : [ "obj-102", 0 ]
-								}
-
-							}
-, 							{
-								"patchline" : 								{
-									"destination" : [ "obj-16", 0 ],
-									"source" : [ "obj-103", 0 ]
-								}
-
-							}
-, 							{
-								"patchline" : 								{
-									"destination" : [ "obj-86", 0 ],
-									"source" : [ "obj-103", 1 ]
-								}
-
-							}
-, 							{
-								"patchline" : 								{
-									"destination" : [ "obj-107", 0 ],
-									"source" : [ "obj-104", 0 ]
+									"source" : [ "obj-1", 1 ]
 								}
 
 							}
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-108", 0 ],
-									"source" : [ "obj-104", 1 ]
-								}
-
-							}
-, 							{
-								"patchline" : 								{
-									"destination" : [ "obj-1", 0 ],
-									"midpoints" : [ 137.25, 560.0, 18.0, 560.0, 18.0, 461.0, 42.25, 461.0 ],
-									"source" : [ "obj-107", 0 ]
-								}
-
-							}
-, 							{
-								"patchline" : 								{
-									"destination" : [ "obj-102", 0 ],
-									"source" : [ "obj-16", 0 ]
-								}
-
-							}
-, 							{
-								"patchline" : 								{
-									"destination" : [ "obj-25", 0 ],
-									"source" : [ "obj-20", 0 ]
+									"source" : [ "obj-104", 0 ]
 								}
 
 							}
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-34", 0 ],
-									"midpoints" : [ 532.25, 563.0, 414.0, 563.0, 414.0, 461.0, 437.25, 461.0 ],
-									"source" : [ "obj-22", 0 ]
+									"source" : [ "obj-15", 0 ]
 								}
 
 							}
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-21", 0 ],
-									"source" : [ "obj-23", 2 ]
-								}
-
-							}
-, 							{
-								"patchline" : 								{
-									"destination" : [ "obj-22", 0 ],
-									"source" : [ "obj-23", 1 ]
-								}
-
-							}
-, 							{
-								"patchline" : 								{
-									"destination" : [ "obj-22", 0 ],
 									"source" : [ "obj-23", 0 ]
 								}
 
 							}
 , 							{
 								"patchline" : 								{
-									"destination" : [ "obj-20", 0 ],
-									"source" : [ "obj-24", 0 ]
-								}
-
-							}
-, 							{
-								"patchline" : 								{
-									"destination" : [ "obj-26", 0 ],
-									"source" : [ "obj-24", 1 ]
-								}
-
-							}
-, 							{
-								"patchline" : 								{
-									"destination" : [ "obj-29", 0 ],
-									"source" : [ "obj-25", 0 ]
-								}
-
-							}
-, 							{
-								"patchline" : 								{
-									"destination" : [ "obj-25", 1 ],
-									"source" : [ "obj-26", 0 ]
-								}
-
-							}
-, 							{
-								"patchline" : 								{
-									"destination" : [ "obj-24", 0 ],
-									"source" : [ "obj-27", 2 ]
-								}
-
-							}
-, 							{
-								"patchline" : 								{
-									"destination" : [ "obj-29", 0 ],
-									"source" : [ "obj-27", 1 ]
-								}
-
-							}
-, 							{
-								"patchline" : 								{
-									"destination" : [ "obj-33", 0 ],
-									"source" : [ "obj-28", 0 ]
-								}
-
-							}
-, 							{
-								"patchline" : 								{
-									"destination" : [ "obj-28", 0 ],
-									"source" : [ "obj-29", 0 ]
-								}
-
-							}
-, 							{
-								"patchline" : 								{
-									"destination" : [ "obj-32", 0 ],
-									"source" : [ "obj-30", 0 ]
-								}
-
-							}
-, 							{
-								"patchline" : 								{
-									"destination" : [ "obj-27", 0 ],
-									"source" : [ "obj-32", 0 ]
-								}
-
-							}
-, 							{
-								"patchline" : 								{
-									"destination" : [ "obj-31", 0 ],
-									"source" : [ "obj-32", 1 ]
-								}
-
-							}
-, 							{
-								"patchline" : 								{
-									"destination" : [ "obj-34", 0 ],
-									"midpoints" : [ 437.25, 455.0, 437.25, 455.0 ],
-									"source" : [ "obj-33", 0 ]
-								}
-
-							}
-, 							{
-								"patchline" : 								{
 									"destination" : [ "obj-23", 0 ],
-									"source" : [ "obj-34", 2 ]
-								}
-
-							}
-, 							{
-								"patchline" : 								{
-									"destination" : [ "obj-1", 0 ],
-									"source" : [ "obj-43", 0 ]
+									"source" : [ "obj-34", 1 ]
 								}
 
 							}
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-34", 0 ],
-									"midpoints" : [ 574.5, 460.0, 437.25, 460.0 ],
+									"midpoints" : [ 514.5, 353.0, 399.5, 353.0 ],
 									"source" : [ "obj-44", 0 ]
 								}
 
 							}
 , 							{
 								"patchline" : 								{
-									"destination" : [ "obj-54", 0 ],
-									"source" : [ "obj-52", 1 ]
+									"destination" : [ "obj-1", 0 ],
+									"source" : [ "obj-7", 0 ]
 								}
 
 							}
 , 							{
 								"patchline" : 								{
-									"destination" : [ "obj-74", 0 ],
-									"source" : [ "obj-52", 0 ]
+									"destination" : [ "obj-15", 0 ],
+									"midpoints" : [ 59.5, 297.0, 399.5, 297.0 ],
+									"order" : 0,
+									"source" : [ "obj-9", 0 ]
 								}
 
 							}
 , 							{
 								"patchline" : 								{
-									"destination" : [ "obj-52", 0 ],
-									"source" : [ "obj-56", 0 ]
-								}
-
-							}
-, 							{
-								"patchline" : 								{
-									"destination" : [ "obj-71", 0 ],
-									"source" : [ "obj-70", 0 ]
-								}
-
-							}
-, 							{
-								"patchline" : 								{
-									"destination" : [ "obj-43", 0 ],
-									"source" : [ "obj-71", 0 ]
-								}
-
-							}
-, 							{
-								"patchline" : 								{
-									"destination" : [ "obj-103", 0 ],
-									"source" : [ "obj-74", 2 ]
-								}
-
-							}
-, 							{
-								"patchline" : 								{
-									"destination" : [ "obj-70", 0 ],
-									"source" : [ "obj-74", 1 ]
-								}
-
-							}
-, 							{
-								"patchline" : 								{
-									"destination" : [ "obj-102", 1 ],
-									"source" : [ "obj-86", 0 ]
+									"destination" : [ "obj-7", 0 ],
+									"midpoints" : [ 59.5, 285.0, 59.5, 285.0 ],
+									"order" : 1,
+									"source" : [ "obj-9", 0 ]
 								}
 
 							}
@@ -1751,13 +1931,13 @@
 								"name" : "max6message",
 								"default" : 								{
 									"bgfillcolor" : 									{
-										"type" : "gradient",
+										"angle" : 270.0,
+										"autogradient" : 0,
+										"color" : [ 0.290196, 0.309804, 0.301961, 1.0 ],
 										"color1" : [ 0.866667, 0.866667, 0.866667, 1.0 ],
 										"color2" : [ 0.788235, 0.788235, 0.788235, 1.0 ],
-										"color" : [ 0.290196, 0.309804, 0.301961, 1.0 ],
-										"angle" : 270.0,
 										"proportion" : 0.39,
-										"autogradient" : 0
+										"type" : "gradient"
 									}
 ,
 									"textcolor_inverse" : [ 0.0, 0.0, 0.0, 1.0 ]
@@ -1778,7 +1958,7 @@
  ]
 					}
 ,
-					"patching_rect" : [ 123.031982421875, 300.0, 66.0, 23.0 ],
+					"patching_rect" : [ 234.031982421875, 326.0, 66.0, 23.0 ],
 					"saved_object_attributes" : 					{
 						"description" : "",
 						"digest" : "",
@@ -1808,7 +1988,7 @@
 						}
 ,
 						"classnamespace" : "box",
-						"rect" : [ 0.0, 26.0, 1049.0, 753.0 ],
+						"rect" : [ 0.0, 26.0, 995.0, 751.0 ],
 						"bglocked" : 0,
 						"openinpresentation" : 0,
 						"default_fontsize" : 13.0,
@@ -1909,7 +2089,7 @@
 									"numoutlets" : 3,
 									"outlettype" : [ "", "", "int" ],
 									"parameter_enable" : 0,
-									"patching_rect" : [ 490.5, 566.5, 20.0, 20.0 ],
+									"patching_rect" : [ 174.5, 571.5, 20.0, 20.0 ],
 									"rounded" : 60.0,
 									"text" : "2",
 									"textcolor" : [ 0.34902, 0.34902, 0.34902, 1.0 ]
@@ -1924,7 +2104,7 @@
 									"maxclass" : "comment",
 									"numinlets" : 1,
 									"numoutlets" : 0,
-									"patching_rect" : [ 516.0, 553.5, 356.0, 54.0 ],
+									"patching_rect" : [ 200.0, 558.5, 356.0, 54.0 ],
 									"text" : "Open the max console to see the data that was generated and stored in the dataset with the identity \"scratch-synth\"",
 									"textcolor" : [ 0.0, 0.0, 0.0, 1.0 ]
 								}
@@ -1947,7 +2127,7 @@
 									"maxclass" : "newobj",
 									"numinlets" : 1,
 									"numoutlets" : 0,
-									"patching_rect" : [ 331.0, 565.0, 156.0, 23.0 ],
+									"patching_rect" : [ 15.0, 570.0, 156.0, 23.0 ],
 									"text" : "print \"fluid.dataset~ help:\""
 								}
 
@@ -1988,26 +2168,13 @@
 , 							{
 								"box" : 								{
 									"color" : [ 0.0, 0.854901960784314, 0.282352941176471, 1.0 ],
-									"id" : "obj-32",
-									"maxclass" : "newobj",
-									"numinlets" : 1,
-									"numoutlets" : 2,
-									"outlettype" : [ "float", "bang" ],
-									"patching_rect" : [ 520.0, 525.0, 110.0, 23.0 ],
-									"text" : "buffer~ retrieval 1"
-								}
-
-							}
-, 							{
-								"box" : 								{
-									"color" : [ 0.0, 0.854901960784314, 0.282352941176471, 1.0 ],
 									"id" : "obj-28",
 									"maxclass" : "newobj",
 									"numinlets" : 2,
 									"numoutlets" : 1,
 									"outlettype" : [ "list" ],
-									"patching_rect" : [ 331.0, 525.0, 183.0, 23.0 ],
-									"text" : "fluid.buf2list @source retrieval"
+									"patching_rect" : [ 15.0, 530.0, 77.0, 23.0 ],
+									"text" : "fluid.buf2list"
 								}
 
 							}
@@ -2018,8 +2185,8 @@
 									"numinlets" : 2,
 									"numoutlets" : 2,
 									"outlettype" : [ "", "" ],
-									"patching_rect" : [ 331.0, 490.0, 88.0, 23.0 ],
-									"text" : "route getpoint"
+									"patching_rect" : [ 15.0, 495.0, 151.0, 23.0 ],
+									"text" : "substitute getpoint buffer"
 								}
 
 							}
@@ -2030,8 +2197,8 @@
 									"numinlets" : 2,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 173.0, 420.0, 186.0, 23.0 ],
-									"text" : "getpoint scratch-synth retrieval"
+									"patching_rect" : [ 15.0, 425.0, 238.0, 23.0 ],
+									"text" : "getpoint scratch-synth features.stats.flat"
 								}
 
 							}
@@ -2040,9 +2207,9 @@
 									"id" : "obj-24",
 									"maxclass" : "newobj",
 									"numinlets" : 1,
-									"numoutlets" : 3,
-									"outlettype" : [ "bang", "float", "" ],
-									"patching_rect" : [ 173.0, 455.0, 177.0, 23.0 ],
+									"numoutlets" : 2,
+									"outlettype" : [ "", "" ],
+									"patching_rect" : [ 15.0, 460.0, 177.0, 23.0 ],
 									"text" : "fluid.dataset~ sound-analysis"
 								}
 
@@ -2054,7 +2221,7 @@
 									"numinlets" : 2,
 									"numoutlets" : 2,
 									"outlettype" : [ "", "" ],
-									"patching_rect" : [ 173.0, 385.0, 87.0, 23.0 ],
+									"patching_rect" : [ 15.0, 390.0, 87.0, 23.0 ],
 									"text" : "route setpoint"
 								}
 
@@ -2064,8 +2231,8 @@
 									"id" : "obj-21",
 									"maxclass" : "newobj",
 									"numinlets" : 1,
-									"numoutlets" : 3,
-									"outlettype" : [ "bang", "float", "" ],
+									"numoutlets" : 2,
+									"outlettype" : [ "", "" ],
 									"patching_rect" : [ 15.0, 350.0, 177.0, 23.0 ],
 									"text" : "fluid.dataset~ sound-analysis"
 								}
@@ -2126,8 +2293,8 @@
 									"id" : "obj-10",
 									"maxclass" : "newobj",
 									"numinlets" : 1,
-									"numoutlets" : 3,
-									"outlettype" : [ "bang", "float", "" ],
+									"numoutlets" : 2,
+									"outlettype" : [ "", "" ],
 									"patching_rect" : [ 15.0, 265.0, 417.0, 23.0 ],
 									"text" : "fluid.bufflatten~ @source features.stats @destination features.stats.flat"
 								}
@@ -2151,9 +2318,9 @@
 									"color" : [ 1.0, 0.694117647058824, 0.0, 1.0 ],
 									"id" : "obj-8",
 									"maxclass" : "newobj",
-									"numinlets" : 1,
-									"numoutlets" : 3,
-									"outlettype" : [ "bang", "float", "" ],
+									"numinlets" : 2,
+									"numoutlets" : 2,
+									"outlettype" : [ "", "" ],
 									"patching_rect" : [ 15.0, 225.0, 409.0, 23.0 ],
 									"text" : "fluid.bufstats~ @source features @stats features.stats @numderivs 0"
 								}
@@ -2178,8 +2345,8 @@
 									"id" : "obj-6",
 									"maxclass" : "newobj",
 									"numinlets" : 1,
-									"numoutlets" : 3,
-									"outlettype" : [ "bang", "float", "" ],
+									"numoutlets" : 2,
+									"outlettype" : [ "", "" ],
 									"patching_rect" : [ 15.0, 185.0, 298.0, 23.0 ],
 									"text" : "fluid.bufmfcc~ 13 @source src @features features"
 								}
@@ -2239,7 +2406,7 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-22", 0 ],
-									"source" : [ "obj-21", 2 ]
+									"source" : [ "obj-21", 0 ]
 								}
 
 							}
@@ -2253,7 +2420,7 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-27", 0 ],
-									"source" : [ "obj-24", 2 ]
+									"source" : [ "obj-24", 0 ]
 								}
 
 							}
@@ -2317,13 +2484,13 @@
 								"name" : "max6message",
 								"default" : 								{
 									"bgfillcolor" : 									{
-										"type" : "gradient",
+										"angle" : 270.0,
+										"autogradient" : 0,
+										"color" : [ 0.290196, 0.309804, 0.301961, 1.0 ],
 										"color1" : [ 0.866667, 0.866667, 0.866667, 1.0 ],
 										"color2" : [ 0.788235, 0.788235, 0.788235, 1.0 ],
-										"color" : [ 0.290196, 0.309804, 0.301961, 1.0 ],
-										"angle" : 270.0,
 										"proportion" : 0.39,
-										"autogradient" : 0
+										"type" : "gradient"
 									}
 ,
 									"textcolor_inverse" : [ 0.0, 0.0, 0.0, 1.0 ]
@@ -2344,7 +2511,7 @@
  ]
 					}
 ,
-					"patching_rect" : [ 26.0, 129.0, 175.0, 23.0 ],
+					"patching_rect" : [ 137.0, 155.0, 175.0, 23.0 ],
 					"saved_object_attributes" : 					{
 						"description" : "",
 						"digest" : "",
@@ -2375,7 +2542,7 @@
 						}
 ,
 						"classnamespace" : "box",
-						"rect" : [ 0.0, 26.0, 1049.0, 753.0 ],
+						"rect" : [ 0.0, 26.0, 995.0, 751.0 ],
 						"bglocked" : 0,
 						"openinpresentation" : 0,
 						"default_fontsize" : 13.0,
@@ -2471,7 +2638,7 @@
 										}
 ,
 										"classnamespace" : "box",
-										"rect" : [ 59.0, 106.0, 316.0, 411.0 ],
+										"rect" : [ 59.0, 106.0, 414.0, 473.0 ],
 										"bglocked" : 0,
 										"openinpresentation" : 0,
 										"default_fontsize" : 13.0,
@@ -2502,12 +2669,11 @@
 										"boxes" : [ 											{
 												"box" : 												{
 													"id" : "obj-3",
-													"linecount" : 2,
 													"maxclass" : "newobj",
 													"numinlets" : 1,
 													"numoutlets" : 2,
 													"outlettype" : [ "dump", "bang" ],
-													"patching_rect" : [ 39.75, 194.0, 55.0, 22.0 ],
+													"patching_rect" : [ 27.5, 216.0, 59.0, 23.0 ],
 													"text" : "t dump b"
 												}
 
@@ -2520,7 +2686,7 @@
 													"maxclass" : "outlet",
 													"numinlets" : 1,
 													"numoutlets" : 0,
-													"patching_rect" : [ 75.75, 353.0, 30.0, 30.0 ]
+													"patching_rect" : [ 63.5, 375.0, 30.0, 30.0 ]
 												}
 
 											}
@@ -2544,7 +2710,7 @@
 													"numinlets" : 1,
 													"numoutlets" : 2,
 													"outlettype" : [ "int", "bang" ],
-													"patching_rect" : [ 113.25, 134.0, 116.5, 22.0 ],
+													"patching_rect" : [ 100.5, 134.0, 29.5, 23.0 ],
 													"text" : "t i b"
 												}
 
@@ -2556,7 +2722,7 @@
 													"numinlets" : 2,
 													"numoutlets" : 1,
 													"outlettype" : [ "" ],
-													"patching_rect" : [ 112.75, 194.0, 117.0, 22.0 ],
+													"patching_rect" : [ 100.5, 216.0, 117.0, 23.0 ],
 													"text" : "sprintf entry-%i: %i"
 												}
 
@@ -2568,7 +2734,7 @@
 													"numinlets" : 2,
 													"numoutlets" : 1,
 													"outlettype" : [ "int" ],
-													"patching_rect" : [ 210.75, 165.0, 78.0, 22.0 ],
+													"patching_rect" : [ 198.5, 184.0, 78.0, 23.0 ],
 													"text" : "random 100"
 												}
 
@@ -2580,7 +2746,7 @@
 													"numinlets" : 2,
 													"numoutlets" : 3,
 													"outlettype" : [ "bang", "bang", "int" ],
-													"patching_rect" : [ 12.0, 99.0, 74.5, 22.0 ],
+													"patching_rect" : [ 12.0, 99.0, 50.0, 23.0 ],
 													"text" : "uzi 100"
 												}
 
@@ -2592,7 +2758,7 @@
 													"numinlets" : 2,
 													"numoutlets" : 1,
 													"outlettype" : [ "dictionary" ],
-													"patching_rect" : [ 75.75, 275.0, 130.0, 22.0 ],
+													"patching_rect" : [ 63.5, 297.0, 130.0, 23.0 ],
 													"text" : "dict.pack data: cols:1"
 												}
 
@@ -2604,7 +2770,7 @@
 													"numinlets" : 1,
 													"numoutlets" : 1,
 													"outlettype" : [ "dictionary" ],
-													"patching_rect" : [ 75.75, 245.0, 66.0, 22.0 ],
+													"patching_rect" : [ 63.5, 267.0, 66.0, 23.0 ],
 													"text" : "dict.group"
 												}
 
@@ -2612,12 +2778,11 @@
 , 											{
 												"box" : 												{
 													"id" : "obj-54",
-													"linecount" : 2,
 													"maxclass" : "newobj",
 													"numinlets" : 1,
-													"numoutlets" : 3,
-													"outlettype" : [ "bang", "float", "" ],
-													"patching_rect" : [ 111.5, 99.0, 137.0, 22.0 ],
+													"numoutlets" : 2,
+													"outlettype" : [ "", "" ],
+													"patching_rect" : [ 111.5, 99.0, 148.0, 23.0 ],
 													"text" : "fluid.dataset~ help.other"
 												}
 
@@ -2629,7 +2794,7 @@
 													"numinlets" : 1,
 													"numoutlets" : 2,
 													"outlettype" : [ "bang", "clear" ],
-													"patching_rect" : [ 12.0, 64.0, 118.5, 22.0 ],
+													"patching_rect" : [ 12.0, 64.0, 118.5, 23.0 ],
 													"text" : "t b clear"
 												}
 
@@ -2641,7 +2806,7 @@
 													"numinlets" : 1,
 													"numoutlets" : 1,
 													"outlettype" : [ "" ],
-													"patching_rect" : [ 75.75, 310.0, 84.0, 22.0 ],
+													"patching_rect" : [ 63.5, 332.0, 84.0, 23.0 ],
 													"text" : "prepend load"
 												}
 
@@ -2657,7 +2822,7 @@
 , 											{
 												"patchline" : 												{
 													"destination" : [ "obj-70", 0 ],
-													"midpoints" : [ 122.25, 230.0, 85.25, 230.0 ],
+													"midpoints" : [ 110.0, 252.0, 73.0, 252.0 ],
 													"source" : [ "obj-102", 0 ]
 												}
 
@@ -2665,6 +2830,7 @@
 , 											{
 												"patchline" : 												{
 													"destination" : [ "obj-102", 0 ],
+													"midpoints" : [ 110.0, 159.0, 110.0, 159.0 ],
 													"source" : [ "obj-103", 0 ]
 												}
 
@@ -2672,6 +2838,7 @@
 , 											{
 												"patchline" : 												{
 													"destination" : [ "obj-86", 0 ],
+													"midpoints" : [ 120.5, 171.0, 208.0, 171.0 ],
 													"source" : [ "obj-103", 1 ]
 												}
 
@@ -2679,7 +2846,7 @@
 , 											{
 												"patchline" : 												{
 													"destination" : [ "obj-2", 0 ],
-													"midpoints" : [ 49.25, 347.0, 85.25, 347.0 ],
+													"midpoints" : [ 37.0, 369.0, 73.0, 369.0 ],
 													"source" : [ "obj-3", 0 ]
 												}
 
@@ -2687,7 +2854,7 @@
 , 											{
 												"patchline" : 												{
 													"destination" : [ "obj-70", 0 ],
-													"midpoints" : [ 85.25, 218.0, 85.25, 218.0 ],
+													"midpoints" : [ 77.0, 240.0, 73.0, 240.0 ],
 													"source" : [ "obj-3", 1 ]
 												}
 
@@ -2730,7 +2897,7 @@
 , 											{
 												"patchline" : 												{
 													"destination" : [ "obj-103", 0 ],
-													"midpoints" : [ 77.0, 131.0, 122.75, 131.0 ],
+													"midpoints" : [ 52.5, 131.0, 110.0, 131.0 ],
 													"source" : [ "obj-74", 2 ]
 												}
 
@@ -2767,13 +2934,13 @@
 							}
 , 							{
 								"box" : 								{
-									"bubble" : 1,
 									"id" : "obj-27",
 									"maxclass" : "comment",
 									"numinlets" : 1,
 									"numoutlets" : 0,
-									"patching_rect" : [ 219.0, 365.0, 365.0, 25.0 ],
-									"text" : "Dump the contents of the fluid.dataset~ to a Max dictionary"
+									"patching_rect" : [ 183.0, 351.0, 365.0, 21.0 ],
+									"text" : "Dump the contents of the fluid.dataset~ to a Max dictionary",
+									"textcolor" : [ 0.501960784313725, 0.501960784313725, 0.501960784313725, 1.0 ]
 								}
 
 							}
@@ -2784,28 +2951,8 @@
 									"numinlets" : 2,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 154.0, 365.0, 41.0, 23.0 ],
+									"patching_rect" : [ 140.0, 350.0, 41.0, 23.0 ],
 									"text" : "dump"
-								}
-
-							}
-, 							{
-								"box" : 								{
-									"bgcolor" : [ 0.968627450980392, 0.431372549019608, 0.431372549019608, 1.0 ],
-									"fontname" : "Arial Bold",
-									"hint" : "",
-									"id" : "obj-29",
-									"ignoreclick" : 1,
-									"legacytextcolor" : 1,
-									"maxclass" : "textbutton",
-									"numinlets" : 1,
-									"numoutlets" : 3,
-									"outlettype" : [ "", "", "int" ],
-									"parameter_enable" : 0,
-									"patching_rect" : [ 219.0, 411.5, 20.0, 20.0 ],
-									"rounded" : 60.0,
-									"text" : "6",
-									"textcolor" : [ 0.929411764705882, 0.941176470588235, 0.956862745098039, 1.0 ]
 								}
 
 							}
@@ -2815,20 +2962,20 @@
 									"maxclass" : "dict.view",
 									"numinlets" : 1,
 									"numoutlets" : 0,
-									"patching_rect" : [ 144.0, 560.0, 241.0, 160.0 ]
+									"patching_rect" : [ 144.0, 545.0, 241.0, 160.0 ]
 								}
 
 							}
 , 							{
 								"box" : 								{
-									"bubble" : 1,
 									"id" : "obj-22",
 									"linecount" : 2,
 									"maxclass" : "comment",
 									"numinlets" : 1,
 									"numoutlets" : 0,
-									"patching_rect" : [ 186.5, 311.5, 557.0, 40.0 ],
-									"text" : "Get the number of columns, or dimensions of the data points. Since all points must have the same number of dimensions, this is just a single number. It is reported out the right outlet."
+									"patching_rect" : [ 154.0, 310.0, 557.0, 36.0 ],
+									"text" : "Get the number of columns, or dimensions of the data points. Since all points must have the same number of dimensions, this is just a single number. It is reported out the right outlet.",
+									"textcolor" : [ 0.501960784313725, 0.501960784313725, 0.501960784313725, 1.0 ]
 								}
 
 							}
@@ -2839,28 +2986,8 @@
 									"numinlets" : 2,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 130.0, 320.0, 32.0, 23.0 ],
+									"patching_rect" : [ 120.0, 310.0, 32.0, 23.0 ],
 									"text" : "cols"
-								}
-
-							}
-, 							{
-								"box" : 								{
-									"bgcolor" : [ 0.968627450980392, 0.431372549019608, 0.431372549019608, 1.0 ],
-									"fontname" : "Arial Bold",
-									"hint" : "",
-									"id" : "obj-24",
-									"ignoreclick" : 1,
-									"legacytextcolor" : 1,
-									"maxclass" : "textbutton",
-									"numinlets" : 1,
-									"numoutlets" : 3,
-									"outlettype" : [ "", "", "int" ],
-									"parameter_enable" : 0,
-									"patching_rect" : [ 197.0, 365.0, 20.0, 20.0 ],
-									"rounded" : 60.0,
-									"text" : "5",
-									"textcolor" : [ 0.929411764705882, 0.941176470588235, 0.956862745098039, 1.0 ]
 								}
 
 							}
@@ -2870,7 +2997,7 @@
 									"maxclass" : "newobj",
 									"numinlets" : 1,
 									"numoutlets" : 0,
-									"patching_rect" : [ 390.0, 560.0, 98.0, 23.0 ],
+									"patching_rect" : [ 390.0, 545.0, 98.0, 23.0 ],
 									"text" : "print @popup 1"
 								}
 
@@ -2882,20 +3009,20 @@
 									"numinlets" : 2,
 									"numoutlets" : 2,
 									"outlettype" : [ "", "" ],
-									"patching_rect" : [ 144.0, 515.0, 74.0, 23.0 ],
+									"patching_rect" : [ 144.0, 500.0, 74.0, 23.0 ],
 									"text" : "route dump"
 								}
 
 							}
 , 							{
 								"box" : 								{
-									"bubble" : 1,
 									"id" : "obj-13",
 									"maxclass" : "comment",
 									"numinlets" : 1,
 									"numoutlets" : 0,
-									"patching_rect" : [ 160.0, 271.5, 630.0, 25.0 ],
-									"text" : "Get the size (the number of <identifier> <data> pairs in the dataset), which is reported out the right outlet."
+									"patching_rect" : [ 134.0, 271.0, 630.0, 21.0 ],
+									"text" : "Get the size (the number of <identifier> <data> pairs in the dataset), which is reported out the right outlet.",
+									"textcolor" : [ 0.501960784313725, 0.501960784313725, 0.501960784313725, 1.0 ]
 								}
 
 							}
@@ -2913,33 +3040,13 @@
 							}
 , 							{
 								"box" : 								{
-									"bgcolor" : [ 0.968627450980392, 0.431372549019608, 0.431372549019608, 1.0 ],
-									"fontname" : "Arial Bold",
-									"hint" : "",
-									"id" : "obj-15",
-									"ignoreclick" : 1,
-									"legacytextcolor" : 1,
-									"maxclass" : "textbutton",
-									"numinlets" : 1,
-									"numoutlets" : 3,
-									"outlettype" : [ "", "", "int" ],
-									"parameter_enable" : 0,
-									"patching_rect" : [ 164.5, 321.5, 20.0, 20.0 ],
-									"rounded" : 60.0,
-									"text" : "4",
-									"textcolor" : [ 0.929411764705882, 0.941176470588235, 0.956862745098039, 1.0 ]
-								}
-
-							}
-, 							{
-								"box" : 								{
-									"bubble" : 1,
 									"id" : "obj-10",
 									"maxclass" : "comment",
 									"numinlets" : 1,
 									"numoutlets" : 0,
-									"patching_rect" : [ 137.5, 231.5, 205.0, 25.0 ],
-									"text" : "Read a fluid.dataset~ from disk"
+									"patching_rect" : [ 113.0, 231.0, 205.0, 21.0 ],
+									"text" : "Read a fluid.dataset~ from disk",
+									"textcolor" : [ 0.501960784313725, 0.501960784313725, 0.501960784313725, 1.0 ]
 								}
 
 							}
@@ -2957,33 +3064,13 @@
 							}
 , 							{
 								"box" : 								{
-									"bgcolor" : [ 0.968627450980392, 0.431372549019608, 0.431372549019608, 1.0 ],
-									"fontname" : "Arial Bold",
-									"hint" : "",
-									"id" : "obj-12",
-									"ignoreclick" : 1,
-									"legacytextcolor" : 1,
-									"maxclass" : "textbutton",
-									"numinlets" : 1,
-									"numoutlets" : 3,
-									"outlettype" : [ "", "", "int" ],
-									"parameter_enable" : 0,
-									"patching_rect" : [ 136.0, 271.5, 20.0, 20.0 ],
-									"rounded" : 60.0,
-									"text" : "3",
-									"textcolor" : [ 0.929411764705882, 0.941176470588235, 0.956862745098039, 1.0 ]
-								}
-
-							}
-, 							{
-								"box" : 								{
-									"bubble" : 1,
 									"id" : "obj-7",
 									"maxclass" : "comment",
 									"numinlets" : 1,
 									"numoutlets" : 0,
-									"patching_rect" : [ 108.0, 196.5, 189.0, 25.0 ],
-									"text" : "Write a fluid.dataset~ to disk"
+									"patching_rect" : [ 86.0, 196.0, 189.0, 21.0 ],
+									"text" : "Write a fluid.dataset~ to disk",
+									"textcolor" : [ 0.501960784313725, 0.501960784313725, 0.501960784313725, 1.0 ]
 								}
 
 							}
@@ -3001,33 +3088,13 @@
 							}
 , 							{
 								"box" : 								{
-									"bgcolor" : [ 0.968627450980392, 0.431372549019608, 0.431372549019608, 1.0 ],
-									"fontname" : "Arial Bold",
-									"hint" : "",
-									"id" : "obj-9",
-									"ignoreclick" : 1,
-									"legacytextcolor" : 1,
-									"maxclass" : "textbutton",
-									"numinlets" : 1,
-									"numoutlets" : 3,
-									"outlettype" : [ "", "", "int" ],
-									"parameter_enable" : 0,
-									"patching_rect" : [ 112.0, 231.5, 20.0, 20.0 ],
-									"rounded" : 60.0,
-									"text" : "2",
-									"textcolor" : [ 0.929411764705882, 0.941176470588235, 0.956862745098039, 1.0 ]
-								}
-
-							}
-, 							{
-								"box" : 								{
-									"bubble" : 1,
 									"id" : "obj-6",
 									"maxclass" : "comment",
 									"numinlets" : 1,
 									"numoutlets" : 0,
-									"patching_rect" : [ 242.0, 411.5, 280.0, 25.0 ],
-									"text" : "Completely empty and reset a fluid.dataset~"
+									"patching_rect" : [ 208.0, 390.0, 280.0, 21.0 ],
+									"text" : "Completely empty and reset a fluid.dataset~",
+									"textcolor" : [ 0.501960784313725, 0.501960784313725, 0.501960784313725, 1.0 ]
 								}
 
 							}
@@ -3038,28 +3105,8 @@
 									"numinlets" : 2,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 180.0, 410.0, 37.0, 23.0 ],
+									"patching_rect" : [ 170.0, 390.0, 37.0, 23.0 ],
 									"text" : "clear"
-								}
-
-							}
-, 							{
-								"box" : 								{
-									"bgcolor" : [ 0.968627450980392, 0.431372549019608, 0.431372549019608, 1.0 ],
-									"fontname" : "Arial Bold",
-									"hint" : "",
-									"id" : "obj-42",
-									"ignoreclick" : 1,
-									"legacytextcolor" : 1,
-									"maxclass" : "textbutton",
-									"numinlets" : 1,
-									"numoutlets" : 3,
-									"outlettype" : [ "", "", "int" ],
-									"parameter_enable" : 0,
-									"patching_rect" : [ 86.0, 196.5, 20.0, 20.0 ],
-									"rounded" : 60.0,
-									"text" : "1",
-									"textcolor" : [ 0.929411764705882, 0.941176470588235, 0.956862745098039, 1.0 ]
 								}
 
 							}
@@ -3068,9 +3115,9 @@
 									"id" : "obj-1",
 									"maxclass" : "newobj",
 									"numinlets" : 1,
-									"numoutlets" : 3,
-									"outlettype" : [ "bang", "float", "" ],
-									"patching_rect" : [ 15.0, 480.0, 148.0, 23.0 ],
+									"numoutlets" : 2,
+									"outlettype" : [ "", "" ],
+									"patching_rect" : [ 15.0, 460.0, 148.0, 23.0 ],
 									"text" : "fluid.dataset~ help.other"
 								}
 
@@ -3079,14 +3126,14 @@
 						"lines" : [ 							{
 								"patchline" : 								{
 									"destination" : [ "obj-16", 0 ],
-									"source" : [ "obj-1", 2 ]
+									"source" : [ "obj-1", 1 ]
 								}
 
 							}
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-1", 0 ],
-									"midpoints" : [ 85.5, 467.0, 24.5, 467.0 ],
+									"midpoints" : [ 85.5, 447.0, 24.5, 447.0 ],
 									"source" : [ "obj-11", 0 ]
 								}
 
@@ -3094,7 +3141,7 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-1", 0 ],
-									"midpoints" : [ 109.5, 467.0, 24.5, 467.0 ],
+									"midpoints" : [ 109.5, 303.0, 24.5, 303.0 ],
 									"source" : [ "obj-14", 0 ]
 								}
 
@@ -3102,7 +3149,7 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-21", 0 ],
-									"midpoints" : [ 208.5, 548.5, 399.5, 548.5 ],
+									"midpoints" : [ 208.5, 533.5, 399.5, 533.5 ],
 									"source" : [ "obj-16", 1 ]
 								}
 
@@ -3110,7 +3157,7 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-26", 0 ],
-									"midpoints" : [ 153.5, 548.5, 153.5, 548.5 ],
+									"midpoints" : [ 153.5, 533.5, 153.5, 533.5 ],
 									"source" : [ "obj-16", 0 ]
 								}
 
@@ -3125,7 +3172,7 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-1", 0 ],
-									"midpoints" : [ 139.5, 467.0, 24.5, 467.0 ],
+									"midpoints" : [ 129.5, 345.0, 24.5, 345.0 ],
 									"source" : [ "obj-23", 0 ]
 								}
 
@@ -3133,7 +3180,7 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-1", 0 ],
-									"midpoints" : [ 163.5, 467.0, 24.5, 467.0 ],
+									"midpoints" : [ 149.5, 447.0, 24.5, 447.0 ],
 									"source" : [ "obj-28", 0 ]
 								}
 
@@ -3141,7 +3188,7 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-1", 0 ],
-									"midpoints" : [ 189.5, 467.0, 24.5, 467.0 ],
+									"midpoints" : [ 179.5, 447.0, 24.5, 447.0 ],
 									"source" : [ "obj-4", 0 ]
 								}
 
@@ -3149,7 +3196,7 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-1", 0 ],
-									"midpoints" : [ 24.5, 191.0, 24.5, 191.0 ],
+									"midpoints" : [ 24.5, 189.0, 24.5, 189.0 ],
 									"source" : [ "obj-5", 0 ]
 								}
 
@@ -3157,7 +3204,7 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-1", 0 ],
-									"midpoints" : [ 57.5, 467.0, 24.5, 467.0 ],
+									"midpoints" : [ 57.5, 447.0, 24.5, 447.0 ],
 									"source" : [ "obj-8", 0 ]
 								}
 
@@ -3187,13 +3234,13 @@
 								"name" : "max6message",
 								"default" : 								{
 									"bgfillcolor" : 									{
-										"type" : "gradient",
+										"angle" : 270.0,
+										"autogradient" : 0,
+										"color" : [ 0.290196, 0.309804, 0.301961, 1.0 ],
 										"color1" : [ 0.866667, 0.866667, 0.866667, 1.0 ],
 										"color2" : [ 0.788235, 0.788235, 0.788235, 1.0 ],
-										"color" : [ 0.290196, 0.309804, 0.301961, 1.0 ],
-										"angle" : 270.0,
 										"proportion" : 0.39,
-										"autogradient" : 0
+										"type" : "gradient"
 									}
 ,
 									"textcolor_inverse" : [ 0.0, 0.0, 0.0, 1.0 ]
@@ -3214,7 +3261,7 @@
  ]
 					}
 ,
-					"patching_rect" : [ 53.0, 184.0, 121.0, 23.0 ],
+					"patching_rect" : [ 164.0, 210.0, 121.0, 23.0 ],
 					"saved_object_attributes" : 					{
 						"description" : "",
 						"digest" : "",
@@ -3245,7 +3292,7 @@
 						}
 ,
 						"classnamespace" : "box",
-						"rect" : [ 0.0, 26.0, 1049.0, 753.0 ],
+						"rect" : [ 0.0, 26.0, 995.0, 751.0 ],
 						"bglocked" : 0,
 						"openinpresentation" : 0,
 						"default_fontsize" : 13.0,
@@ -3275,6 +3322,18 @@
 						"showontab" : 1,
 						"assistshowspatchername" : 0,
 						"boxes" : [ 							{
+								"box" : 								{
+									"id" : "obj-5",
+									"maxclass" : "newobj",
+									"numinlets" : 2,
+									"numoutlets" : 1,
+									"outlettype" : [ "int" ],
+									"patching_rect" : [ 213.5, 290.0, 78.0, 23.0 ],
+									"text" : "random 100"
+								}
+
+							}
+, 							{
 								"box" : 								{
 									"args" : [ "dataset" ],
 									"bgmode" : 0,
@@ -3324,7 +3383,7 @@
 									"numoutlets" : 3,
 									"outlettype" : [ "", "", "int" ],
 									"parameter_enable" : 0,
-									"patching_rect" : [ 385.0, 202.5, 20.0, 20.0 ],
+									"patching_rect" : [ 435.0, 152.5, 20.0, 20.0 ],
 									"rounded" : 60.0,
 									"text" : "1",
 									"textcolor" : [ 0.34902, 0.34902, 0.34902, 1.0 ]
@@ -3338,7 +3397,7 @@
 									"maxclass" : "comment",
 									"numinlets" : 1,
 									"numoutlets" : 0,
-									"patching_rect" : [ 37.75, 200.0, 345.0, 25.0 ],
+									"patching_rect" : [ 87.75, 150.0, 345.0, 25.0 ],
 									"text" : "Generate random data to be stored in the fluid.dataset~"
 								}
 
@@ -3349,19 +3408,7 @@
 									"maxclass" : "dict.view",
 									"numinlets" : 1,
 									"numoutlets" : 0,
-									"patching_rect" : [ 244.125, 575.0, 162.875, 175.0 ]
-								}
-
-							}
-, 							{
-								"box" : 								{
-									"id" : "obj-107",
-									"maxclass" : "message",
-									"numinlets" : 2,
-									"numoutlets" : 1,
-									"outlettype" : [ "" ],
-									"patching_rect" : [ 186.75, 575.0, 41.0, 23.0 ],
-									"text" : "dump"
+									"patching_rect" : [ 236.75, 548.0, 162.875, 175.0 ]
 								}
 
 							}
@@ -3369,11 +3416,11 @@
 								"box" : 								{
 									"id" : "obj-104",
 									"maxclass" : "newobj",
-									"numinlets" : 3,
-									"numoutlets" : 3,
-									"outlettype" : [ "", "", "" ],
-									"patching_rect" : [ 186.75, 540.0, 133.75, 23.0 ],
-									"text" : "route load dump"
+									"numinlets" : 2,
+									"numoutlets" : 2,
+									"outlettype" : [ "", "" ],
+									"patching_rect" : [ 236.75, 518.0, 74.0, 23.0 ],
+									"text" : "route dump"
 								}
 
 							}
@@ -3384,7 +3431,7 @@
 									"numinlets" : 1,
 									"numoutlets" : 2,
 									"outlettype" : [ "int", "bang" ],
-									"patching_rect" : [ 65.5, 315.0, 108.5, 23.0 ],
+									"patching_rect" : [ 115.5, 260.0, 117.0, 23.0 ],
 									"text" : "t i b"
 								}
 
@@ -3396,20 +3443,8 @@
 									"numinlets" : 2,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 65.0, 375.0, 117.0, 23.0 ],
+									"patching_rect" : [ 115.5, 325.0, 117.0, 23.0 ],
 									"text" : "sprintf entry-%i: %i"
-								}
-
-							}
-, 							{
-								"box" : 								{
-									"id" : "obj-86",
-									"maxclass" : "newobj",
-									"numinlets" : 2,
-									"numoutlets" : 1,
-									"outlettype" : [ "int" ],
-									"patching_rect" : [ 155.0, 345.0, 78.0, 23.0 ],
-									"text" : "random 100"
 								}
 
 							}
@@ -3420,7 +3455,7 @@
 									"numinlets" : 2,
 									"numoutlets" : 3,
 									"outlettype" : [ "bang", "bang", "int" ],
-									"patching_rect" : [ 10.0, 275.0, 74.5, 23.0 ],
+									"patching_rect" : [ 60.0, 225.0, 74.5, 23.0 ],
 									"text" : "uzi 100"
 								}
 
@@ -3432,7 +3467,7 @@
 									"numinlets" : 2,
 									"numoutlets" : 1,
 									"outlettype" : [ "dictionary" ],
-									"patching_rect" : [ 37.75, 440.0, 130.0, 23.0 ],
+									"patching_rect" : [ 87.75, 400.0, 130.0, 23.0 ],
 									"text" : "dict.pack data: cols:1"
 								}
 
@@ -3444,7 +3479,7 @@
 									"numinlets" : 1,
 									"numoutlets" : 1,
 									"outlettype" : [ "dictionary" ],
-									"patching_rect" : [ 37.75, 410.0, 66.0, 23.0 ],
+									"patching_rect" : [ 87.75, 360.0, 66.0, 23.0 ],
 									"text" : "dict.group"
 								}
 
@@ -3457,7 +3492,7 @@
 									"numoutlets" : 1,
 									"outlettype" : [ "bang" ],
 									"parameter_enable" : 0,
-									"patching_rect" : [ 10.0, 200.0, 24.0, 24.0 ]
+									"patching_rect" : [ 60.0, 150.0, 24.0, 24.0 ]
 								}
 
 							}
@@ -3466,9 +3501,9 @@
 									"id" : "obj-54",
 									"maxclass" : "newobj",
 									"numinlets" : 1,
-									"numoutlets" : 3,
-									"outlettype" : [ "bang", "float", "" ],
-									"patching_rect" : [ 109.5, 275.0, 168.0, 23.0 ],
+									"numoutlets" : 2,
+									"outlettype" : [ "", "" ],
+									"patching_rect" : [ 159.5, 225.0, 168.0, 23.0 ],
 									"text" : "fluid.dataset~ dictionary-fun"
 								}
 
@@ -3480,7 +3515,7 @@
 									"numinlets" : 1,
 									"numoutlets" : 2,
 									"outlettype" : [ "bang", "clear" ],
-									"patching_rect" : [ 10.0, 240.0, 118.5, 23.0 ],
+									"patching_rect" : [ 60.0, 190.0, 118.5, 23.0 ],
 									"text" : "t b clear"
 								}
 
@@ -3488,11 +3523,11 @@
 , 							{
 								"box" : 								{
 									"id" : "obj-4",
-									"linecount" : 3,
+									"linecount" : 9,
 									"maxclass" : "comment",
 									"numinlets" : 1,
 									"numoutlets" : 0,
-									"patching_rect" : [ 10.0, 125.0, 548.0, 50.0 ],
+									"patching_rect" : [ 470.0, 150.0, 207.0, 137.0 ],
 									"text" : "You can construct the contents of a fluid.dataset~ programatically by creating a dictionary in the correct format before \"loading\" it into a dataset. In the example below, we will use random number generation to create a toy dataset by first loading the information into a dictionary.",
 									"textcolor" : [ 0.501960784313725, 0.501960784313725, 0.501960784313725, 1.0 ]
 								}
@@ -3501,12 +3536,12 @@
 , 							{
 								"box" : 								{
 									"id" : "obj-43",
-									"maxclass" : "newobj",
-									"numinlets" : 1,
+									"maxclass" : "message",
+									"numinlets" : 2,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 37.75, 475.0, 84.0, 23.0 ],
-									"text" : "prepend load"
+									"patching_rect" : [ 87.75, 440.0, 150.0, 23.0 ],
+									"text" : "load dictionary $2, dump"
 								}
 
 							}
@@ -3515,9 +3550,9 @@
 									"id" : "obj-1",
 									"maxclass" : "newobj",
 									"numinlets" : 1,
-									"numoutlets" : 3,
-									"outlettype" : [ "bang", "float", "" ],
-									"patching_rect" : [ 37.75, 507.0, 168.0, 23.0 ],
+									"numoutlets" : 2,
+									"outlettype" : [ "", "" ],
+									"patching_rect" : [ 87.75, 485.0, 168.0, 23.0 ],
 									"text" : "fluid.dataset~ dictionary-fun"
 								}
 
@@ -3526,13 +3561,14 @@
 						"lines" : [ 							{
 								"patchline" : 								{
 									"destination" : [ "obj-104", 0 ],
-									"source" : [ "obj-1", 2 ]
+									"source" : [ "obj-1", 1 ]
 								}
 
 							}
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-70", 0 ],
+									"midpoints" : [ 125.0, 351.0, 97.25, 351.0 ],
 									"source" : [ "obj-102", 0 ]
 								}
 
@@ -3546,30 +3582,15 @@
 							}
 , 							{
 								"patchline" : 								{
-									"destination" : [ "obj-86", 0 ],
+									"destination" : [ "obj-5", 0 ],
 									"source" : [ "obj-103", 1 ]
 								}
 
 							}
 , 							{
 								"patchline" : 								{
-									"destination" : [ "obj-107", 0 ],
-									"source" : [ "obj-104", 0 ]
-								}
-
-							}
-, 							{
-								"patchline" : 								{
 									"destination" : [ "obj-108", 0 ],
-									"source" : [ "obj-104", 1 ]
-								}
-
-							}
-, 							{
-								"patchline" : 								{
-									"destination" : [ "obj-1", 0 ],
-									"midpoints" : [ 196.25, 600.0, 24.0, 600.0, 24.0, 501.0, 47.25, 501.0 ],
-									"source" : [ "obj-107", 0 ]
+									"source" : [ "obj-104", 0 ]
 								}
 
 							}
@@ -3577,6 +3598,13 @@
 								"patchline" : 								{
 									"destination" : [ "obj-1", 0 ],
 									"source" : [ "obj-43", 0 ]
+								}
+
+							}
+, 							{
+								"patchline" : 								{
+									"destination" : [ "obj-102", 1 ],
+									"source" : [ "obj-5", 0 ]
 								}
 
 							}
@@ -3629,13 +3657,6 @@
 								}
 
 							}
-, 							{
-								"patchline" : 								{
-									"destination" : [ "obj-102", 1 ],
-									"source" : [ "obj-86", 0 ]
-								}
-
-							}
  ],
 						"styles" : [ 							{
 								"name" : "max6box",
@@ -3661,13 +3682,13 @@
 								"name" : "max6message",
 								"default" : 								{
 									"bgfillcolor" : 									{
-										"type" : "gradient",
+										"angle" : 270.0,
+										"autogradient" : 0,
+										"color" : [ 0.290196, 0.309804, 0.301961, 1.0 ],
 										"color1" : [ 0.866667, 0.866667, 0.866667, 1.0 ],
 										"color2" : [ 0.788235, 0.788235, 0.788235, 1.0 ],
-										"color" : [ 0.290196, 0.309804, 0.301961, 1.0 ],
-										"angle" : 270.0,
 										"proportion" : 0.39,
-										"autogradient" : 0
+										"type" : "gradient"
 									}
 ,
 									"textcolor_inverse" : [ 0.0, 0.0, 0.0, 1.0 ]
@@ -3688,7 +3709,7 @@
  ]
 					}
 ,
-					"patching_rect" : [ 103.0, 238.0, 40.0, 23.0 ],
+					"patching_rect" : [ 214.0, 264.0, 40.0, 23.0 ],
 					"saved_object_attributes" : 					{
 						"description" : "",
 						"digest" : "",
@@ -3718,7 +3739,7 @@
 						}
 ,
 						"classnamespace" : "box",
-						"rect" : [ 34.0, 113.0, 1049.0, 753.0 ],
+						"rect" : [ 35.0, 114.0, 995.0, 751.0 ],
 						"bglocked" : 0,
 						"openinpresentation" : 0,
 						"default_fontsize" : 13.0,
@@ -3749,6 +3770,272 @@
 						"assistshowspatchername" : 0,
 						"boxes" : [ 							{
 								"box" : 								{
+									"id" : "obj-63",
+									"maxclass" : "newobj",
+									"numinlets" : 1,
+									"numoutlets" : 2,
+									"outlettype" : [ "float", "bang" ],
+									"patching_rect" : [ 650.0, 440.0, 85.0, 23.0 ],
+									"text" : "buffer~ query"
+								}
+
+							}
+, 							{
+								"box" : 								{
+									"bgcolor" : [ 1.0, 0.788235, 0.470588, 1.0 ],
+									"fontname" : "Arial Bold",
+									"hint" : "",
+									"id" : "obj-55",
+									"ignoreclick" : 1,
+									"legacytextcolor" : 1,
+									"maxclass" : "textbutton",
+									"numinlets" : 1,
+									"numoutlets" : 3,
+									"outlettype" : [ "", "", "int" ],
+									"parameter_enable" : 0,
+									"patching_rect" : [ 763.0, 341.5, 20.0, 20.0 ],
+									"rounded" : 60.0,
+									"text" : "6",
+									"textcolor" : [ 0.34902, 0.34902, 0.34902, 1.0 ]
+								}
+
+							}
+, 							{
+								"box" : 								{
+									"fontface" : 0,
+									"fontname" : "Arial",
+									"id" : "obj-59",
+									"maxclass" : "comment",
+									"numinlets" : 1,
+									"numoutlets" : 0,
+									"patching_rect" : [ 650.0, 310.0, 100.0, 21.0 ],
+									"text" : "Getting Points",
+									"textjustification" : 1
+								}
+
+							}
+, 							{
+								"box" : 								{
+									"bubbleside" : 0,
+									"id" : "obj-60",
+									"linecount" : 3,
+									"maxclass" : "comment",
+									"numinlets" : 1,
+									"numoutlets" : 0,
+									"patching_rect" : [ 629.0, 370.5, 154.0, 50.0 ],
+									"text" : "Retrieve the values for a given identifier. Outputs to a buffer.",
+									"textcolor" : [ 0.501960784313725, 0.501960784313725, 0.501960784313725, 1.0 ]
+								}
+
+							}
+, 							{
+								"box" : 								{
+									"id" : "obj-61",
+									"maxclass" : "message",
+									"numinlets" : 2,
+									"numoutlets" : 1,
+									"outlettype" : [ "" ],
+									"patching_rect" : [ 611.0, 341.5, 145.0, 23.0 ],
+									"text" : "getpoint numbers query"
+								}
+
+							}
+, 							{
+								"box" : 								{
+									"bgcolor" : [ 1.0, 0.788235, 0.470588, 1.0 ],
+									"fontname" : "Arial Bold",
+									"hint" : "",
+									"id" : "obj-49",
+									"ignoreclick" : 1,
+									"legacytextcolor" : 1,
+									"maxclass" : "textbutton",
+									"numinlets" : 1,
+									"numoutlets" : 3,
+									"outlettype" : [ "", "", "int" ],
+									"parameter_enable" : 0,
+									"patching_rect" : [ 560.0, 479.5, 20.0, 20.0 ],
+									"rounded" : 60.0,
+									"text" : "5",
+									"textcolor" : [ 0.34902, 0.34902, 0.34902, 1.0 ]
+								}
+
+							}
+, 							{
+								"box" : 								{
+									"fontface" : 0,
+									"fontname" : "Arial",
+									"id" : "obj-50",
+									"maxclass" : "comment",
+									"numinlets" : 1,
+									"numoutlets" : 0,
+									"patching_rect" : [ 430.0, 448.0, 100.0, 21.0 ],
+									"text" : "Updating Points",
+									"textjustification" : 1
+								}
+
+							}
+, 							{
+								"box" : 								{
+									"bubbleside" : 0,
+									"id" : "obj-51",
+									"linecount" : 2,
+									"maxclass" : "comment",
+									"numinlets" : 1,
+									"numoutlets" : 0,
+									"patching_rect" : [ 409.0, 508.5, 154.0, 36.0 ],
+									"text" : "Update the values for an existing point.",
+									"textcolor" : [ 0.501960784313725, 0.501960784313725, 0.501960784313725, 1.0 ]
+								}
+
+							}
+, 							{
+								"box" : 								{
+									"id" : "obj-52",
+									"maxclass" : "message",
+									"numinlets" : 2,
+									"numoutlets" : 1,
+									"outlettype" : [ "" ],
+									"patching_rect" : [ 391.0, 479.5, 162.0, 23.0 ],
+									"text" : "updatepoint numbers point"
+								}
+
+							}
+, 							{
+								"box" : 								{
+									"bgcolor" : [ 1.0, 0.788235, 0.470588, 1.0 ],
+									"fontname" : "Arial Bold",
+									"hint" : "",
+									"id" : "obj-33",
+									"ignoreclick" : 1,
+									"legacytextcolor" : 1,
+									"maxclass" : "textbutton",
+									"numinlets" : 1,
+									"numoutlets" : 3,
+									"outlettype" : [ "", "", "int" ],
+									"parameter_enable" : 0,
+									"patching_rect" : [ 500.0, 343.0, 20.0, 20.0 ],
+									"rounded" : 60.0,
+									"text" : "4",
+									"textcolor" : [ 0.34902, 0.34902, 0.34902, 1.0 ]
+								}
+
+							}
+, 							{
+								"box" : 								{
+									"fontface" : 0,
+									"fontname" : "Arial",
+									"id" : "obj-34",
+									"maxclass" : "comment",
+									"numinlets" : 1,
+									"numoutlets" : 0,
+									"patching_rect" : [ 390.0, 310.0, 96.0, 21.0 ],
+									"text" : "Setting Points",
+									"textjustification" : 1
+								}
+
+							}
+, 							{
+								"box" : 								{
+									"bubbleside" : 0,
+									"id" : "obj-36",
+									"linecount" : 3,
+									"maxclass" : "comment",
+									"numinlets" : 1,
+									"numoutlets" : 0,
+									"patching_rect" : [ 369.0, 370.5, 155.0, 50.0 ],
+									"text" : "Will overwrite an existing point or create a new one if doesn't exist.",
+									"textcolor" : [ 0.501960784313725, 0.501960784313725, 0.501960784313725, 1.0 ]
+								}
+
+							}
+, 							{
+								"box" : 								{
+									"id" : "obj-38",
+									"maxclass" : "message",
+									"numinlets" : 2,
+									"numoutlets" : 1,
+									"outlettype" : [ "" ],
+									"patching_rect" : [ 351.0, 341.5, 140.0, 23.0 ],
+									"text" : "setpoint numbers point"
+								}
+
+							}
+, 							{
+								"box" : 								{
+									"bgcolor" : [ 1.0, 0.788235, 0.470588, 1.0 ],
+									"fontname" : "Arial Bold",
+									"hint" : "",
+									"id" : "obj-20",
+									"ignoreclick" : 1,
+									"legacytextcolor" : 1,
+									"maxclass" : "textbutton",
+									"numinlets" : 1,
+									"numoutlets" : 3,
+									"outlettype" : [ "", "", "int" ],
+									"parameter_enable" : 0,
+									"patching_rect" : [ 274.0, 479.5, 20.0, 20.0 ],
+									"rounded" : 60.0,
+									"text" : "3",
+									"textcolor" : [ 0.34902, 0.34902, 0.34902, 1.0 ]
+								}
+
+							}
+, 							{
+								"box" : 								{
+									"fontface" : 0,
+									"fontname" : "Arial",
+									"id" : "obj-7",
+									"maxclass" : "comment",
+									"numinlets" : 1,
+									"numoutlets" : 0,
+									"patching_rect" : [ 184.0, 448.0, 96.0, 21.0 ],
+									"text" : "Deleting Points",
+									"textjustification" : 1
+								}
+
+							}
+, 							{
+								"box" : 								{
+									"bubbleside" : 0,
+									"id" : "obj-12",
+									"linecount" : 2,
+									"maxclass" : "comment",
+									"numinlets" : 1,
+									"numoutlets" : 0,
+									"patching_rect" : [ 164.0, 515.5, 151.0, 36.0 ],
+									"text" : "Delete a point with deletepoint <identifier>.",
+									"textcolor" : [ 0.501960784313725, 0.501960784313725, 0.501960784313725, 1.0 ]
+								}
+
+							}
+, 							{
+								"box" : 								{
+									"id" : "obj-13",
+									"maxclass" : "message",
+									"numinlets" : 2,
+									"numoutlets" : 1,
+									"outlettype" : [ "" ],
+									"patching_rect" : [ 145.0, 479.5, 126.0, 23.0 ],
+									"text" : "deletepoint numbers"
+								}
+
+							}
+, 							{
+								"box" : 								{
+									"fontface" : 0,
+									"fontname" : "Arial",
+									"id" : "obj-6",
+									"maxclass" : "comment",
+									"numinlets" : 1,
+									"numoutlets" : 0,
+									"patching_rect" : [ 113.25, 307.5, 113.5, 21.0 ],
+									"text" : "Adding Points",
+									"textjustification" : 1
+								}
+
+							}
+, 							{
+								"box" : 								{
 									"args" : [ "dataset" ],
 									"bgmode" : 0,
 									"border" : 0,
@@ -3763,7 +4050,7 @@
 									"numinlets" : 0,
 									"numoutlets" : 0,
 									"offset" : [ 0.0, 0.0 ],
-									"patching_rect" : [ 402.0, 11.0, 232.600000649690628, 109.0 ],
+									"patching_rect" : [ 402.0, 10.0, 232.600000649690628, 109.0 ],
 									"viewvisibility" : 1
 								}
 
@@ -3781,7 +4068,7 @@
 									"numoutlets" : 3,
 									"outlettype" : [ "", "", "int" ],
 									"parameter_enable" : 0,
-									"patching_rect" : [ 547.0, 698.0, 20.0, 20.0 ],
+									"patching_rect" : [ 400.0, 685.0, 20.0, 20.0 ],
 									"rounded" : 60.0,
 									"text" : "!!!",
 									"textcolor" : [ 1.0, 0.968627450980392, 0.0, 1.0 ]
@@ -3796,7 +4083,7 @@
 									"maxclass" : "comment",
 									"numinlets" : 1,
 									"numoutlets" : 0,
-									"patching_rect" : [ 265.0, 683.0, 280.0, 50.0 ],
+									"patching_rect" : [ 118.0, 670.0, 280.0, 50.0 ],
 									"text" : "fluid.dataset~ will report back when an operation is complete from its right outlet. You can use this to chain together processes.",
 									"textcolor" : [ 0.501960784313725, 0.501960784313725, 0.501960784313725, 1.0 ]
 								}
@@ -3808,187 +4095,8 @@
 									"maxclass" : "newobj",
 									"numinlets" : 1,
 									"numoutlets" : 0,
-									"patching_rect" : [ 159.0, 710.0, 98.0, 23.0 ],
+									"patching_rect" : [ 17.0, 670.0, 98.0, 23.0 ],
 									"text" : "print @popup 1"
-								}
-
-							}
-, 							{
-								"box" : 								{
-									"bgcolor" : [ 1.0, 0.788235, 0.470588, 1.0 ],
-									"fontname" : "Arial Bold",
-									"hint" : "",
-									"id" : "obj-51",
-									"ignoreclick" : 1,
-									"legacytextcolor" : 1,
-									"maxclass" : "textbutton",
-									"numinlets" : 1,
-									"numoutlets" : 3,
-									"outlettype" : [ "", "", "int" ],
-									"parameter_enable" : 0,
-									"patching_rect" : [ 250.0, 480.5, 20.0, 20.0 ],
-									"rounded" : 60.0,
-									"text" : "4",
-									"textcolor" : [ 0.34902, 0.34902, 0.34902, 1.0 ]
-								}
-
-							}
-, 							{
-								"box" : 								{
-									"bubble" : 1,
-									"id" : "obj-52",
-									"maxclass" : "comment",
-									"numinlets" : 1,
-									"numoutlets" : 0,
-									"patching_rect" : [ 272.0, 480.5, 428.200001299381256, 25.0 ],
-									"text" : "Delete a datapoint by sending the message deletepoint <identifier>."
-								}
-
-							}
-, 							{
-								"box" : 								{
-									"arrows" : 1,
-									"id" : "obj-41",
-									"maxclass" : "live.line",
-									"numinlets" : 1,
-									"numoutlets" : 0,
-									"patching_rect" : [ 118.0, 196.5, 91.0, 8.0 ]
-								}
-
-							}
-, 							{
-								"box" : 								{
-									"id" : "obj-39",
-									"maxclass" : "newobj",
-									"numinlets" : 1,
-									"numoutlets" : 2,
-									"outlettype" : [ "float", "bang" ],
-									"patching_rect" : [ 210.0, 634.0, 165.0, 23.0 ],
-									"text" : "buffer~ retrieval @samps 3"
-								}
-
-							}
-, 							{
-								"box" : 								{
-									"bgcolor" : [ 1.0, 0.788235, 0.470588, 1.0 ],
-									"fontname" : "Arial Bold",
-									"hint" : "",
-									"id" : "obj-34",
-									"ignoreclick" : 1,
-									"legacytextcolor" : 1,
-									"maxclass" : "textbutton",
-									"numinlets" : 1,
-									"numoutlets" : 3,
-									"outlettype" : [ "", "", "int" ],
-									"parameter_enable" : 0,
-									"patching_rect" : [ 287.0, 530.5, 20.0, 20.0 ],
-									"rounded" : 60.0,
-									"text" : "5",
-									"textcolor" : [ 0.34902, 0.34902, 0.34902, 1.0 ]
-								}
-
-							}
-, 							{
-								"box" : 								{
-									"bubble" : 1,
-									"id" : "obj-36",
-									"linecount" : 4,
-									"maxclass" : "comment",
-									"numinlets" : 1,
-									"numoutlets" : 0,
-									"patching_rect" : [ 408.899999350309372, 574.5, 428.200001299381256, 69.0 ],
-									"text" : "To retrieve the data associated to a particular <identifier> use the getpoint message and provide an <identifier> and a <buffer>. The data associated to the <identifier> will be written into the provided <buffer>"
-								}
-
-							}
-, 							{
-								"box" : 								{
-									"bgcolor" : [ 1.0, 0.788235, 0.470588, 1.0 ],
-									"fontname" : "Arial Bold",
-									"hint" : "",
-									"id" : "obj-27",
-									"ignoreclick" : 1,
-									"legacytextcolor" : 1,
-									"maxclass" : "textbutton",
-									"numinlets" : 1,
-									"numoutlets" : 3,
-									"outlettype" : [ "", "", "int" ],
-									"parameter_enable" : 0,
-									"patching_rect" : [ 380.0, 599.0, 20.0, 20.0 ],
-									"rounded" : 60.0,
-									"text" : "6",
-									"textcolor" : [ 0.34902, 0.34902, 0.34902, 1.0 ]
-								}
-
-							}
-, 							{
-								"box" : 								{
-									"bubble" : 1,
-									"id" : "obj-28",
-									"linecount" : 2,
-									"maxclass" : "comment",
-									"numinlets" : 1,
-									"numoutlets" : 0,
-									"patching_rect" : [ 309.0, 522.5, 628.0, 40.0 ],
-									"text" : "The message setpoint <identifier> <buffer> will also add a point to the dataset, unless a point already exists with that identifier, in which case it will update the data associated with the provided identifier."
-								}
-
-							}
-, 							{
-								"box" : 								{
-									"bgcolor" : [ 1.0, 0.788235, 0.470588, 1.0 ],
-									"fontname" : "Arial Bold",
-									"hint" : "",
-									"id" : "obj-18",
-									"ignoreclick" : 1,
-									"legacytextcolor" : 1,
-									"maxclass" : "textbutton",
-									"numinlets" : 1,
-									"numoutlets" : 3,
-									"outlettype" : [ "", "", "int" ],
-									"parameter_enable" : 0,
-									"patching_rect" : [ 246.0, 405.0, 20.0, 20.0 ],
-									"rounded" : 60.0,
-									"text" : "3",
-									"textcolor" : [ 0.34902, 0.34902, 0.34902, 1.0 ]
-								}
-
-							}
-, 							{
-								"box" : 								{
-									"bubble" : 1,
-									"id" : "obj-19",
-									"linecount" : 4,
-									"maxclass" : "comment",
-									"numinlets" : 1,
-									"numoutlets" : 0,
-									"patching_rect" : [ 272.0, 380.5, 387.200001299381256, 69.0 ],
-									"text" : "You can update points in the fluid.dataaset by sending the message updatepoint <identifier> <buffer>. The new data in the <buffer> has to be the same length as what was originally stored."
-								}
-
-							}
-, 							{
-								"box" : 								{
-									"id" : "obj-23",
-									"maxclass" : "message",
-									"numinlets" : 2,
-									"numoutlets" : 1,
-									"outlettype" : [ "" ],
-									"patching_rect" : [ 47.0, 368.0, 94.0, 23.0 ],
-									"text" : "-100 -200 -300"
-								}
-
-							}
-, 							{
-								"box" : 								{
-									"color" : [ 0.309803921568627, 0.63921568627451, 0.988235294117647, 1.0 ],
-									"id" : "obj-24",
-									"maxclass" : "newobj",
-									"numinlets" : 1,
-									"numoutlets" : 1,
-									"outlettype" : [ "list" ],
-									"patching_rect" : [ 47.0, 405.0, 189.0, 23.0 ],
-									"text" : "fluid.list2buf @destination point"
 								}
 
 							}
@@ -4005,7 +4113,7 @@
 									"numoutlets" : 3,
 									"outlettype" : [ "", "", "int" ],
 									"parameter_enable" : 0,
-									"patching_rect" : [ 165.0, 302.0, 20.0, 20.0 ],
+									"patching_rect" : [ 221.0, 341.5, 20.0, 20.0 ],
 									"rounded" : 60.0,
 									"text" : "2",
 									"textcolor" : [ 0.34902, 0.34902, 0.34902, 1.0 ]
@@ -4014,14 +4122,16 @@
 							}
 , 							{
 								"box" : 								{
-									"bubble" : 1,
+									"bubbleside" : 0,
 									"id" : "obj-17",
 									"linecount" : 2,
 									"maxclass" : "comment",
 									"numinlets" : 1,
 									"numoutlets" : 0,
-									"patching_rect" : [ 187.0, 294.0, 635.199999928474426, 40.0 ],
-									"text" : "You can then add the point to the fluid.dataset~ by sending a message in the format addpoint <identifier> <buffer>. This will add the data from the <buffer> and associate it with the provided <identifier>."
+									"patching_rect" : [ 77.0, 377.5, 186.0, 36.0 ],
+									"text" : "Add a point with the message addpoint <identifier> <buffer>.",
+									"textcolor" : [ 0.501960784313725, 0.501960784313725, 0.501960784313725, 1.0 ],
+									"textjustification" : 2
 								}
 
 							}
@@ -4038,7 +4148,7 @@
 									"numoutlets" : 3,
 									"outlettype" : [ "", "", "int" ],
 									"parameter_enable" : 0,
-									"patching_rect" : [ 224.0, 215.0, 20.0, 20.0 ],
+									"patching_rect" : [ 551.0, 224.5, 20.0, 20.0 ],
 									"rounded" : 60.0,
 									"text" : "1",
 									"textcolor" : [ 0.34902, 0.34902, 0.34902, 1.0 ]
@@ -4053,7 +4163,7 @@
 									"maxclass" : "comment",
 									"numinlets" : 1,
 									"numoutlets" : 0,
-									"patching_rect" : [ 250.0, 198.0, 321.0, 54.0 ],
+									"patching_rect" : [ 221.0, 207.5, 321.0, 54.0 ],
 									"text" : "Store a list of numbers in a buffer. These numbers could be anything, including audio-descriptor data, synthesiser parameters or anything!"
 								}
 
@@ -4065,8 +4175,8 @@
 									"numinlets" : 2,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 17.0, 189.0, 92.0, 23.0 ],
-									"text" : "3.14 2.7 1.618"
+									"patching_rect" : [ 17.0, 189.0, 70.0, 23.0 ],
+									"text" : "0.1 0.2 0.3"
 								}
 
 							}
@@ -4099,24 +4209,13 @@
 , 							{
 								"box" : 								{
 									"id" : "obj-29",
-									"linecount" : 3,
+									"linecount" : 2,
 									"maxclass" : "comment",
 									"numinlets" : 1,
 									"numoutlets" : 0,
-									"patching_rect" : [ 10.0, 123.0, 522.0, 50.0 ],
-									"text" : "The fluid.dataset~ object is central to the FluCoMa data analysis objects. It is used for storing many data points, each of which will be attached to an identifier, also known as a key. All of the data points in a dataset must have the same number of dimensions"
-								}
-
-							}
-, 							{
-								"box" : 								{
-									"id" : "obj-8",
-									"maxclass" : "message",
-									"numinlets" : 2,
-									"numoutlets" : 1,
-									"outlettype" : [ "" ],
-									"patching_rect" : [ 145.0, 529.0, 140.0, 23.0 ],
-									"text" : "setpoint numbers point"
+									"patching_rect" : [ 10.0, 130.0, 760.0, 36.0 ],
+									"text" : "The fluid.dataset~ object is central to the FluCoMa data analysis objects. It is used for storing many data points, each of which will be attached to an identifier, also known as a key. All of the data points in a dataset must have the same number of dimensions",
+									"textcolor" : [ 0.501960784313725, 0.501960784313725, 0.501960784313725, 1.0 ]
 								}
 
 							}
@@ -4125,9 +4224,9 @@
 									"id" : "obj-1",
 									"maxclass" : "newobj",
 									"numinlets" : 1,
-									"numoutlets" : 3,
-									"outlettype" : [ "bang", "float", "" ],
-									"patching_rect" : [ 17.0, 680.0, 161.0, 23.0 ],
+									"numoutlets" : 2,
+									"outlettype" : [ "", "" ],
+									"patching_rect" : [ 17.0, 620.0, 161.0, 23.0 ],
 									"text" : "fluid.dataset~ help.dataset"
 								}
 
@@ -4139,44 +4238,8 @@
 									"numinlets" : 2,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 17.0, 299.0, 144.0, 23.0 ],
+									"patching_rect" : [ 71.0, 340.0, 144.0, 23.0 ],
 									"text" : "addpoint numbers point"
-								}
-
-							}
-, 							{
-								"box" : 								{
-									"id" : "obj-16",
-									"maxclass" : "message",
-									"numinlets" : 2,
-									"numoutlets" : 1,
-									"outlettype" : [ "" ],
-									"patching_rect" : [ 47.0, 439.0, 162.0, 23.0 ],
-									"text" : "updatepoint numbers point"
-								}
-
-							}
-, 							{
-								"box" : 								{
-									"id" : "obj-21",
-									"maxclass" : "message",
-									"numinlets" : 2,
-									"numoutlets" : 1,
-									"outlettype" : [ "" ],
-									"patching_rect" : [ 210.0, 594.0, 159.0, 23.0 ],
-									"text" : "getpoint numbers retrieval"
-								}
-
-							}
-, 							{
-								"box" : 								{
-									"id" : "obj-22",
-									"maxclass" : "message",
-									"numinlets" : 2,
-									"numoutlets" : 1,
-									"outlettype" : [ "" ],
-									"patching_rect" : [ 118.0, 479.0, 130.0, 23.0 ],
-									"text" : "deletepoint numbers"
 								}
 
 							}
@@ -4193,6 +4256,23 @@
 									"outlettype" : [ "" ],
 									"parameter_enable" : 0,
 									"patching_rect" : [ 10.0, 10.0, 390.0, 110.0 ]
+								}
+
+							}
+, 							{
+								"box" : 								{
+									"angle" : 270.0,
+									"background" : 1,
+									"bgcolor" : [ 0.2, 0.2, 0.2, 0.0 ],
+									"border" : 2,
+									"bordercolor" : [ 0.423529411764706, 0.513725490196078, 1.0, 1.0 ],
+									"id" : "obj-4",
+									"maxclass" : "panel",
+									"mode" : 0,
+									"numinlets" : 1,
+									"numoutlets" : 0,
+									"patching_rect" : [ 60.0, 300.0, 220.0, 130.0 ],
+									"proportion" : 0.5
 								}
 
 							}
@@ -4219,13 +4299,64 @@
 									"background" : 1,
 									"bgcolor" : [ 0.2, 0.2, 0.2, 0.0 ],
 									"border" : 2,
-									"bordercolor" : [ 1.0, 0.709803921568627, 0.196078431372549, 1.0 ],
-									"id" : "obj-26",
+									"bordercolor" : [ 0.423529411764706, 0.513725490196078, 1.0, 1.0 ],
+									"id" : "obj-14",
 									"maxclass" : "panel",
 									"mode" : 0,
 									"numinlets" : 1,
 									"numoutlets" : 0,
-									"patching_rect" : [ 40.0, 359.0, 204.0, 110.0 ],
+									"patching_rect" : [ 134.0, 438.0, 200.0, 130.0 ],
+									"proportion" : 0.5
+								}
+
+							}
+, 							{
+								"box" : 								{
+									"angle" : 270.0,
+									"background" : 1,
+									"bgcolor" : [ 0.2, 0.2, 0.2, 0.0 ],
+									"border" : 2,
+									"bordercolor" : [ 0.423529411764706, 0.513725490196078, 1.0, 1.0 ],
+									"id" : "obj-39",
+									"maxclass" : "panel",
+									"mode" : 0,
+									"numinlets" : 1,
+									"numoutlets" : 0,
+									"patching_rect" : [ 340.0, 300.0, 200.0, 130.0 ],
+									"proportion" : 0.5
+								}
+
+							}
+, 							{
+								"box" : 								{
+									"angle" : 270.0,
+									"background" : 1,
+									"bgcolor" : [ 0.2, 0.2, 0.2, 0.0 ],
+									"border" : 2,
+									"bordercolor" : [ 0.423529411764706, 0.513725490196078, 1.0, 1.0 ],
+									"id" : "obj-62",
+									"maxclass" : "panel",
+									"mode" : 0,
+									"numinlets" : 1,
+									"numoutlets" : 0,
+									"patching_rect" : [ 600.0, 300.0, 201.0, 180.0 ],
+									"proportion" : 0.5
+								}
+
+							}
+, 							{
+								"box" : 								{
+									"angle" : 270.0,
+									"background" : 1,
+									"bgcolor" : [ 0.2, 0.2, 0.2, 0.0 ],
+									"border" : 2,
+									"bordercolor" : [ 0.423529411764706, 0.513725490196078, 1.0, 1.0 ],
+									"id" : "obj-54",
+									"maxclass" : "panel",
+									"mode" : 0,
+									"numinlets" : 1,
+									"numoutlets" : 0,
+									"patching_rect" : [ 380.0, 438.0, 210.0, 130.0 ],
 									"proportion" : 0.5
 								}
 
@@ -4234,45 +4365,16 @@
 						"lines" : [ 							{
 								"patchline" : 								{
 									"destination" : [ "obj-56", 0 ],
-									"source" : [ "obj-1", 2 ]
+									"midpoints" : [ 26.5, 666.0, 26.5, 666.0 ],
+									"source" : [ "obj-1", 0 ]
 								}
 
 							}
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-1", 0 ],
-									"midpoints" : [ 56.5, 666.0, 26.5, 666.0 ],
-									"source" : [ "obj-16", 0 ]
-								}
-
-							}
-, 							{
-								"patchline" : 								{
-									"destination" : [ "obj-1", 0 ],
-									"midpoints" : [ 219.5, 618.0, 26.5, 618.0 ],
-									"source" : [ "obj-21", 0 ]
-								}
-
-							}
-, 							{
-								"patchline" : 								{
-									"destination" : [ "obj-1", 0 ],
-									"midpoints" : [ 127.5, 666.0, 26.5, 666.0 ],
-									"source" : [ "obj-22", 0 ]
-								}
-
-							}
-, 							{
-								"patchline" : 								{
-									"destination" : [ "obj-24", 0 ],
-									"source" : [ "obj-23", 0 ]
-								}
-
-							}
-, 							{
-								"patchline" : 								{
-									"destination" : [ "obj-16", 0 ],
-									"source" : [ "obj-24", 0 ]
+									"midpoints" : [ 154.5, 606.0, 26.5, 606.0 ],
+									"source" : [ "obj-13", 0 ]
 								}
 
 							}
@@ -4286,15 +4388,31 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-1", 0 ],
-									"midpoints" : [ 154.5, 666.0, 26.5, 666.0 ],
-									"source" : [ "obj-8", 0 ]
+									"midpoints" : [ 360.5, 366.0, 360.0, 366.0, 360.0, 606.0, 26.5, 606.0 ],
+									"source" : [ "obj-38", 0 ]
 								}
 
 							}
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-1", 0 ],
-									"midpoints" : [ 26.5, 324.0, 26.5, 324.0 ],
+									"midpoints" : [ 400.5, 606.0, 360.0, 606.0, 360.0, 606.0, 26.5, 606.0 ],
+									"source" : [ "obj-52", 0 ]
+								}
+
+							}
+, 							{
+								"patchline" : 								{
+									"destination" : [ "obj-1", 0 ],
+									"midpoints" : [ 620.5, 375.0, 620.0, 375.0, 620.0, 606.0, 26.5, 606.0 ],
+									"source" : [ "obj-61", 0 ]
+								}
+
+							}
+, 							{
+								"patchline" : 								{
+									"destination" : [ "obj-1", 0 ],
+									"midpoints" : [ 80.5, 366.0, 26.5, 366.0 ],
 									"source" : [ "obj-9", 0 ]
 								}
 
@@ -4324,13 +4442,13 @@
 								"name" : "max6message",
 								"default" : 								{
 									"bgfillcolor" : 									{
-										"type" : "gradient",
+										"angle" : 270.0,
+										"autogradient" : 0,
+										"color" : [ 0.290196, 0.309804, 0.301961, 1.0 ],
 										"color1" : [ 0.866667, 0.866667, 0.866667, 1.0 ],
 										"color2" : [ 0.788235, 0.788235, 0.788235, 1.0 ],
-										"color" : [ 0.290196, 0.309804, 0.301961, 1.0 ],
-										"angle" : 270.0,
 										"proportion" : 0.39,
-										"autogradient" : 0
+										"type" : "gradient"
 									}
 ,
 									"textcolor_inverse" : [ 0.0, 0.0, 0.0, 1.0 ]
@@ -4398,7 +4516,7 @@
 						}
 ,
 						"classnamespace" : "box",
-						"rect" : [ 0.0, 26.0, 1049.0, 753.0 ],
+						"rect" : [ 0.0, 26.0, 995.0, 751.0 ],
 						"bglocked" : 0,
 						"openinpresentation" : 0,
 						"default_fontsize" : 13.0,
@@ -4447,61 +4565,6 @@
 			}
  ],
 		"lines" : [  ],
-		"dependency_cache" : [ 			{
-				"name" : "fluid.buf2list.mxo",
-				"type" : "iLaX"
-			}
-, 			{
-				"name" : "fluid.bufflatten~.mxo",
-				"type" : "iLaX"
-			}
-, 			{
-				"name" : "fluid.bufmfcc~.mxo",
-				"type" : "iLaX"
-			}
-, 			{
-				"name" : "fluid.bufspectralshape~.mxo",
-				"type" : "iLaX"
-			}
-, 			{
-				"name" : "fluid.bufstats~.mxo",
-				"type" : "iLaX"
-			}
-, 			{
-				"name" : "fluid.flucomaorg.maxpat",
-				"bootpath" : "~/dev/flucoma/max/help",
-				"patcherrelativepath" : ".",
-				"type" : "JSON",
-				"implicit" : 1
-			}
-, 			{
-				"name" : "fluid.learn.maxpat",
-				"bootpath" : "~/dev/flucoma/max/help",
-				"patcherrelativepath" : ".",
-				"type" : "JSON",
-				"implicit" : 1
-			}
-, 			{
-				"name" : "fluid.libmanipulation.mxo",
-				"type" : "iLaX"
-			}
-, 			{
-				"name" : "fluid.list2buf.mxo",
-				"type" : "iLaX"
-			}
-, 			{
-				"name" : "helpdetails.js",
-				"bootpath" : "C74:/help/resources",
-				"type" : "TEXT",
-				"implicit" : 1
-			}
-, 			{
-				"name" : "helpname.js",
-				"bootpath" : "C74:/help/resources",
-				"type" : "TEXT",
-				"implicit" : 1
-			}
- ],
 		"autosave" : 0
 	}
 

--- a/help/fluid.dataset~.maxhelp
+++ b/help/fluid.dataset~.maxhelp
@@ -57,7 +57,7 @@
 						}
 ,
 						"classnamespace" : "box",
-						"rect" : [ 0.0, 26.0, 995.0, 751.0 ],
+						"rect" : [ 35.0, 114.0, 995.0, 751.0 ],
 						"bglocked" : 0,
 						"openinpresentation" : 0,
 						"default_fontsize" : 13.0,
@@ -88,12 +88,25 @@
 						"assistshowspatchername" : 0,
 						"boxes" : [ 							{
 								"box" : 								{
+									"id" : "obj-14",
+									"maxclass" : "comment",
+									"numinlets" : 1,
+									"numoutlets" : 0,
+									"patching_rect" : [ 10.0, 62.0, 729.0, 21.0 ],
+									"presentation_linecount" : 6,
+									"text" : "A fluid.dataset~ can be created from the contents of a buffer as well as converted from its internal representation TO a buffer. ",
+									"textcolor" : [ 0.501960784313725, 0.501960784313725, 0.501960784313725, 1.0 ]
+								}
+
+							}
+, 							{
+								"box" : 								{
 									"id" : "obj-32",
 									"linecount" : 11,
 									"maxclass" : "comment",
 									"numinlets" : 1,
 									"numoutlets" : 0,
-									"patching_rect" : [ 338.0, 510.0, 215.0, 166.0 ],
+									"patching_rect" : [ 388.0, 490.0, 215.0, 166.0 ],
 									"text" : "By default, each row is layed out framewise, so all of channel 1 is ordered in time as the columns of identifier 0.\n\nWhen frombuffer <buffer> 1 is passed (implicitly 0), the copying is transposed. This means each identifier will contain the same index across all channels as the columns of a given identifier.",
 									"textcolor" : [ 0.501960784313725, 0.501960784313725, 0.501960784313725, 1.0 ]
 								}
@@ -126,7 +139,7 @@
 									"numoutlets" : 3,
 									"outlettype" : [ "", "", "int" ],
 									"parameter_enable" : 0,
-									"patching_rect" : [ 695.0, 375.0, 20.0, 20.0 ],
+									"patching_rect" : [ 770.0, 355.0, 20.0, 20.0 ],
 									"rounded" : 60.0,
 									"text" : "3",
 									"textcolor" : [ 0.34902, 0.34902, 0.34902, 1.0 ]
@@ -141,7 +154,7 @@
 									"maxclass" : "comment",
 									"numinlets" : 1,
 									"numoutlets" : 0,
-									"patching_rect" : [ 495.0, 359.5, 201.0, 54.0 ],
+									"patching_rect" : [ 570.0, 339.5, 201.0, 54.0 ],
 									"text" : "You can provide an optional number (0 or 1) to change the transposition of the copying.",
 									"textcolor" : [ 0.0, 0.0, 0.0, 1.0 ]
 								}
@@ -154,7 +167,7 @@
 									"numinlets" : 2,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 245.0, 375.0, 238.0, 23.0 ],
+									"patching_rect" : [ 320.0, 355.0, 238.0, 23.0 ],
 									"text" : "frombuffer help.ds.buffers.stats 1, dump"
 								}
 
@@ -172,7 +185,7 @@
 									"numoutlets" : 3,
 									"outlettype" : [ "", "", "int" ],
 									"parameter_enable" : 0,
-									"patching_rect" : [ 234.0, 315.0, 20.0, 20.0 ],
+									"patching_rect" : [ 284.0, 295.0, 20.0, 20.0 ],
 									"rounded" : 60.0,
 									"text" : "2",
 									"textcolor" : [ 0.34902, 0.34902, 0.34902, 1.0 ]
@@ -188,7 +201,7 @@
 									"maxclass" : "comment",
 									"numinlets" : 0,
 									"numoutlets" : 0,
-									"patching_rect" : [ 20.0, 300.0, 207.0, 69.0 ],
+									"patching_rect" : [ 70.0, 280.0, 207.0, 69.0 ],
 									"suppressinlet" : 1,
 									"text" : "frombuffer messages copies the contents of the buffer you provide as an argument to the dataset.",
 									"textcolor" : [ 0.0, 0.0, 0.0, 1.0 ]
@@ -208,7 +221,7 @@
 									"numoutlets" : 3,
 									"outlettype" : [ "", "", "int" ],
 									"parameter_enable" : 0,
-									"patching_rect" : [ 50.0, 152.0, 20.0, 20.0 ],
+									"patching_rect" : [ 100.0, 132.0, 20.0, 20.0 ],
 									"rounded" : 60.0,
 									"text" : "1",
 									"textcolor" : [ 0.34902, 0.34902, 0.34902, 1.0 ]
@@ -223,7 +236,7 @@
 									"maxclass" : "comment",
 									"numinlets" : 1,
 									"numoutlets" : 0,
-									"patching_rect" : [ 72.0, 143.5, 167.0, 40.0 ],
+									"patching_rect" : [ 122.0, 123.5, 167.0, 40.0 ],
 									"text" : "Trigger audio-descriptor analysis",
 									"textcolor" : [ 0.0, 0.0, 0.0, 1.0 ]
 								}
@@ -236,7 +249,7 @@
 									"maxclass" : "comment",
 									"numinlets" : 1,
 									"numoutlets" : 0,
-									"patching_rect" : [ 654.699999675154686, 238.5, 170.0, 36.0 ],
+									"patching_rect" : [ 704.699999675154686, 218.5, 170.0, 36.0 ],
 									"text" : "Compure the stats across each spectral shape feature",
 									"textcolor" : [ 0.501960784313725, 0.501960784313725, 0.501960784313725, 1.0 ]
 								}
@@ -249,7 +262,7 @@
 									"maxclass" : "comment",
 									"numinlets" : 1,
 									"numoutlets" : 0,
-									"patching_rect" : [ 755.0, 188.5, 150.0, 36.0 ],
+									"patching_rect" : [ 805.0, 168.5, 150.0, 36.0 ],
 									"text" : "Analyse spectral shape features of the source",
 									"textcolor" : [ 0.501960784313725, 0.501960784313725, 0.501960784313725, 1.0 ]
 								}
@@ -261,7 +274,7 @@
 									"maxclass" : "comment",
 									"numinlets" : 1,
 									"numoutlets" : 0,
-									"patching_rect" : [ 552.0, 153.0, 156.0, 21.0 ],
+									"patching_rect" : [ 602.0, 133.0, 156.0, 21.0 ],
 									"text" : "A sound stored in a buffer",
 									"textcolor" : [ 0.501960784313725, 0.501960784313725, 0.501960784313725, 1.0 ]
 								}
@@ -274,7 +287,7 @@
 									"numinlets" : 2,
 									"numoutlets" : 2,
 									"outlettype" : [ "", "" ],
-									"patching_rect" : [ 20.0, 465.0, 74.0, 23.0 ],
+									"patching_rect" : [ 70.0, 445.0, 74.0, 23.0 ],
 									"text" : "route dump"
 								}
 
@@ -285,7 +298,7 @@
 									"maxclass" : "dict.view",
 									"numinlets" : 1,
 									"numoutlets" : 0,
-									"patching_rect" : [ 20.0, 505.0, 312.0, 190.0 ]
+									"patching_rect" : [ 70.0, 485.0, 312.0, 190.0 ]
 								}
 
 							}
@@ -296,7 +309,7 @@
 									"numinlets" : 2,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 20.0, 375.0, 227.0, 23.0 ],
+									"patching_rect" : [ 70.0, 355.0, 227.0, 23.0 ],
 									"text" : "frombuffer help.ds.buffers.stats, dump"
 								}
 
@@ -309,7 +322,7 @@
 									"numinlets" : 1,
 									"numoutlets" : 2,
 									"outlettype" : [ "float", "bang" ],
-									"patching_rect" : [ 480.0, 245.0, 169.0, 23.0 ],
+									"patching_rect" : [ 530.0, 225.0, 169.0, 23.0 ],
 									"text" : "buffer~ help.ds.buffers.stats"
 								}
 
@@ -322,7 +335,7 @@
 									"numinlets" : 2,
 									"numoutlets" : 2,
 									"outlettype" : [ "", "" ],
-									"patching_rect" : [ 20.0, 245.0, 448.0, 23.0 ],
+									"patching_rect" : [ 70.0, 225.0, 448.0, 23.0 ],
 									"text" : "fluid.bufstats~ @source help.ds.buffers.features @stats help.ds.buffers.stats"
 								}
 
@@ -335,7 +348,7 @@
 									"numoutlets" : 1,
 									"outlettype" : [ "bang" ],
 									"parameter_enable" : 0,
-									"patching_rect" : [ 20.0, 150.0, 24.0, 24.0 ]
+									"patching_rect" : [ 70.0, 130.0, 24.0, 24.0 ]
 								}
 
 							}
@@ -347,7 +360,7 @@
 									"numinlets" : 1,
 									"numoutlets" : 2,
 									"outlettype" : [ "", "" ],
-									"patching_rect" : [ 20.0, 195.0, 533.0, 23.0 ],
+									"patching_rect" : [ 70.0, 175.0, 533.0, 23.0 ],
 									"text" : "fluid.bufspectralshape~ @source help.ds.buffers.source @features help.ds.buffers.features"
 								}
 
@@ -359,7 +372,7 @@
 									"numinlets" : 1,
 									"numoutlets" : 2,
 									"outlettype" : [ "float", "bang" ],
-									"patching_rect" : [ 245.0, 152.0, 297.0, 23.0 ],
+									"patching_rect" : [ 295.0, 132.0, 297.0, 23.0 ],
 									"text" : "buffer~ help.ds.buffers.source Nicol-LoopE-M.wav"
 								}
 
@@ -372,7 +385,7 @@
 									"numinlets" : 1,
 									"numoutlets" : 2,
 									"outlettype" : [ "float", "bang" ],
-									"patching_rect" : [ 560.0, 195.0, 188.0, 23.0 ],
+									"patching_rect" : [ 610.0, 175.0, 188.0, 23.0 ],
 									"text" : "buffer~ help.ds.buffers.features"
 								}
 
@@ -384,29 +397,8 @@
 									"numinlets" : 1,
 									"numoutlets" : 2,
 									"outlettype" : [ "", "" ],
-									"patching_rect" : [ 20.0, 415.0, 175.0, 23.0 ],
+									"patching_rect" : [ 70.0, 395.0, 175.0, 23.0 ],
 									"text" : "fluid.dataset~ help.ds.buffers"
-								}
-
-							}
-, 							{
-								"box" : 								{
-									"args" : [ "dataset" ],
-									"bgmode" : 0,
-									"border" : 0,
-									"clickthrough" : 0,
-									"enablehscroll" : 0,
-									"enablevscroll" : 0,
-									"id" : "obj-3",
-									"lockeddragscroll" : 0,
-									"lockedsize" : 0,
-									"maxclass" : "bpatcher",
-									"name" : "fluid.learn.maxpat",
-									"numinlets" : 0,
-									"numoutlets" : 0,
-									"offset" : [ 0.0, 0.0 ],
-									"patching_rect" : [ 402.0, 11.0, 232.600000649690628, 109.0 ],
-									"viewvisibility" : 1
 								}
 
 							}
@@ -422,7 +414,7 @@
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
 									"parameter_enable" : 0,
-									"patching_rect" : [ 10.0, 10.0, 390.0, 110.0 ]
+									"patching_rect" : [ 10.0, 10.0, 290.0, 50.0 ]
 								}
 
 							}
@@ -430,7 +422,7 @@
 						"lines" : [ 							{
 								"patchline" : 								{
 									"destination" : [ "obj-16", 0 ],
-									"midpoints" : [ 185.5, 450.0, 29.5, 450.0 ],
+									"midpoints" : [ 235.5, 430.0, 79.5, 430.0 ],
 									"source" : [ "obj-1", 1 ]
 								}
 
@@ -452,7 +444,7 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-1", 0 ],
-									"midpoints" : [ 254.5, 405.5, 29.5, 405.5 ],
+									"midpoints" : [ 329.5, 385.5, 79.5, 385.5 ],
 									"source" : [ "obj-30", 0 ]
 								}
 
@@ -589,7 +581,7 @@
 									"maxclass" : "comment",
 									"numinlets" : 1,
 									"numoutlets" : 0,
-									"patching_rect" : [ 700.0, 430.0, 150.0, 94.0 ],
+									"patching_rect" : [ 670.0, 290.0, 150.0, 94.0 ],
 									"text" : "Notice after clicking merge that some new kills will appear in this dictionary (a representation of the dataset).",
 									"textcolor" : [ 0.501960784313725, 0.501960784313725, 0.501960784313725, 1.0 ]
 								}
@@ -608,7 +600,7 @@
 									"numoutlets" : 3,
 									"outlettype" : [ "", "", "int" ],
 									"parameter_enable" : 0,
-									"patching_rect" : [ 890.0, 310.0, 20.0, 20.0 ],
+									"patching_rect" : [ 860.0, 170.0, 20.0, 20.0 ],
 									"rounded" : 60.0,
 									"text" : "2",
 									"textcolor" : [ 0.34902, 0.34902, 0.34902, 1.0 ]
@@ -622,7 +614,7 @@
 									"maxclass" : "comment",
 									"numinlets" : 1,
 									"numoutlets" : 0,
-									"patching_rect" : [ 80.0, 260.0, 213.0, 25.0 ],
+									"patching_rect" : [ 50.0, 120.0, 213.0, 25.0 ],
 									"text" : "generate some random data first"
 								}
 
@@ -635,7 +627,7 @@
 									"numoutlets" : 1,
 									"outlettype" : [ "bang" ],
 									"parameter_enable" : 0,
-									"patching_rect" : [ 50.0, 260.0, 24.0, 24.0 ]
+									"patching_rect" : [ 20.0, 120.0, 24.0, 24.0 ]
 								}
 
 							}
@@ -1144,7 +1136,7 @@
  ]
 									}
 ,
-									"patching_rect" : [ 390.0, 310.0, 96.0, 23.0 ],
+									"patching_rect" : [ 360.0, 170.0, 96.0, 23.0 ],
 									"saved_object_attributes" : 									{
 										"description" : "",
 										"digest" : "",
@@ -1648,7 +1640,7 @@
  ]
 									}
 ,
-									"patching_rect" : [ 50.0, 310.0, 96.0, 23.0 ],
+									"patching_rect" : [ 20.0, 170.0, 96.0, 23.0 ],
 									"saved_object_attributes" : 									{
 										"description" : "",
 										"digest" : "",
@@ -1657,27 +1649,6 @@
 									}
 ,
 									"text" : "p random_data"
-								}
-
-							}
-, 							{
-								"box" : 								{
-									"args" : [ "dataset" ],
-									"bgmode" : 0,
-									"border" : 0,
-									"clickthrough" : 0,
-									"enablehscroll" : 0,
-									"enablevscroll" : 0,
-									"id" : "obj-3",
-									"lockeddragscroll" : 0,
-									"lockedsize" : 0,
-									"maxclass" : "bpatcher",
-									"name" : "fluid.learn.maxpat",
-									"numinlets" : 0,
-									"numoutlets" : 0,
-									"offset" : [ 0.0, 0.0 ],
-									"patching_rect" : [ 400.5, 11.0, 232.600000649690628, 109.0 ],
-									"viewvisibility" : 1
 								}
 
 							}
@@ -1693,7 +1664,7 @@
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
 									"parameter_enable" : 0,
-									"patching_rect" : [ 8.5, 10.0, 390.0, 110.0 ]
+									"patching_rect" : [ 8.5, 10.0, 291.5, 50.0 ]
 								}
 
 							}
@@ -1714,7 +1685,7 @@
 									"numinlets" : 2,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 505.0, 310.0, 121.0, 23.0 ],
+									"patching_rect" : [ 475.0, 170.0, 121.0, 23.0 ],
 									"text" : "merge data1, dump"
 								}
 
@@ -1732,7 +1703,7 @@
 									"numoutlets" : 3,
 									"outlettype" : [ "", "", "int" ],
 									"parameter_enable" : 0,
-									"patching_rect" : [ 300.0, 262.5, 20.0, 20.0 ],
+									"patching_rect" : [ 270.0, 122.5, 20.0, 20.0 ],
 									"rounded" : 60.0,
 									"text" : "1",
 									"textcolor" : [ 0.34902, 0.34902, 0.34902, 1.0 ]
@@ -1747,7 +1718,7 @@
 									"maxclass" : "comment",
 									"numinlets" : 1,
 									"numoutlets" : 0,
-									"patching_rect" : [ 628.0, 294.5, 260.0, 54.0 ],
+									"patching_rect" : [ 598.0, 154.5, 260.0, 54.0 ],
 									"text" : "Merge the contents of fluid.dataset~ named \"data1\" into \"data2\". \"dump\" is automatically called afterwards."
 								}
 
@@ -1758,7 +1729,7 @@
 									"maxclass" : "dict.view",
 									"numinlets" : 1,
 									"numoutlets" : 0,
-									"patching_rect" : [ 493.0, 428.0, 196.25, 195.0 ],
+									"patching_rect" : [ 463.0, 288.0, 196.25, 195.0 ],
 									"stripecolor" : [ 1.0, 0.392156862745098, 0.0, 0.54 ]
 								}
 
@@ -1770,7 +1741,7 @@
 									"numinlets" : 2,
 									"numoutlets" : 2,
 									"outlettype" : [ "", "" ],
-									"patching_rect" : [ 493.0, 393.0, 74.0, 23.0 ],
+									"patching_rect" : [ 463.0, 253.0, 74.0, 23.0 ],
 									"text" : "route dump"
 								}
 
@@ -1783,7 +1754,7 @@
 									"numinlets" : 1,
 									"numoutlets" : 2,
 									"outlettype" : [ "", "" ],
-									"patching_rect" : [ 390.0, 360.0, 122.0, 23.0 ],
+									"patching_rect" : [ 360.0, 220.0, 122.0, 23.0 ],
 									"text" : "fluid.dataset~ data2"
 								}
 
@@ -1794,7 +1765,7 @@
 									"maxclass" : "dict.view",
 									"numinlets" : 1,
 									"numoutlets" : 0,
-									"patching_rect" : [ 153.0, 428.0, 195.875, 190.0 ],
+									"patching_rect" : [ 123.0, 288.0, 195.875, 190.0 ],
 									"stripecolor" : [ 0.427450980392157, 0.843137254901961, 1.0, 0.45 ]
 								}
 
@@ -1806,7 +1777,7 @@
 									"numinlets" : 2,
 									"numoutlets" : 2,
 									"outlettype" : [ "", "" ],
-									"patching_rect" : [ 153.0, 393.0, 74.0, 23.0 ],
+									"patching_rect" : [ 123.0, 253.0, 74.0, 23.0 ],
 									"text" : "route dump"
 								}
 
@@ -1818,7 +1789,7 @@
 									"maxclass" : "comment",
 									"numinlets" : 1,
 									"numoutlets" : 0,
-									"patching_rect" : [ 50.0, 150.0, 580.0, 50.0 ],
+									"patching_rect" : [ 8.5, 62.0, 584.0, 50.0 ],
 									"text" : "You can merge the points in one dataset with another. If the dataset you call merge on already has a key existing in the dataset you want to merge, the caller's will be preserved. Any keys not found in the dataset to merge will be added to the caller.",
 									"textcolor" : [ 0.501960784313725, 0.501960784313725, 0.501960784313725, 1.0 ]
 								}
@@ -1832,7 +1803,7 @@
 									"numinlets" : 1,
 									"numoutlets" : 2,
 									"outlettype" : [ "", "" ],
-									"patching_rect" : [ 50.0, 360.0, 122.0, 23.0 ],
+									"patching_rect" : [ 20.0, 220.0, 122.0, 23.0 ],
 									"text" : "fluid.dataset~ data1"
 								}
 
@@ -1876,7 +1847,7 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-34", 0 ],
-									"midpoints" : [ 514.5, 353.0, 399.5, 353.0 ],
+									"midpoints" : [ 484.5, 213.0, 369.5, 213.0 ],
 									"source" : [ "obj-44", 0 ]
 								}
 
@@ -1891,7 +1862,7 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-15", 0 ],
-									"midpoints" : [ 59.5, 297.0, 399.5, 297.0 ],
+									"midpoints" : [ 29.5, 157.0, 369.5, 157.0 ],
 									"order" : 0,
 									"source" : [ "obj-9", 0 ]
 								}
@@ -1900,7 +1871,7 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-7", 0 ],
-									"midpoints" : [ 59.5, 285.0, 59.5, 285.0 ],
+									"midpoints" : [ 29.5, 145.0, 29.5, 145.0 ],
 									"order" : 1,
 									"source" : [ "obj-9", 0 ]
 								}
@@ -2019,12 +1990,24 @@
 						"assistshowspatchername" : 0,
 						"boxes" : [ 							{
 								"box" : 								{
+									"id" : "obj-12",
+									"maxclass" : "comment",
+									"numinlets" : 1,
+									"numoutlets" : 0,
+									"patching_rect" : [ 10.0, 62.0, 354.0, 21.0 ],
+									"text" : "An example of storing audio descriptors into a fluid.dataset~",
+									"textcolor" : [ 0.501960784313725, 0.501960784313725, 0.501960784313725, 1.0 ]
+								}
+
+							}
+, 							{
+								"box" : 								{
 									"id" : "obj-5",
 									"justification" : 1,
 									"maxclass" : "live.line",
 									"numinlets" : 1,
 									"numoutlets" : 0,
-									"patching_rect" : [ 586.0, 199.0, 35.600000649690628, 6.0 ]
+									"patching_rect" : [ 621.0, 179.0, 35.600000649690628, 6.0 ]
 								}
 
 							}
@@ -2035,28 +2018,7 @@
 									"maxclass" : "live.line",
 									"numinlets" : 1,
 									"numoutlets" : 0,
-									"patching_rect" : [ 584.0, 162.0, 5.0, 40.0 ]
-								}
-
-							}
-, 							{
-								"box" : 								{
-									"args" : [ "dataset" ],
-									"bgmode" : 0,
-									"border" : 0,
-									"clickthrough" : 0,
-									"enablehscroll" : 0,
-									"enablevscroll" : 0,
-									"id" : "obj-1",
-									"lockeddragscroll" : 0,
-									"lockedsize" : 0,
-									"maxclass" : "bpatcher",
-									"name" : "fluid.learn.maxpat",
-									"numinlets" : 0,
-									"numoutlets" : 0,
-									"offset" : [ 0.0, 0.0 ],
-									"patching_rect" : [ 402.0, 11.0, 232.600000649690628, 109.0 ],
-									"viewvisibility" : 1
+									"patching_rect" : [ 619.0, 142.0, 5.0, 40.0 ]
 								}
 
 							}
@@ -2072,7 +2034,7 @@
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
 									"parameter_enable" : 0,
-									"patching_rect" : [ 10.0, 10.0, 390.0, 110.0 ]
+									"patching_rect" : [ 10.0, 10.0, 303.0, 50.0 ]
 								}
 
 							}
@@ -2089,7 +2051,7 @@
 									"numoutlets" : 3,
 									"outlettype" : [ "", "", "int" ],
 									"parameter_enable" : 0,
-									"patching_rect" : [ 174.5, 571.5, 20.0, 20.0 ],
+									"patching_rect" : [ 209.5, 551.5, 20.0, 20.0 ],
 									"rounded" : 60.0,
 									"text" : "2",
 									"textcolor" : [ 0.34902, 0.34902, 0.34902, 1.0 ]
@@ -2104,7 +2066,7 @@
 									"maxclass" : "comment",
 									"numinlets" : 1,
 									"numoutlets" : 0,
-									"patching_rect" : [ 200.0, 558.5, 356.0, 54.0 ],
+									"patching_rect" : [ 235.0, 538.5, 356.0, 54.0 ],
 									"text" : "Open the max console to see the data that was generated and stored in the dataset with the identity \"scratch-synth\"",
 									"textcolor" : [ 0.0, 0.0, 0.0, 1.0 ]
 								}
@@ -2117,7 +2079,7 @@
 									"maxclass" : "live.line",
 									"numinlets" : 1,
 									"numoutlets" : 0,
-									"patching_rect" : [ 46.25, 158.0, 540.75, 7.0 ]
+									"patching_rect" : [ 81.25, 138.0, 540.75, 7.0 ]
 								}
 
 							}
@@ -2127,7 +2089,7 @@
 									"maxclass" : "newobj",
 									"numinlets" : 1,
 									"numoutlets" : 0,
-									"patching_rect" : [ 15.0, 570.0, 156.0, 23.0 ],
+									"patching_rect" : [ 50.0, 550.0, 156.0, 23.0 ],
 									"text" : "print \"fluid.dataset~ help:\""
 								}
 
@@ -2145,7 +2107,7 @@
 									"numoutlets" : 3,
 									"outlettype" : [ "", "", "int" ],
 									"parameter_enable" : 0,
-									"patching_rect" : [ 623.600000649690628, 192.0, 20.0, 20.0 ],
+									"patching_rect" : [ 658.600000649690628, 172.0, 20.0, 20.0 ],
 									"rounded" : 60.0,
 									"text" : "1",
 									"textcolor" : [ 0.34902, 0.34902, 0.34902, 1.0 ]
@@ -2160,7 +2122,7 @@
 									"maxclass" : "comment",
 									"numinlets" : 1,
 									"numoutlets" : 0,
-									"patching_rect" : [ 648.600000649690628, 153.0, 230.0, 98.0 ],
+									"patching_rect" : [ 683.600000649690628, 133.0, 230.0, 98.0 ],
 									"text" : "Analyse the buffer named src with the mel-frequency cepstrum coefficient descriptor. Calculate the statistics across each coefficient per spectral frame and flatten the data to a single dimension."
 								}
 
@@ -2173,7 +2135,7 @@
 									"numinlets" : 2,
 									"numoutlets" : 1,
 									"outlettype" : [ "list" ],
-									"patching_rect" : [ 15.0, 530.0, 77.0, 23.0 ],
+									"patching_rect" : [ 50.0, 510.0, 77.0, 23.0 ],
 									"text" : "fluid.buf2list"
 								}
 
@@ -2185,7 +2147,7 @@
 									"numinlets" : 2,
 									"numoutlets" : 2,
 									"outlettype" : [ "", "" ],
-									"patching_rect" : [ 15.0, 495.0, 151.0, 23.0 ],
+									"patching_rect" : [ 50.0, 475.0, 151.0, 23.0 ],
 									"text" : "substitute getpoint buffer"
 								}
 
@@ -2197,7 +2159,7 @@
 									"numinlets" : 2,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 15.0, 425.0, 238.0, 23.0 ],
+									"patching_rect" : [ 50.0, 405.0, 238.0, 23.0 ],
 									"text" : "getpoint scratch-synth features.stats.flat"
 								}
 
@@ -2209,7 +2171,7 @@
 									"numinlets" : 1,
 									"numoutlets" : 2,
 									"outlettype" : [ "", "" ],
-									"patching_rect" : [ 15.0, 460.0, 177.0, 23.0 ],
+									"patching_rect" : [ 50.0, 440.0, 177.0, 23.0 ],
 									"text" : "fluid.dataset~ sound-analysis"
 								}
 
@@ -2221,7 +2183,7 @@
 									"numinlets" : 2,
 									"numoutlets" : 2,
 									"outlettype" : [ "", "" ],
-									"patching_rect" : [ 15.0, 390.0, 87.0, 23.0 ],
+									"patching_rect" : [ 50.0, 370.0, 87.0, 23.0 ],
 									"text" : "route setpoint"
 								}
 
@@ -2233,7 +2195,7 @@
 									"numinlets" : 1,
 									"numoutlets" : 2,
 									"outlettype" : [ "", "" ],
-									"patching_rect" : [ 15.0, 350.0, 177.0, 23.0 ],
+									"patching_rect" : [ 50.0, 330.0, 177.0, 23.0 ],
 									"text" : "fluid.dataset~ sound-analysis"
 								}
 
@@ -2244,7 +2206,7 @@
 									"maxclass" : "comment",
 									"numinlets" : 1,
 									"numoutlets" : 0,
-									"patching_rect" : [ 255.0, 312.0, 185.0, 21.0 ],
+									"patching_rect" : [ 290.0, 292.0, 185.0, 21.0 ],
 									"text" : "setpoint <identifier> <buffer>",
 									"textcolor" : [ 0.501960784313725, 0.501960784313725, 0.501960784313725, 1.0 ]
 								}
@@ -2257,7 +2219,7 @@
 									"numinlets" : 2,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 15.0, 310.0, 238.0, 23.0 ],
+									"patching_rect" : [ 50.0, 290.0, 238.0, 23.0 ],
 									"text" : "setpoint scratch-synth features.stats.flat"
 								}
 
@@ -2270,7 +2232,7 @@
 									"numoutlets" : 1,
 									"outlettype" : [ "bang" ],
 									"parameter_enable" : 0,
-									"patching_rect" : [ 15.0, 150.0, 24.0, 24.0 ]
+									"patching_rect" : [ 50.0, 130.0, 24.0, 24.0 ]
 								}
 
 							}
@@ -2282,7 +2244,7 @@
 									"numinlets" : 1,
 									"numoutlets" : 2,
 									"outlettype" : [ "float", "bang" ],
-									"patching_rect" : [ 435.0, 265.0, 152.0, 23.0 ],
+									"patching_rect" : [ 470.0, 245.0, 152.0, 23.0 ],
 									"text" : "buffer~ features.stats.flat"
 								}
 
@@ -2295,7 +2257,7 @@
 									"numinlets" : 1,
 									"numoutlets" : 2,
 									"outlettype" : [ "", "" ],
-									"patching_rect" : [ 15.0, 265.0, 417.0, 23.0 ],
+									"patching_rect" : [ 50.0, 245.0, 417.0, 23.0 ],
 									"text" : "fluid.bufflatten~ @source features.stats @destination features.stats.flat"
 								}
 
@@ -2308,7 +2270,7 @@
 									"numinlets" : 1,
 									"numoutlets" : 2,
 									"outlettype" : [ "float", "bang" ],
-									"patching_rect" : [ 435.0, 225.0, 131.0, 23.0 ],
+									"patching_rect" : [ 470.0, 205.0, 131.0, 23.0 ],
 									"text" : "buffer~ features.stats"
 								}
 
@@ -2321,7 +2283,7 @@
 									"numinlets" : 2,
 									"numoutlets" : 2,
 									"outlettype" : [ "", "" ],
-									"patching_rect" : [ 15.0, 225.0, 409.0, 23.0 ],
+									"patching_rect" : [ 50.0, 205.0, 409.0, 23.0 ],
 									"text" : "fluid.bufstats~ @source features @stats features.stats @numderivs 0"
 								}
 
@@ -2334,7 +2296,7 @@
 									"numinlets" : 1,
 									"numoutlets" : 2,
 									"outlettype" : [ "float", "bang" ],
-									"patching_rect" : [ 435.0, 185.0, 100.0, 23.0 ],
+									"patching_rect" : [ 470.0, 165.0, 100.0, 23.0 ],
 									"text" : "buffer~ features"
 								}
 
@@ -2347,7 +2309,7 @@
 									"numinlets" : 1,
 									"numoutlets" : 2,
 									"outlettype" : [ "", "" ],
-									"patching_rect" : [ 15.0, 185.0, 298.0, 23.0 ],
+									"patching_rect" : [ 50.0, 165.0, 298.0, 23.0 ],
 									"text" : "fluid.bufmfcc~ 13 @source src @features features"
 								}
 
@@ -2359,7 +2321,7 @@
 									"numinlets" : 1,
 									"numoutlets" : 2,
 									"outlettype" : [ "float", "bang" ],
-									"patching_rect" : [ 600.0, 265.0, 313.0, 23.0 ],
+									"patching_rect" : [ 635.0, 245.0, 313.0, 23.0 ],
 									"text" : "buffer~ src Tremblay-ASWINE-ScratchySynth-M.wav"
 								}
 
@@ -2376,7 +2338,7 @@
 									"mode" : 0,
 									"numinlets" : 1,
 									"numoutlets" : 0,
-									"patching_rect" : [ 10.0, 145.0, 585.0, 150.0 ],
+									"patching_rect" : [ 45.0, 125.0, 585.0, 150.0 ],
 									"proportion" : 0.5
 								}
 
@@ -2573,22 +2535,13 @@
 						"assistshowspatchername" : 0,
 						"boxes" : [ 							{
 								"box" : 								{
-									"args" : [ "dataset" ],
-									"bgmode" : 0,
-									"border" : 0,
-									"clickthrough" : 0,
-									"enablehscroll" : 0,
-									"enablevscroll" : 0,
-									"id" : "obj-3",
-									"lockeddragscroll" : 0,
-									"lockedsize" : 0,
-									"maxclass" : "bpatcher",
-									"name" : "fluid.learn.maxpat",
-									"numinlets" : 0,
+									"id" : "obj-9",
+									"maxclass" : "comment",
+									"numinlets" : 1,
 									"numoutlets" : 0,
-									"offset" : [ 0.0, 0.0 ],
-									"patching_rect" : [ 402.0, 11.0, 232.600000649690628, 109.0 ],
-									"viewvisibility" : 1
+									"patching_rect" : [ 10.0, 62.0, 350.0, 21.0 ],
+									"text" : "Other useful messages that can be used with fluid.dataset~",
+									"textcolor" : [ 0.501960784313725, 0.501960784313725, 0.501960784313725, 1.0 ]
 								}
 
 							}
@@ -2604,7 +2557,7 @@
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
 									"parameter_enable" : 0,
-									"patching_rect" : [ 10.0, 10.0, 390.0, 110.0 ]
+									"patching_rect" : [ 10.0, 10.0, 300.0, 50.0 ]
 								}
 
 							}
@@ -2615,7 +2568,7 @@
 									"numinlets" : 1,
 									"numoutlets" : 1,
 									"outlettype" : [ "bang" ],
-									"patching_rect" : [ 15.0, 132.0, 62.0, 23.0 ],
+									"patching_rect" : [ 60.0, 120.0, 62.0, 23.0 ],
 									"text" : "loadbang"
 								}
 
@@ -2919,7 +2872,7 @@
  ]
 									}
 ,
-									"patching_rect" : [ 15.0, 165.0, 164.0, 23.0 ],
+									"patching_rect" : [ 60.0, 153.0, 164.0, 23.0 ],
 									"saved_object_attributes" : 									{
 										"description" : "",
 										"digest" : "",
@@ -2938,7 +2891,7 @@
 									"maxclass" : "comment",
 									"numinlets" : 1,
 									"numoutlets" : 0,
-									"patching_rect" : [ 183.0, 351.0, 365.0, 21.0 ],
+									"patching_rect" : [ 228.0, 339.0, 365.0, 21.0 ],
 									"text" : "Dump the contents of the fluid.dataset~ to a Max dictionary",
 									"textcolor" : [ 0.501960784313725, 0.501960784313725, 0.501960784313725, 1.0 ]
 								}
@@ -2951,7 +2904,7 @@
 									"numinlets" : 2,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 140.0, 350.0, 41.0, 23.0 ],
+									"patching_rect" : [ 185.0, 338.0, 41.0, 23.0 ],
 									"text" : "dump"
 								}
 
@@ -2962,7 +2915,7 @@
 									"maxclass" : "dict.view",
 									"numinlets" : 1,
 									"numoutlets" : 0,
-									"patching_rect" : [ 144.0, 545.0, 241.0, 160.0 ]
+									"patching_rect" : [ 189.0, 533.0, 241.0, 160.0 ]
 								}
 
 							}
@@ -2973,7 +2926,7 @@
 									"maxclass" : "comment",
 									"numinlets" : 1,
 									"numoutlets" : 0,
-									"patching_rect" : [ 154.0, 310.0, 557.0, 36.0 ],
+									"patching_rect" : [ 199.0, 298.0, 557.0, 36.0 ],
 									"text" : "Get the number of columns, or dimensions of the data points. Since all points must have the same number of dimensions, this is just a single number. It is reported out the right outlet.",
 									"textcolor" : [ 0.501960784313725, 0.501960784313725, 0.501960784313725, 1.0 ]
 								}
@@ -2986,7 +2939,7 @@
 									"numinlets" : 2,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 120.0, 310.0, 32.0, 23.0 ],
+									"patching_rect" : [ 165.0, 298.0, 32.0, 23.0 ],
 									"text" : "cols"
 								}
 
@@ -2997,7 +2950,7 @@
 									"maxclass" : "newobj",
 									"numinlets" : 1,
 									"numoutlets" : 0,
-									"patching_rect" : [ 390.0, 545.0, 98.0, 23.0 ],
+									"patching_rect" : [ 435.0, 533.0, 98.0, 23.0 ],
 									"text" : "print @popup 1"
 								}
 
@@ -3009,7 +2962,7 @@
 									"numinlets" : 2,
 									"numoutlets" : 2,
 									"outlettype" : [ "", "" ],
-									"patching_rect" : [ 144.0, 500.0, 74.0, 23.0 ],
+									"patching_rect" : [ 189.0, 488.0, 74.0, 23.0 ],
 									"text" : "route dump"
 								}
 
@@ -3020,7 +2973,7 @@
 									"maxclass" : "comment",
 									"numinlets" : 1,
 									"numoutlets" : 0,
-									"patching_rect" : [ 134.0, 271.0, 630.0, 21.0 ],
+									"patching_rect" : [ 179.0, 259.0, 630.0, 21.0 ],
 									"text" : "Get the size (the number of <identifier> <data> pairs in the dataset), which is reported out the right outlet.",
 									"textcolor" : [ 0.501960784313725, 0.501960784313725, 0.501960784313725, 1.0 ]
 								}
@@ -3033,7 +2986,7 @@
 									"numinlets" : 2,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 100.0, 270.0, 32.0, 23.0 ],
+									"patching_rect" : [ 145.0, 258.0, 32.0, 23.0 ],
 									"text" : "size"
 								}
 
@@ -3044,7 +2997,7 @@
 									"maxclass" : "comment",
 									"numinlets" : 1,
 									"numoutlets" : 0,
-									"patching_rect" : [ 113.0, 231.0, 205.0, 21.0 ],
+									"patching_rect" : [ 158.0, 219.0, 205.0, 21.0 ],
 									"text" : "Read a fluid.dataset~ from disk",
 									"textcolor" : [ 0.501960784313725, 0.501960784313725, 0.501960784313725, 1.0 ]
 								}
@@ -3057,7 +3010,7 @@
 									"numinlets" : 2,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 76.0, 230.0, 35.0, 23.0 ],
+									"patching_rect" : [ 121.0, 218.0, 35.0, 23.0 ],
 									"text" : "read"
 								}
 
@@ -3068,7 +3021,7 @@
 									"maxclass" : "comment",
 									"numinlets" : 1,
 									"numoutlets" : 0,
-									"patching_rect" : [ 86.0, 196.0, 189.0, 21.0 ],
+									"patching_rect" : [ 131.0, 184.0, 189.0, 21.0 ],
 									"text" : "Write a fluid.dataset~ to disk",
 									"textcolor" : [ 0.501960784313725, 0.501960784313725, 0.501960784313725, 1.0 ]
 								}
@@ -3081,7 +3034,7 @@
 									"numinlets" : 2,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 48.0, 195.0, 36.0, 23.0 ],
+									"patching_rect" : [ 93.0, 183.0, 36.0, 23.0 ],
 									"text" : "write"
 								}
 
@@ -3092,7 +3045,7 @@
 									"maxclass" : "comment",
 									"numinlets" : 1,
 									"numoutlets" : 0,
-									"patching_rect" : [ 208.0, 390.0, 280.0, 21.0 ],
+									"patching_rect" : [ 253.0, 378.0, 280.0, 21.0 ],
 									"text" : "Completely empty and reset a fluid.dataset~",
 									"textcolor" : [ 0.501960784313725, 0.501960784313725, 0.501960784313725, 1.0 ]
 								}
@@ -3105,7 +3058,7 @@
 									"numinlets" : 2,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 170.0, 390.0, 37.0, 23.0 ],
+									"patching_rect" : [ 215.0, 378.0, 37.0, 23.0 ],
 									"text" : "clear"
 								}
 
@@ -3117,7 +3070,7 @@
 									"numinlets" : 1,
 									"numoutlets" : 2,
 									"outlettype" : [ "", "" ],
-									"patching_rect" : [ 15.0, 460.0, 148.0, 23.0 ],
+									"patching_rect" : [ 60.0, 448.0, 148.0, 23.0 ],
 									"text" : "fluid.dataset~ help.other"
 								}
 
@@ -3133,7 +3086,7 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-1", 0 ],
-									"midpoints" : [ 85.5, 447.0, 24.5, 447.0 ],
+									"midpoints" : [ 130.5, 435.0, 69.5, 435.0 ],
 									"source" : [ "obj-11", 0 ]
 								}
 
@@ -3141,7 +3094,7 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-1", 0 ],
-									"midpoints" : [ 109.5, 303.0, 24.5, 303.0 ],
+									"midpoints" : [ 154.5, 291.0, 69.5, 291.0 ],
 									"source" : [ "obj-14", 0 ]
 								}
 
@@ -3149,7 +3102,7 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-21", 0 ],
-									"midpoints" : [ 208.5, 533.5, 399.5, 533.5 ],
+									"midpoints" : [ 253.5, 521.5, 444.5, 521.5 ],
 									"source" : [ "obj-16", 1 ]
 								}
 
@@ -3157,7 +3110,7 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-26", 0 ],
-									"midpoints" : [ 153.5, 533.5, 153.5, 533.5 ],
+									"midpoints" : [ 198.5, 521.5, 198.5, 521.5 ],
 									"source" : [ "obj-16", 0 ]
 								}
 
@@ -3172,7 +3125,7 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-1", 0 ],
-									"midpoints" : [ 129.5, 345.0, 24.5, 345.0 ],
+									"midpoints" : [ 174.5, 333.0, 69.5, 333.0 ],
 									"source" : [ "obj-23", 0 ]
 								}
 
@@ -3180,7 +3133,7 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-1", 0 ],
-									"midpoints" : [ 149.5, 447.0, 24.5, 447.0 ],
+									"midpoints" : [ 194.5, 435.0, 69.5, 435.0 ],
 									"source" : [ "obj-28", 0 ]
 								}
 
@@ -3188,7 +3141,7 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-1", 0 ],
-									"midpoints" : [ 179.5, 447.0, 24.5, 447.0 ],
+									"midpoints" : [ 224.5, 435.0, 69.5, 435.0 ],
 									"source" : [ "obj-4", 0 ]
 								}
 
@@ -3196,7 +3149,7 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-1", 0 ],
-									"midpoints" : [ 24.5, 189.0, 24.5, 189.0 ],
+									"midpoints" : [ 69.5, 177.0, 69.5, 177.0 ],
 									"source" : [ "obj-5", 0 ]
 								}
 
@@ -3204,7 +3157,7 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-1", 0 ],
-									"midpoints" : [ 57.5, 447.0, 24.5, 447.0 ],
+									"midpoints" : [ 102.5, 435.0, 69.5, 435.0 ],
 									"source" : [ "obj-8", 0 ]
 								}
 
@@ -3328,29 +3281,8 @@
 									"numinlets" : 2,
 									"numoutlets" : 1,
 									"outlettype" : [ "int" ],
-									"patching_rect" : [ 213.5, 290.0, 78.0, 23.0 ],
+									"patching_rect" : [ 183.5, 220.0, 78.0, 23.0 ],
 									"text" : "random 100"
-								}
-
-							}
-, 							{
-								"box" : 								{
-									"args" : [ "dataset" ],
-									"bgmode" : 0,
-									"border" : 0,
-									"clickthrough" : 0,
-									"enablehscroll" : 0,
-									"enablevscroll" : 0,
-									"id" : "obj-3",
-									"lockeddragscroll" : 0,
-									"lockedsize" : 0,
-									"maxclass" : "bpatcher",
-									"name" : "fluid.learn.maxpat",
-									"numinlets" : 0,
-									"numoutlets" : 0,
-									"offset" : [ 0.0, 0.0 ],
-									"patching_rect" : [ 402.0, 11.0, 232.600000649690628, 109.0 ],
-									"viewvisibility" : 1
 								}
 
 							}
@@ -3366,7 +3298,7 @@
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
 									"parameter_enable" : 0,
-									"patching_rect" : [ 10.0, 10.0, 390.0, 110.0 ]
+									"patching_rect" : [ 10.0, 10.0, 290.0, 50.0 ]
 								}
 
 							}
@@ -3383,7 +3315,7 @@
 									"numoutlets" : 3,
 									"outlettype" : [ "", "", "int" ],
 									"parameter_enable" : 0,
-									"patching_rect" : [ 435.0, 152.5, 20.0, 20.0 ],
+									"patching_rect" : [ 405.0, 82.5, 20.0, 20.0 ],
 									"rounded" : 60.0,
 									"text" : "1",
 									"textcolor" : [ 0.34902, 0.34902, 0.34902, 1.0 ]
@@ -3397,7 +3329,7 @@
 									"maxclass" : "comment",
 									"numinlets" : 1,
 									"numoutlets" : 0,
-									"patching_rect" : [ 87.75, 150.0, 345.0, 25.0 ],
+									"patching_rect" : [ 57.75, 80.0, 345.0, 25.0 ],
 									"text" : "Generate random data to be stored in the fluid.dataset~"
 								}
 
@@ -3408,7 +3340,7 @@
 									"maxclass" : "dict.view",
 									"numinlets" : 1,
 									"numoutlets" : 0,
-									"patching_rect" : [ 236.75, 548.0, 162.875, 175.0 ]
+									"patching_rect" : [ 206.75, 478.0, 162.875, 175.0 ]
 								}
 
 							}
@@ -3419,7 +3351,7 @@
 									"numinlets" : 2,
 									"numoutlets" : 2,
 									"outlettype" : [ "", "" ],
-									"patching_rect" : [ 236.75, 518.0, 74.0, 23.0 ],
+									"patching_rect" : [ 206.75, 448.0, 74.0, 23.0 ],
 									"text" : "route dump"
 								}
 
@@ -3431,7 +3363,7 @@
 									"numinlets" : 1,
 									"numoutlets" : 2,
 									"outlettype" : [ "int", "bang" ],
-									"patching_rect" : [ 115.5, 260.0, 117.0, 23.0 ],
+									"patching_rect" : [ 85.5, 190.0, 117.0, 23.0 ],
 									"text" : "t i b"
 								}
 
@@ -3443,7 +3375,7 @@
 									"numinlets" : 2,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 115.5, 325.0, 117.0, 23.0 ],
+									"patching_rect" : [ 85.5, 255.0, 117.0, 23.0 ],
 									"text" : "sprintf entry-%i: %i"
 								}
 
@@ -3455,7 +3387,7 @@
 									"numinlets" : 2,
 									"numoutlets" : 3,
 									"outlettype" : [ "bang", "bang", "int" ],
-									"patching_rect" : [ 60.0, 225.0, 74.5, 23.0 ],
+									"patching_rect" : [ 30.0, 155.0, 74.5, 23.0 ],
 									"text" : "uzi 100"
 								}
 
@@ -3467,7 +3399,7 @@
 									"numinlets" : 2,
 									"numoutlets" : 1,
 									"outlettype" : [ "dictionary" ],
-									"patching_rect" : [ 87.75, 400.0, 130.0, 23.0 ],
+									"patching_rect" : [ 57.75, 330.0, 130.0, 23.0 ],
 									"text" : "dict.pack data: cols:1"
 								}
 
@@ -3479,7 +3411,7 @@
 									"numinlets" : 1,
 									"numoutlets" : 1,
 									"outlettype" : [ "dictionary" ],
-									"patching_rect" : [ 87.75, 360.0, 66.0, 23.0 ],
+									"patching_rect" : [ 57.75, 290.0, 66.0, 23.0 ],
 									"text" : "dict.group"
 								}
 
@@ -3492,7 +3424,7 @@
 									"numoutlets" : 1,
 									"outlettype" : [ "bang" ],
 									"parameter_enable" : 0,
-									"patching_rect" : [ 60.0, 150.0, 24.0, 24.0 ]
+									"patching_rect" : [ 30.0, 80.0, 24.0, 24.0 ]
 								}
 
 							}
@@ -3503,7 +3435,7 @@
 									"numinlets" : 1,
 									"numoutlets" : 2,
 									"outlettype" : [ "", "" ],
-									"patching_rect" : [ 159.5, 225.0, 168.0, 23.0 ],
+									"patching_rect" : [ 129.5, 155.0, 168.0, 23.0 ],
 									"text" : "fluid.dataset~ dictionary-fun"
 								}
 
@@ -3515,7 +3447,7 @@
 									"numinlets" : 1,
 									"numoutlets" : 2,
 									"outlettype" : [ "bang", "clear" ],
-									"patching_rect" : [ 60.0, 190.0, 118.5, 23.0 ],
+									"patching_rect" : [ 30.0, 120.0, 118.5, 23.0 ],
 									"text" : "t b clear"
 								}
 
@@ -3527,7 +3459,7 @@
 									"maxclass" : "comment",
 									"numinlets" : 1,
 									"numoutlets" : 0,
-									"patching_rect" : [ 470.0, 150.0, 207.0, 137.0 ],
+									"patching_rect" : [ 440.0, 80.0, 210.0, 137.0 ],
 									"text" : "You can construct the contents of a fluid.dataset~ programatically by creating a dictionary in the correct format before \"loading\" it into a dataset. In the example below, we will use random number generation to create a toy dataset by first loading the information into a dictionary.",
 									"textcolor" : [ 0.501960784313725, 0.501960784313725, 0.501960784313725, 1.0 ]
 								}
@@ -3540,7 +3472,7 @@
 									"numinlets" : 2,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 87.75, 440.0, 150.0, 23.0 ],
+									"patching_rect" : [ 57.75, 370.0, 150.0, 23.0 ],
 									"text" : "load dictionary $2, dump"
 								}
 
@@ -3552,7 +3484,7 @@
 									"numinlets" : 1,
 									"numoutlets" : 2,
 									"outlettype" : [ "", "" ],
-									"patching_rect" : [ 87.75, 485.0, 168.0, 23.0 ],
+									"patching_rect" : [ 57.75, 415.0, 168.0, 23.0 ],
 									"text" : "fluid.dataset~ dictionary-fun"
 								}
 
@@ -3568,7 +3500,7 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-70", 0 ],
-									"midpoints" : [ 125.0, 351.0, 97.25, 351.0 ],
+									"midpoints" : [ 95.0, 281.0, 67.25, 281.0 ],
 									"source" : [ "obj-102", 0 ]
 								}
 
@@ -3739,7 +3671,7 @@
 						}
 ,
 						"classnamespace" : "box",
-						"rect" : [ 35.0, 114.0, 995.0, 751.0 ],
+						"rect" : [ 0.0, 26.0, 995.0, 751.0 ],
 						"bglocked" : 0,
 						"openinpresentation" : 0,
 						"default_fontsize" : 13.0,
@@ -3942,7 +3874,7 @@
 									"maxclass" : "comment",
 									"numinlets" : 1,
 									"numoutlets" : 0,
-									"patching_rect" : [ 369.0, 370.5, 155.0, 50.0 ],
+									"patching_rect" : [ 369.0, 370.5, 159.0, 50.0 ],
 									"text" : "Will overwrite an existing point or create a new one if doesn't exist.",
 									"textcolor" : [ 0.501960784313725, 0.501960784313725, 0.501960784313725, 1.0 ]
 								}

--- a/help/fluid.grid~.maxhelp
+++ b/help/fluid.grid~.maxhelp
@@ -3,8 +3,8 @@
 		"fileversion" : 1,
 		"appversion" : 		{
 			"major" : 8,
-			"minor" : 2,
-			"revision" : 2,
+			"minor" : 3,
+			"revision" : 0,
 			"architecture" : "x64",
 			"modernui" : 1
 		}
@@ -50,14 +50,14 @@
 						"fileversion" : 1,
 						"appversion" : 						{
 							"major" : 8,
-							"minor" : 2,
-							"revision" : 2,
+							"minor" : 3,
+							"revision" : 0,
 							"architecture" : "x64",
 							"modernui" : 1
 						}
 ,
 						"classnamespace" : "box",
-						"rect" : [ 34.0, 113.0, 994.0, 753.0 ],
+						"rect" : [ 0.0, 26.0, 994.0, 753.0 ],
 						"bglocked" : 0,
 						"openinpresentation" : 0,
 						"default_fontsize" : 13.0,
@@ -88,22 +88,15 @@
 						"assistshowspatchername" : 0,
 						"boxes" : [ 							{
 								"box" : 								{
-									"args" : [ "grid" ],
-									"bgmode" : 0,
-									"border" : 0,
-									"clickthrough" : 0,
-									"enablehscroll" : 0,
-									"enablevscroll" : 0,
-									"id" : "obj-75",
-									"lockeddragscroll" : 0,
-									"lockedsize" : 0,
-									"maxclass" : "bpatcher",
-									"name" : "fluid.learn.maxpat",
-									"numinlets" : 0,
+									"id" : "obj-10",
+									"linecount" : 2,
+									"maxclass" : "comment",
+									"numinlets" : 1,
 									"numoutlets" : 0,
-									"offset" : [ -10.0, -8.0 ],
-									"patching_rect" : [ 390.0, 10.0, 240.0, 95.0 ],
-									"viewvisibility" : 1
+									"patching_rect" : [ 10.0, 62.0, 963.0, 36.0 ],
+									"presentation_linecount" : 11,
+									"text" : "Constraining the grid to an \"extent\" along either axis is possible. This means you can enforce the grid to have a certain dimensionality. Good for mapping sounds onto controllers!",
+									"textcolor" : [ 0.501960784313725, 0.501960784313725, 0.501960784313725, 1.0 ]
 								}
 
 							}
@@ -119,7 +112,7 @@
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
 									"parameter_enable" : 0,
-									"patching_rect" : [ 10.0, 10.0, 370.0, 100.0 ]
+									"patching_rect" : [ 10.0, 10.0, 220.0, 50.0 ]
 								}
 
 							}
@@ -129,7 +122,7 @@
 									"maxclass" : "comment",
 									"numinlets" : 1,
 									"numoutlets" : 0,
-									"patching_rect" : [ 733.0, 241.0, 50.0, 21.0 ],
+									"patching_rect" : [ 773.0, 231.0, 50.0, 21.0 ],
 									"text" : "extent",
 									"textcolor" : [ 0.501960784313725, 0.501960784313725, 0.501960784313725, 1.0 ]
 								}
@@ -141,7 +134,7 @@
 									"maxclass" : "newobj",
 									"numinlets" : 1,
 									"numoutlets" : 0,
-									"patching_rect" : [ 196.5, 275.0, 79.0, 23.0 ],
+									"patching_rect" : [ 236.5, 265.0, 79.0, 23.0 ],
 									"text" : "s help.grid.3"
 								}
 
@@ -153,7 +146,7 @@
 									"numinlets" : 1,
 									"numoutlets" : 3,
 									"outlettype" : [ "dump", "", "clear" ],
-									"patching_rect" : [ 10.0, 200.0, 206.0, 23.0 ],
+									"patching_rect" : [ 50.0, 190.0, 206.0, 23.0 ],
 									"text" : "t dump l clear"
 								}
 
@@ -165,7 +158,7 @@
 									"numinlets" : 2,
 									"numoutlets" : 2,
 									"outlettype" : [ "", "" ],
-									"patching_rect" : [ 10.0, 315.0, 74.0, 23.0 ],
+									"patching_rect" : [ 50.0, 305.0, 74.0, 23.0 ],
 									"text" : "route dump"
 								}
 
@@ -177,7 +170,7 @@
 									"numinlets" : 1,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 103.5, 235.0, 86.0, 23.0 ],
+									"patching_rect" : [ 143.5, 225.0, 86.0, 23.0 ],
 									"text" : "prepend read"
 								}
 
@@ -198,7 +191,7 @@
 									"numoutlets" : 1,
 									"offset" : [ 0.0, 0.0 ],
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 10.0, 120.0, 170.0, 67.0 ],
+									"patching_rect" : [ 50.0, 110.0, 170.0, 67.0 ],
 									"viewvisibility" : 1
 								}
 
@@ -210,7 +203,7 @@
 									"maxclass" : "comment",
 									"numinlets" : 1,
 									"numoutlets" : 0,
-									"patching_rect" : [ 280.0, 420.0, 122.0, 123.0 ],
+									"patching_rect" : [ 320.0, 410.0, 122.0, 123.0 ],
 									"text" : "The raw dataset is plotted here and each point is assigned a colour based on its position to create a smooth colour change spectrum",
 									"textcolor" : [ 0.501960784313725, 0.501960784313725, 0.501960784313725, 1.0 ]
 								}
@@ -229,7 +222,7 @@
 									"numoutlets" : 3,
 									"outlettype" : [ "", "", "int" ],
 									"parameter_enable" : 0,
-									"patching_rect" : [ 404.0, 122.5, 20.0, 20.0 ],
+									"patching_rect" : [ 444.0, 112.5, 20.0, 20.0 ],
 									"rounded" : 60.0,
 									"text" : "1",
 									"textcolor" : [ 0.34902, 0.34902, 0.34902, 1.0 ]
@@ -243,7 +236,7 @@
 									"maxclass" : "comment",
 									"numinlets" : 1,
 									"numoutlets" : 0,
-									"patching_rect" : [ 182.0, 120.0, 220.0, 25.0 ],
+									"patching_rect" : [ 222.0, 110.0, 220.0, 25.0 ],
 									"text" : "Select a premade dataset to load."
 								}
 
@@ -254,7 +247,7 @@
 									"maxclass" : "newobj",
 									"numinlets" : 1,
 									"numoutlets" : 0,
-									"patching_rect" : [ 30.0, 385.0, 79.0, 23.0 ],
+									"patching_rect" : [ 70.0, 375.0, 79.0, 23.0 ],
 									"text" : "s help.grid.3"
 								}
 
@@ -266,7 +259,7 @@
 									"numinlets" : 0,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 256.0, 385.0, 77.0, 23.0 ],
+									"patching_rect" : [ 296.0, 375.0, 77.0, 23.0 ],
 									"text" : "r help.grid.3"
 								}
 
@@ -282,8 +275,8 @@
 										"fileversion" : 1,
 										"appversion" : 										{
 											"major" : 8,
-											"minor" : 2,
-											"revision" : 2,
+											"minor" : 3,
+											"revision" : 0,
 											"architecture" : "x64",
 											"modernui" : 1
 										}
@@ -535,13 +528,13 @@
 												"name" : "max6message",
 												"default" : 												{
 													"bgfillcolor" : 													{
-														"type" : "gradient",
+														"angle" : 270.0,
+														"autogradient" : 0,
+														"color" : [ 0.290196, 0.309804, 0.301961, 1.0 ],
 														"color1" : [ 0.866667, 0.866667, 0.866667, 1.0 ],
 														"color2" : [ 0.788235, 0.788235, 0.788235, 1.0 ],
-														"color" : [ 0.290196, 0.309804, 0.301961, 1.0 ],
-														"angle" : 270.0,
 														"proportion" : 0.39,
-														"autogradient" : 0
+														"type" : "gradient"
 													}
 ,
 													"textcolor_inverse" : [ 0.0, 0.0, 0.0, 1.0 ]
@@ -562,7 +555,7 @@
  ]
 									}
 ,
-									"patching_rect" : [ 30.0, 355.0, 157.0, 23.0 ],
+									"patching_rect" : [ 70.0, 345.0, 157.0, 23.0 ],
 									"saved_object_attributes" : 									{
 										"description" : "",
 										"digest" : "",
@@ -579,9 +572,9 @@
 									"id" : "obj-69",
 									"maxclass" : "newobj",
 									"numinlets" : 1,
-									"numoutlets" : 3,
-									"outlettype" : [ "bang", "float", "" ],
-									"patching_rect" : [ 10.0, 275.0, 182.0, 23.0 ],
+									"numoutlets" : 2,
+									"outlettype" : [ "", "" ],
+									"patching_rect" : [ 50.0, 265.0, 182.0, 23.0 ],
 									"text" : "fluid.dataset~ help.grid.3.input"
 								}
 
@@ -592,10 +585,10 @@
 									"id" : "obj-3",
 									"maxclass" : "jsui",
 									"numinlets" : 2,
-									"numoutlets" : 1,
-									"outlettype" : [ "" ],
+									"numoutlets" : 2,
+									"outlettype" : [ "", "" ],
 									"parameter_enable" : 0,
-									"patching_rect" : [ 10.0, 420.0, 265.0, 265.0 ]
+									"patching_rect" : [ 50.0, 410.0, 265.0, 265.0 ]
 								}
 
 							}
@@ -605,7 +598,7 @@
 									"maxclass" : "comment",
 									"numinlets" : 1,
 									"numoutlets" : 0,
-									"patching_rect" : [ 690.0, 207.0, 50.0, 21.0 ],
+									"patching_rect" : [ 730.0, 197.0, 50.0, 21.0 ],
 									"text" : "vertical",
 									"textcolor" : [ 0.501960784313725, 0.501960784313725, 0.501960784313725, 1.0 ]
 								}
@@ -617,7 +610,7 @@
 									"maxclass" : "comment",
 									"numinlets" : 1,
 									"numoutlets" : 0,
-									"patching_rect" : [ 666.0, 170.0, 65.0, 21.0 ],
+									"patching_rect" : [ 706.0, 160.0, 65.0, 21.0 ],
 									"text" : "horizontal",
 									"textcolor" : [ 0.501960784313725, 0.501960784313725, 0.501960784313725, 1.0 ]
 								}
@@ -631,7 +624,7 @@
 									"numoutlets" : 2,
 									"outlettype" : [ "", "bang" ],
 									"parameter_enable" : 0,
-									"patching_rect" : [ 679.5, 240.0, 50.0, 23.0 ]
+									"patching_rect" : [ 719.5, 230.0, 50.0, 23.0 ]
 								}
 
 							}
@@ -642,7 +635,7 @@
 									"numinlets" : 2,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 679.5, 275.0, 62.0, 23.0 ],
+									"patching_rect" : [ 719.5, 265.0, 62.0, 23.0 ],
 									"text" : "extent $1"
 								}
 
@@ -654,7 +647,7 @@
 									"numinlets" : 2,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 645.0, 207.0, 42.0, 23.0 ],
+									"patching_rect" : [ 685.0, 197.0, 42.0, 23.0 ],
 									"text" : "axis 1"
 								}
 
@@ -666,7 +659,7 @@
 									"numinlets" : 1,
 									"numoutlets" : 2,
 									"outlettype" : [ "bang", "" ],
-									"patching_rect" : [ 618.5, 325.0, 29.5, 23.0 ],
+									"patching_rect" : [ 658.5, 315.0, 29.5, 23.0 ],
 									"text" : "t b l"
 								}
 
@@ -679,7 +672,7 @@
 									"maxclass" : "comment",
 									"numinlets" : 1,
 									"numoutlets" : 0,
-									"patching_rect" : [ 690.0, 430.0, 233.0, 181.0 ],
+									"patching_rect" : [ 730.0, 420.0, 233.0, 181.0 ],
 									"text" : "The extent attribute constrains the dimensions of the selected axis when the grid is created. When the value is 0, the constraints are disabled.\n\nThis allows you to control how points are compacted and arranged in the grid output, facilitating distinct arrangements of points in lines of varying density and uniformity. \n\n",
 									"textcolor" : [ 0.501960784313725, 0.501960784313725, 0.501960784313725, 1.0 ]
 								}
@@ -698,7 +691,7 @@
 									"numoutlets" : 3,
 									"outlettype" : [ "", "", "int" ],
 									"parameter_enable" : 0,
-									"patching_rect" : [ 390.0, 170.0, 20.0, 20.0 ],
+									"patching_rect" : [ 430.0, 160.0, 20.0, 20.0 ],
 									"rounded" : 60.0,
 									"text" : "2",
 									"textcolor" : [ 0.34902, 0.34902, 0.34902, 1.0 ]
@@ -714,7 +707,7 @@
 									"maxclass" : "comment",
 									"numinlets" : 1,
 									"numoutlets" : 0,
-									"patching_rect" : [ 420.0, 161.5, 197.0, 40.0 ],
+									"patching_rect" : [ 460.0, 151.5, 197.0, 40.0 ],
 									"text" : "Experiment by changing both the axis and extent attributes."
 								}
 
@@ -726,7 +719,7 @@
 									"numinlets" : 2,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 618.5, 170.0, 42.0, 23.0 ],
+									"patching_rect" : [ 658.5, 160.0, 42.0, 23.0 ],
 									"text" : "axis 0"
 								}
 
@@ -738,7 +731,7 @@
 									"numinlets" : 0,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 666.0, 375.0, 77.0, 23.0 ],
+									"patching_rect" : [ 706.0, 365.0, 77.0, 23.0 ],
 									"text" : "r help.grid.3"
 								}
 
@@ -754,8 +747,8 @@
 										"fileversion" : 1,
 										"appversion" : 										{
 											"major" : 8,
-											"minor" : 2,
-											"revision" : 2,
+											"minor" : 3,
+											"revision" : 0,
 											"architecture" : "x64",
 											"modernui" : 1
 										}
@@ -794,9 +787,9 @@
 													"id" : "obj-32",
 													"maxclass" : "newobj",
 													"numinlets" : 1,
-													"numoutlets" : 3,
-													"outlettype" : [ "bang", "float", "" ],
-													"patching_rect" : [ 171.0, 108.0, 176.0, 22.0 ],
+													"numoutlets" : 2,
+													"outlettype" : [ "", "" ],
+													"patching_rect" : [ 129.0, 106.0, 176.0, 22.0 ],
 													"text" : "fluid.dataset~ help.grid.3.output"
 												}
 
@@ -808,7 +801,7 @@
 													"numinlets" : 2,
 													"numoutlets" : 1,
 													"outlettype" : [ "" ],
-													"patching_rect" : [ 247.0, 255.0, 39.0, 22.0 ],
+													"patching_rect" : [ 18.0, 250.0, 39.0, 22.0 ],
 													"text" : "dump"
 												}
 
@@ -820,7 +813,7 @@
 													"numinlets" : 2,
 													"numoutlets" : 2,
 													"outlettype" : [ "", "" ],
-													"patching_rect" : [ 247.0, 220.0, 99.0, 22.0 ],
+													"patching_rect" : [ 18.0, 215.0, 99.0, 22.0 ],
 													"text" : "route fittransform"
 												}
 
@@ -832,7 +825,7 @@
 													"numinlets" : 2,
 													"numoutlets" : 1,
 													"outlettype" : [ "" ],
-													"patching_rect" : [ 60.0, 148.0, 288.0, 22.0 ],
+													"patching_rect" : [ 18.0, 146.0, 288.0, 22.0 ],
 													"text" : "fittransform help.grid.3.output help.grid.3.normoutput"
 												}
 
@@ -842,9 +835,9 @@
 													"id" : "obj-24",
 													"maxclass" : "newobj",
 													"numinlets" : 1,
-													"numoutlets" : 3,
-													"outlettype" : [ "bang", "float", "" ],
-													"patching_rect" : [ 60.0, 183.0, 206.0, 22.0 ],
+													"numoutlets" : 2,
+													"outlettype" : [ "", "" ],
+													"patching_rect" : [ 18.0, 181.0, 206.0, 22.0 ],
 													"text" : "fluid.normalize~ @min 0.1 @max 0.9"
 												}
 
@@ -856,7 +849,7 @@
 													"numinlets" : 2,
 													"numoutlets" : 2,
 													"outlettype" : [ "", "" ],
-													"patching_rect" : [ 60.0, 108.0, 99.0, 22.0 ],
+													"patching_rect" : [ 18.0, 106.0, 99.0, 22.0 ],
 													"text" : "route fittransform"
 												}
 
@@ -866,8 +859,8 @@
 													"id" : "obj-17",
 													"maxclass" : "newobj",
 													"numinlets" : 1,
-													"numoutlets" : 3,
-													"outlettype" : [ "bang", "float", "" ],
+													"numoutlets" : 2,
+													"outlettype" : [ "", "" ],
 													"patching_rect" : [ 18.0, 73.0, 61.0, 22.0 ],
 													"text" : "fluid.grid~"
 												}
@@ -880,7 +873,7 @@
 													"numinlets" : 2,
 													"numoutlets" : 2,
 													"outlettype" : [ "", "" ],
-													"patching_rect" : [ 432.0, 321.0, 69.0, 22.0 ],
+													"patching_rect" : [ 203.0, 316.0, 69.0, 22.0 ],
 													"text" : "route dump"
 												}
 
@@ -890,9 +883,9 @@
 													"id" : "obj-15",
 													"maxclass" : "newobj",
 													"numinlets" : 1,
-													"numoutlets" : 3,
-													"outlettype" : [ "bang", "float", "" ],
-													"patching_rect" : [ 247.0, 290.0, 204.0, 22.0 ],
+													"numoutlets" : 2,
+													"outlettype" : [ "", "" ],
+													"patching_rect" : [ 18.0, 285.0, 204.0, 22.0 ],
 													"text" : "fluid.dataset~ help.grid.3.normoutput"
 												}
 
@@ -918,31 +911,12 @@
 													"maxclass" : "outlet",
 													"numinlets" : 1,
 													"numoutlets" : 0,
-													"patching_rect" : [ 432.0, 353.0, 30.0, 30.0 ]
-												}
-
-											}
-, 											{
-												"box" : 												{
-													"attr" : "axis",
-													"id" : "obj-1",
-													"maxclass" : "attrui",
-													"numinlets" : 1,
-													"numoutlets" : 1,
-													"outlettype" : [ "" ],
-													"patching_rect" : [ 51.0, 43.0, 150.0, 22.0 ]
+													"patching_rect" : [ 203.0, 348.0, 30.0, 30.0 ]
 												}
 
 											}
  ],
 										"lines" : [ 											{
-												"patchline" : 												{
-													"destination" : [ "obj-17", 0 ],
-													"source" : [ "obj-1", 0 ]
-												}
-
-											}
-, 											{
 												"patchline" : 												{
 													"destination" : [ "obj-34", 0 ],
 													"source" : [ "obj-13", 0 ]
@@ -952,14 +926,14 @@
 , 											{
 												"patchline" : 												{
 													"destination" : [ "obj-13", 0 ],
-													"source" : [ "obj-15", 2 ]
+													"source" : [ "obj-15", 1 ]
 												}
 
 											}
 , 											{
 												"patchline" : 												{
 													"destination" : [ "obj-20", 0 ],
-													"source" : [ "obj-17", 2 ]
+													"source" : [ "obj-17", 0 ]
 												}
 
 											}
@@ -973,7 +947,7 @@
 , 											{
 												"patchline" : 												{
 													"destination" : [ "obj-29", 0 ],
-													"source" : [ "obj-24", 2 ]
+													"source" : [ "obj-24", 0 ]
 												}
 
 											}
@@ -1008,7 +982,7 @@
  ]
 									}
 ,
-									"patching_rect" : [ 420.0, 375.0, 123.0, 23.0 ],
+									"patching_rect" : [ 460.0, 365.0, 123.0, 23.0 ],
 									"saved_object_attributes" : 									{
 										"description" : "",
 										"digest" : "",
@@ -1028,7 +1002,7 @@
 									"numinlets" : 2,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 420.0, 295.0, 123.0, 52.0 ],
+									"patching_rect" : [ 460.0, 285.0, 123.0, 52.0 ],
 									"text" : "fittransform help.grid.3.input help.grid.3.output"
 								}
 
@@ -1039,10 +1013,10 @@
 									"id" : "obj-16",
 									"maxclass" : "jsui",
 									"numinlets" : 2,
-									"numoutlets" : 1,
-									"outlettype" : [ "" ],
+									"numoutlets" : 2,
+									"outlettype" : [ "", "" ],
 									"parameter_enable" : 0,
-									"patching_rect" : [ 420.0, 420.0, 265.0, 265.0 ]
+									"patching_rect" : [ 460.0, 410.0, 265.0, 265.0 ]
 								}
 
 							}
@@ -1050,7 +1024,7 @@
 						"lines" : [ 							{
 								"patchline" : 								{
 									"destination" : [ "obj-69", 0 ],
-									"midpoints" : [ 113.0, 266.0, 19.5, 266.0 ],
+									"midpoints" : [ 153.0, 256.0, 59.5, 256.0 ],
 									"source" : [ "obj-1", 0 ]
 								}
 
@@ -1058,7 +1032,7 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-112", 0 ],
-									"midpoints" : [ 39.5, 378.0, 39.5, 378.0 ],
+									"midpoints" : [ 79.5, 368.0, 79.5, 368.0 ],
 									"source" : [ "obj-108", 0 ]
 								}
 
@@ -1066,7 +1040,7 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-24", 0 ],
-									"midpoints" : [ 689.0, 312.0, 628.0, 312.0 ],
+									"midpoints" : [ 729.0, 302.0, 668.0, 302.0 ],
 									"source" : [ "obj-11", 0 ]
 								}
 
@@ -1095,7 +1069,7 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-108", 0 ],
-									"midpoints" : [ 19.5, 348.0, 39.5, 348.0 ],
+									"midpoints" : [ 59.5, 338.0, 79.5, 338.0 ],
 									"order" : 0,
 									"source" : [ "obj-18", 0 ]
 								}
@@ -1104,7 +1078,7 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-3", 0 ],
-									"midpoints" : [ 19.5, 339.0, 19.5, 339.0 ],
+									"midpoints" : [ 59.5, 329.0, 59.5, 329.0 ],
 									"order" : 1,
 									"source" : [ "obj-18", 0 ]
 								}
@@ -1113,7 +1087,7 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-35", 0 ],
-									"midpoints" : [ 429.5, 361.0, 429.5, 361.0 ],
+									"midpoints" : [ 469.5, 351.0, 469.5, 351.0 ],
 									"source" : [ "obj-19", 0 ]
 								}
 
@@ -1135,7 +1109,7 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-69", 0 ],
-									"midpoints" : [ 19.5, 225.0, 19.5, 225.0 ],
+									"midpoints" : [ 59.5, 215.0, 59.5, 215.0 ],
 									"source" : [ "obj-20", 0 ]
 								}
 
@@ -1143,7 +1117,7 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-19", 0 ],
-									"midpoints" : [ 628.0, 362.0, 406.0, 362.0, 406.0, 282.0, 429.5, 282.0 ],
+									"midpoints" : [ 668.0, 352.0, 446.0, 352.0, 446.0, 272.0, 469.5, 272.0 ],
 									"source" : [ "obj-24", 0 ]
 								}
 
@@ -1151,7 +1125,7 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-35", 0 ],
-									"midpoints" : [ 638.5, 362.0, 429.5, 362.0 ],
+									"midpoints" : [ 678.5, 352.0, 469.5, 352.0 ],
 									"source" : [ "obj-24", 1 ]
 								}
 
@@ -1166,7 +1140,7 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-24", 0 ],
-									"midpoints" : [ 628.0, 195.0, 628.0, 195.0 ],
+									"midpoints" : [ 668.0, 185.0, 668.0, 185.0 ],
 									"source" : [ "obj-4", 0 ]
 								}
 
@@ -1181,15 +1155,15 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-18", 0 ],
-									"midpoints" : [ 182.5, 309.0, 19.5, 309.0 ],
-									"source" : [ "obj-69", 2 ]
+									"midpoints" : [ 222.5, 296.0, 59.5, 296.0 ],
+									"source" : [ "obj-69", 1 ]
 								}
 
 							}
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-24", 0 ],
-									"midpoints" : [ 654.5, 312.0, 628.0, 312.0 ],
+									"midpoints" : [ 694.5, 302.0, 668.0, 302.0 ],
 									"source" : [ "obj-8", 0 ]
 								}
 
@@ -1219,13 +1193,13 @@
 								"name" : "max6message",
 								"default" : 								{
 									"bgfillcolor" : 									{
-										"type" : "gradient",
+										"angle" : 270.0,
+										"autogradient" : 0,
+										"color" : [ 0.290196, 0.309804, 0.301961, 1.0 ],
 										"color1" : [ 0.866667, 0.866667, 0.866667, 1.0 ],
 										"color2" : [ 0.788235, 0.788235, 0.788235, 1.0 ],
-										"color" : [ 0.290196, 0.309804, 0.301961, 1.0 ],
-										"angle" : 270.0,
 										"proportion" : 0.39,
-										"autogradient" : 0
+										"type" : "gradient"
 									}
 ,
 									"textcolor_inverse" : [ 0.0, 0.0, 0.0, 1.0 ]
@@ -1270,14 +1244,14 @@
 						"fileversion" : 1,
 						"appversion" : 						{
 							"major" : 8,
-							"minor" : 2,
-							"revision" : 2,
+							"minor" : 3,
+							"revision" : 0,
 							"architecture" : "x64",
 							"modernui" : 1
 						}
 ,
 						"classnamespace" : "box",
-						"rect" : [ 0.0, 26.0, 994.0, 753.0 ],
+						"rect" : [ 34.0, 113.0, 994.0, 753.0 ],
 						"bglocked" : 0,
 						"openinpresentation" : 0,
 						"default_fontsize" : 13.0,
@@ -1308,22 +1282,14 @@
 						"assistshowspatchername" : 0,
 						"boxes" : [ 							{
 								"box" : 								{
-									"args" : [ "grid" ],
-									"bgmode" : 0,
-									"border" : 0,
-									"clickthrough" : 0,
-									"enablehscroll" : 0,
-									"enablevscroll" : 0,
-									"id" : "obj-75",
-									"lockeddragscroll" : 0,
-									"lockedsize" : 0,
-									"maxclass" : "bpatcher",
-									"name" : "fluid.learn.maxpat",
-									"numinlets" : 0,
+									"id" : "obj-10",
+									"maxclass" : "comment",
+									"numinlets" : 1,
 									"numoutlets" : 0,
-									"offset" : [ -10.0, -8.0 ],
-									"patching_rect" : [ 390.0, 10.0, 240.0, 95.0 ],
-									"viewvisibility" : 1
+									"patching_rect" : [ 10.0, 62.0, 757.0, 21.0 ],
+									"presentation_linecount" : 8,
+									"text" : "fluid.grid~ attemps to create a square grid from the input data. You can change the \"resolution\" of the target grid with oversampling",
+									"textcolor" : [ 0.501960784313725, 0.501960784313725, 0.501960784313725, 1.0 ]
 								}
 
 							}
@@ -1339,7 +1305,7 @@
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
 									"parameter_enable" : 0,
-									"patching_rect" : [ 10.0, 10.0, 370.0, 100.0 ]
+									"patching_rect" : [ 10.0, 10.0, 220.0, 50.0 ]
 								}
 
 							}
@@ -1349,7 +1315,7 @@
 									"maxclass" : "newobj",
 									"numinlets" : 1,
 									"numoutlets" : 0,
-									"patching_rect" : [ 196.5, 275.0, 79.0, 23.0 ],
+									"patching_rect" : [ 246.5, 265.0, 79.0, 23.0 ],
 									"text" : "s help.grid.2"
 								}
 
@@ -1361,7 +1327,7 @@
 									"numinlets" : 1,
 									"numoutlets" : 3,
 									"outlettype" : [ "dump", "", "clear" ],
-									"patching_rect" : [ 10.0, 200.0, 206.0, 23.0 ],
+									"patching_rect" : [ 60.0, 190.0, 206.0, 23.0 ],
 									"text" : "t dump l clear"
 								}
 
@@ -1373,7 +1339,7 @@
 									"numinlets" : 2,
 									"numoutlets" : 2,
 									"outlettype" : [ "", "" ],
-									"patching_rect" : [ 10.0, 315.0, 74.0, 23.0 ],
+									"patching_rect" : [ 60.0, 305.0, 74.0, 23.0 ],
 									"text" : "route dump"
 								}
 
@@ -1385,7 +1351,7 @@
 									"numinlets" : 1,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 103.5, 235.0, 86.0, 23.0 ],
+									"patching_rect" : [ 153.5, 225.0, 86.0, 23.0 ],
 									"text" : "prepend read"
 								}
 
@@ -1406,7 +1372,7 @@
 									"numoutlets" : 1,
 									"offset" : [ 0.0, 0.0 ],
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 10.0, 120.0, 170.0, 67.0 ],
+									"patching_rect" : [ 60.0, 110.0, 170.0, 67.0 ],
 									"viewvisibility" : 1
 								}
 
@@ -1418,7 +1384,7 @@
 									"maxclass" : "comment",
 									"numinlets" : 1,
 									"numoutlets" : 0,
-									"patching_rect" : [ 280.0, 420.0, 122.0, 123.0 ],
+									"patching_rect" : [ 330.0, 410.0, 122.0, 123.0 ],
 									"text" : "The raw dataset is plotted here and each point is assigned a colour based on its position to create a smooth colour change spectrum",
 									"textcolor" : [ 0.501960784313725, 0.501960784313725, 0.501960784313725, 1.0 ]
 								}
@@ -1437,7 +1403,7 @@
 									"numoutlets" : 3,
 									"outlettype" : [ "", "", "int" ],
 									"parameter_enable" : 0,
-									"patching_rect" : [ 404.0, 122.5, 20.0, 20.0 ],
+									"patching_rect" : [ 454.0, 112.5, 20.0, 20.0 ],
 									"rounded" : 60.0,
 									"text" : "1",
 									"textcolor" : [ 0.34902, 0.34902, 0.34902, 1.0 ]
@@ -1451,7 +1417,7 @@
 									"maxclass" : "comment",
 									"numinlets" : 1,
 									"numoutlets" : 0,
-									"patching_rect" : [ 182.0, 120.0, 220.0, 25.0 ],
+									"patching_rect" : [ 232.0, 110.0, 220.0, 25.0 ],
 									"text" : "Select a premade dataset to load."
 								}
 
@@ -1462,7 +1428,7 @@
 									"maxclass" : "newobj",
 									"numinlets" : 1,
 									"numoutlets" : 0,
-									"patching_rect" : [ 30.0, 385.0, 79.0, 23.0 ],
+									"patching_rect" : [ 80.0, 375.0, 79.0, 23.0 ],
 									"text" : "s help.grid.2"
 								}
 
@@ -1474,7 +1440,7 @@
 									"numinlets" : 0,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 256.0, 385.0, 77.0, 23.0 ],
+									"patching_rect" : [ 306.0, 375.0, 77.0, 23.0 ],
 									"text" : "r help.grid.2"
 								}
 
@@ -1490,8 +1456,8 @@
 										"fileversion" : 1,
 										"appversion" : 										{
 											"major" : 8,
-											"minor" : 2,
-											"revision" : 2,
+											"minor" : 3,
+											"revision" : 0,
 											"architecture" : "x64",
 											"modernui" : 1
 										}
@@ -1743,13 +1709,13 @@
 												"name" : "max6message",
 												"default" : 												{
 													"bgfillcolor" : 													{
-														"type" : "gradient",
+														"angle" : 270.0,
+														"autogradient" : 0,
+														"color" : [ 0.290196, 0.309804, 0.301961, 1.0 ],
 														"color1" : [ 0.866667, 0.866667, 0.866667, 1.0 ],
 														"color2" : [ 0.788235, 0.788235, 0.788235, 1.0 ],
-														"color" : [ 0.290196, 0.309804, 0.301961, 1.0 ],
-														"angle" : 270.0,
 														"proportion" : 0.39,
-														"autogradient" : 0
+														"type" : "gradient"
 													}
 ,
 													"textcolor_inverse" : [ 0.0, 0.0, 0.0, 1.0 ]
@@ -1770,7 +1736,7 @@
  ]
 									}
 ,
-									"patching_rect" : [ 30.0, 355.0, 157.0, 23.0 ],
+									"patching_rect" : [ 80.0, 345.0, 157.0, 23.0 ],
 									"saved_object_attributes" : 									{
 										"description" : "",
 										"digest" : "",
@@ -1787,9 +1753,9 @@
 									"id" : "obj-69",
 									"maxclass" : "newobj",
 									"numinlets" : 1,
-									"numoutlets" : 3,
-									"outlettype" : [ "bang", "float", "" ],
-									"patching_rect" : [ 10.0, 275.0, 182.0, 23.0 ],
+									"numoutlets" : 2,
+									"outlettype" : [ "", "" ],
+									"patching_rect" : [ 60.0, 265.0, 182.0, 23.0 ],
 									"text" : "fluid.dataset~ help.grid.2.input"
 								}
 
@@ -1800,10 +1766,10 @@
 									"id" : "obj-3",
 									"maxclass" : "jsui",
 									"numinlets" : 2,
-									"numoutlets" : 1,
-									"outlettype" : [ "" ],
+									"numoutlets" : 2,
+									"outlettype" : [ "", "" ],
 									"parameter_enable" : 0,
-									"patching_rect" : [ 10.0, 420.0, 265.0, 265.0 ]
+									"patching_rect" : [ 60.0, 410.0, 265.0, 265.0 ]
 								}
 
 							}
@@ -1814,7 +1780,7 @@
 									"numinlets" : 1,
 									"numoutlets" : 2,
 									"outlettype" : [ "bang", "" ],
-									"patching_rect" : [ 690.0, 330.0, 29.5, 23.0 ],
+									"patching_rect" : [ 740.0, 320.0, 29.5, 23.0 ],
 									"text" : "t b l"
 								}
 
@@ -1829,7 +1795,7 @@
 									"numoutlets" : 2,
 									"outlettype" : [ "", "bang" ],
 									"parameter_enable" : 0,
-									"patching_rect" : [ 690.0, 260.0, 50.0, 23.0 ]
+									"patching_rect" : [ 740.0, 250.0, 50.0, 23.0 ]
 								}
 
 							}
@@ -1841,7 +1807,7 @@
 									"maxclass" : "comment",
 									"numinlets" : 1,
 									"numoutlets" : 0,
-									"patching_rect" : [ 680.0, 430.0, 233.0, 195.0 ],
+									"patching_rect" : [ 730.0, 420.0, 233.0, 195.0 ],
 									"text" : "As the grid oversamples the original shape of the space is preseved. This gives you a flexible control over how \"gridded\" the result is.\n\nIt is important to remember that oversampling changes the dimensions of the grid too as it essentially is a control of resolution.\n\nIn this instance the changes in shape of the output are overcome by normalising the space.",
 									"textcolor" : [ 0.501960784313725, 0.501960784313725, 0.501960784313725, 1.0 ]
 								}
@@ -1860,7 +1826,7 @@
 									"numoutlets" : 3,
 									"outlettype" : [ "", "", "int" ],
 									"parameter_enable" : 0,
-									"patching_rect" : [ 410.0, 261.5, 20.0, 20.0 ],
+									"patching_rect" : [ 460.0, 251.5, 20.0, 20.0 ],
 									"rounded" : 60.0,
 									"text" : "2",
 									"textcolor" : [ 0.34902, 0.34902, 0.34902, 1.0 ]
@@ -1876,7 +1842,7 @@
 									"maxclass" : "comment",
 									"numinlets" : 1,
 									"numoutlets" : 0,
-									"patching_rect" : [ 434.0, 251.5, 250.0, 40.0 ],
+									"patching_rect" : [ 484.0, 241.5, 250.0, 40.0 ],
 									"text" : "Experiment with transformations and modifying the oversampling factor."
 								}
 
@@ -1888,7 +1854,7 @@
 									"numinlets" : 2,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 690.0, 298.0, 94.0, 23.0 ],
+									"patching_rect" : [ 740.0, 288.0, 94.0, 23.0 ],
 									"text" : "oversample $1"
 								}
 
@@ -1900,7 +1866,7 @@
 									"numinlets" : 0,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 656.0, 380.0, 77.0, 23.0 ],
+									"patching_rect" : [ 706.0, 370.0, 77.0, 23.0 ],
 									"text" : "r help.grid.2"
 								}
 
@@ -1916,8 +1882,8 @@
 										"fileversion" : 1,
 										"appversion" : 										{
 											"major" : 8,
-											"minor" : 2,
-											"revision" : 2,
+											"minor" : 3,
+											"revision" : 0,
 											"architecture" : "x64",
 											"modernui" : 1
 										}
@@ -1956,8 +1922,8 @@
 													"id" : "obj-32",
 													"maxclass" : "newobj",
 													"numinlets" : 1,
-													"numoutlets" : 3,
-													"outlettype" : [ "bang", "float", "" ],
+													"numoutlets" : 2,
+													"outlettype" : [ "", "" ],
 													"patching_rect" : [ 171.0, 108.0, 176.0, 22.0 ],
 													"text" : "fluid.dataset~ help.grid.2.output"
 												}
@@ -2004,8 +1970,8 @@
 													"id" : "obj-24",
 													"maxclass" : "newobj",
 													"numinlets" : 1,
-													"numoutlets" : 3,
-													"outlettype" : [ "bang", "float", "" ],
+													"numoutlets" : 2,
+													"outlettype" : [ "", "" ],
 													"patching_rect" : [ 60.0, 183.0, 206.0, 22.0 ],
 													"text" : "fluid.normalize~ @min 0.1 @max 0.9"
 												}
@@ -2028,8 +1994,8 @@
 													"id" : "obj-17",
 													"maxclass" : "newobj",
 													"numinlets" : 1,
-													"numoutlets" : 3,
-													"outlettype" : [ "bang", "float", "" ],
+													"numoutlets" : 2,
+													"outlettype" : [ "", "" ],
 													"patching_rect" : [ 18.0, 73.0, 61.0, 22.0 ],
 													"text" : "fluid.grid~"
 												}
@@ -2052,8 +2018,8 @@
 													"id" : "obj-15",
 													"maxclass" : "newobj",
 													"numinlets" : 1,
-													"numoutlets" : 3,
-													"outlettype" : [ "bang", "float", "" ],
+													"numoutlets" : 2,
+													"outlettype" : [ "", "" ],
 													"patching_rect" : [ 247.0, 290.0, 204.0, 22.0 ],
 													"text" : "fluid.dataset~ help.grid.2.normoutput"
 												}
@@ -2094,29 +2060,8 @@
 											}
 , 											{
 												"patchline" : 												{
-													"destination" : [ "obj-13", 0 ],
-													"source" : [ "obj-15", 2 ]
-												}
-
-											}
-, 											{
-												"patchline" : 												{
-													"destination" : [ "obj-20", 0 ],
-													"source" : [ "obj-17", 2 ]
-												}
-
-											}
-, 											{
-												"patchline" : 												{
 													"destination" : [ "obj-28", 0 ],
 													"source" : [ "obj-20", 0 ]
-												}
-
-											}
-, 											{
-												"patchline" : 												{
-													"destination" : [ "obj-29", 0 ],
-													"source" : [ "obj-24", 2 ]
 												}
 
 											}
@@ -2151,7 +2096,7 @@
  ]
 									}
 ,
-									"patching_rect" : [ 410.0, 380.0, 123.0, 23.0 ],
+									"patching_rect" : [ 460.0, 370.0, 123.0, 23.0 ],
 									"saved_object_attributes" : 									{
 										"description" : "",
 										"digest" : "",
@@ -2170,7 +2115,7 @@
 									"numinlets" : 2,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 410.0, 330.0, 274.0, 23.0 ],
+									"patching_rect" : [ 460.0, 320.0, 274.0, 23.0 ],
 									"text" : "fittransform help.grid.2.input help.grid.2.output"
 								}
 
@@ -2181,10 +2126,10 @@
 									"id" : "obj-16",
 									"maxclass" : "jsui",
 									"numinlets" : 2,
-									"numoutlets" : 1,
-									"outlettype" : [ "" ],
+									"numoutlets" : 2,
+									"outlettype" : [ "", "" ],
 									"parameter_enable" : 0,
-									"patching_rect" : [ 410.0, 420.0, 265.0, 265.0 ]
+									"patching_rect" : [ 460.0, 410.0, 265.0, 265.0 ]
 								}
 
 							}
@@ -2192,7 +2137,7 @@
 						"lines" : [ 							{
 								"patchline" : 								{
 									"destination" : [ "obj-69", 0 ],
-									"midpoints" : [ 113.0, 266.0, 19.5, 266.0 ],
+									"midpoints" : [ 163.0, 256.0, 69.5, 256.0 ],
 									"source" : [ "obj-1", 0 ]
 								}
 
@@ -2200,7 +2145,7 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-112", 0 ],
-									"midpoints" : [ 39.5, 378.0, 39.5, 378.0 ],
+									"midpoints" : [ 89.5, 368.0, 89.5, 368.0 ],
 									"source" : [ "obj-108", 0 ]
 								}
 
@@ -2222,7 +2167,7 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-108", 0 ],
-									"midpoints" : [ 19.5, 348.0, 39.5, 348.0 ],
+									"midpoints" : [ 69.5, 338.0, 89.5, 338.0 ],
 									"order" : 0,
 									"source" : [ "obj-18", 0 ]
 								}
@@ -2231,7 +2176,7 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-3", 0 ],
-									"midpoints" : [ 19.5, 339.0, 19.5, 339.0 ],
+									"midpoints" : [ 69.5, 329.0, 69.5, 329.0 ],
 									"order" : 1,
 									"source" : [ "obj-18", 0 ]
 								}
@@ -2240,7 +2185,7 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-35", 0 ],
-									"midpoints" : [ 419.5, 366.0, 419.5, 366.0 ],
+									"midpoints" : [ 469.5, 356.0, 469.5, 356.0 ],
 									"source" : [ "obj-19", 0 ]
 								}
 
@@ -2262,7 +2207,7 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-69", 0 ],
-									"midpoints" : [ 19.5, 225.0, 19.5, 225.0 ],
+									"midpoints" : [ 69.5, 215.0, 69.5, 215.0 ],
 									"source" : [ "obj-20", 0 ]
 								}
 
@@ -2277,7 +2222,7 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-19", 0 ],
-									"midpoints" : [ 699.5, 367.0, 397.0, 367.0, 397.0, 325.0, 419.5, 325.0 ],
+									"midpoints" : [ 749.5, 357.0, 447.0, 357.0, 447.0, 315.0, 469.5, 315.0 ],
 									"source" : [ "obj-24", 0 ]
 								}
 
@@ -2285,7 +2230,7 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-35", 0 ],
-									"midpoints" : [ 710.0, 366.0, 419.5, 366.0 ],
+									"midpoints" : [ 760.0, 356.0, 469.5, 356.0 ],
 									"source" : [ "obj-24", 1 ]
 								}
 
@@ -2308,14 +2253,6 @@
 								"patchline" : 								{
 									"destination" : [ "obj-20", 0 ],
 									"source" : [ "obj-5", 0 ]
-								}
-
-							}
-, 							{
-								"patchline" : 								{
-									"destination" : [ "obj-18", 0 ],
-									"midpoints" : [ 182.5, 309.0, 19.5, 309.0 ],
-									"source" : [ "obj-69", 2 ]
 								}
 
 							}
@@ -2344,13 +2281,13 @@
 								"name" : "max6message",
 								"default" : 								{
 									"bgfillcolor" : 									{
-										"type" : "gradient",
+										"angle" : 270.0,
+										"autogradient" : 0,
+										"color" : [ 0.290196, 0.309804, 0.301961, 1.0 ],
 										"color1" : [ 0.866667, 0.866667, 0.866667, 1.0 ],
 										"color2" : [ 0.788235, 0.788235, 0.788235, 1.0 ],
-										"color" : [ 0.290196, 0.309804, 0.301961, 1.0 ],
-										"angle" : 270.0,
 										"proportion" : 0.39,
-										"autogradient" : 0
+										"type" : "gradient"
 									}
 ,
 									"textcolor_inverse" : [ 0.0, 0.0, 0.0, 1.0 ]
@@ -2395,8 +2332,8 @@
 						"fileversion" : 1,
 						"appversion" : 						{
 							"major" : 8,
-							"minor" : 2,
-							"revision" : 2,
+							"minor" : 3,
+							"revision" : 0,
 							"architecture" : "x64",
 							"modernui" : 1
 						}
@@ -2637,8 +2574,8 @@
 										"fileversion" : 1,
 										"appversion" : 										{
 											"major" : 8,
-											"minor" : 2,
-											"revision" : 2,
+											"minor" : 3,
+											"revision" : 0,
 											"architecture" : "x64",
 											"modernui" : 1
 										}
@@ -2890,13 +2827,13 @@
 												"name" : "max6message",
 												"default" : 												{
 													"bgfillcolor" : 													{
-														"type" : "gradient",
+														"angle" : 270.0,
+														"autogradient" : 0,
+														"color" : [ 0.290196, 0.309804, 0.301961, 1.0 ],
 														"color1" : [ 0.866667, 0.866667, 0.866667, 1.0 ],
 														"color2" : [ 0.788235, 0.788235, 0.788235, 1.0 ],
-														"color" : [ 0.290196, 0.309804, 0.301961, 1.0 ],
-														"angle" : 270.0,
 														"proportion" : 0.39,
-														"autogradient" : 0
+														"type" : "gradient"
 													}
 ,
 													"textcolor_inverse" : [ 0.0, 0.0, 0.0, 1.0 ]
@@ -2934,8 +2871,8 @@
 									"id" : "obj-69",
 									"maxclass" : "newobj",
 									"numinlets" : 1,
-									"numoutlets" : 3,
-									"outlettype" : [ "bang", "float", "" ],
+									"numoutlets" : 2,
+									"outlettype" : [ "", "" ],
 									"patching_rect" : [ 10.0, 275.0, 182.0, 23.0 ],
 									"text" : "fluid.dataset~ help.grid.1.input"
 								}
@@ -2952,8 +2889,8 @@
 										"fileversion" : 1,
 										"appversion" : 										{
 											"major" : 8,
-											"minor" : 2,
-											"revision" : 2,
+											"minor" : 3,
+											"revision" : 0,
 											"architecture" : "x64",
 											"modernui" : 1
 										}
@@ -2992,9 +2929,9 @@
 													"id" : "obj-32",
 													"maxclass" : "newobj",
 													"numinlets" : 1,
-													"numoutlets" : 3,
-													"outlettype" : [ "bang", "float", "" ],
-													"patching_rect" : [ 170.0, 108.0, 176.0, 22.0 ],
+													"numoutlets" : 2,
+													"outlettype" : [ "", "" ],
+													"patching_rect" : [ 128.0, 106.0, 176.0, 22.0 ],
 													"text" : "fluid.dataset~ help.grid.1.output"
 												}
 
@@ -3006,7 +2943,7 @@
 													"numinlets" : 2,
 													"numoutlets" : 1,
 													"outlettype" : [ "" ],
-													"patching_rect" : [ 247.0, 255.0, 39.0, 22.0 ],
+													"patching_rect" : [ 18.0, 252.0, 39.0, 22.0 ],
 													"text" : "dump"
 												}
 
@@ -3018,7 +2955,7 @@
 													"numinlets" : 2,
 													"numoutlets" : 2,
 													"outlettype" : [ "", "" ],
-													"patching_rect" : [ 247.0, 220.0, 99.0, 22.0 ],
+													"patching_rect" : [ 18.0, 217.0, 99.0, 22.0 ],
 													"text" : "route fittransform"
 												}
 
@@ -3030,7 +2967,7 @@
 													"numinlets" : 2,
 													"numoutlets" : 1,
 													"outlettype" : [ "" ],
-													"patching_rect" : [ 60.0, 148.0, 288.0, 22.0 ],
+													"patching_rect" : [ 18.0, 146.0, 288.0, 22.0 ],
 													"text" : "fittransform help.grid.1.output help.grid.1.normoutput"
 												}
 
@@ -3040,9 +2977,9 @@
 													"id" : "obj-24",
 													"maxclass" : "newobj",
 													"numinlets" : 1,
-													"numoutlets" : 3,
-													"outlettype" : [ "bang", "float", "" ],
-													"patching_rect" : [ 60.0, 183.0, 206.0, 22.0 ],
+													"numoutlets" : 2,
+													"outlettype" : [ "", "" ],
+													"patching_rect" : [ 18.0, 181.0, 206.0, 22.0 ],
 													"text" : "fluid.normalize~ @min 0.1 @max 0.9"
 												}
 
@@ -3054,7 +2991,7 @@
 													"numinlets" : 2,
 													"numoutlets" : 2,
 													"outlettype" : [ "", "" ],
-													"patching_rect" : [ 60.0, 108.0, 99.0, 22.0 ],
+													"patching_rect" : [ 18.0, 106.0, 99.0, 22.0 ],
 													"text" : "route fittransform"
 												}
 
@@ -3064,9 +3001,9 @@
 													"id" : "obj-17",
 													"maxclass" : "newobj",
 													"numinlets" : 1,
-													"numoutlets" : 3,
-													"outlettype" : [ "bang", "float", "" ],
-													"patching_rect" : [ 18.0, 73.0, 61.0, 22.0 ],
+													"numoutlets" : 2,
+													"outlettype" : [ "", "" ],
+													"patching_rect" : [ 18.0, 64.0, 61.0, 22.0 ],
 													"text" : "fluid.grid~"
 												}
 
@@ -3078,7 +3015,7 @@
 													"numinlets" : 2,
 													"numoutlets" : 2,
 													"outlettype" : [ "", "" ],
-													"patching_rect" : [ 432.0, 322.0, 69.0, 22.0 ],
+													"patching_rect" : [ 203.0, 319.0, 69.0, 22.0 ],
 													"text" : "route dump"
 												}
 
@@ -3088,9 +3025,9 @@
 													"id" : "obj-15",
 													"maxclass" : "newobj",
 													"numinlets" : 1,
-													"numoutlets" : 3,
-													"outlettype" : [ "bang", "float", "" ],
-													"patching_rect" : [ 247.0, 290.0, 204.0, 22.0 ],
+													"numoutlets" : 2,
+													"outlettype" : [ "", "" ],
+													"patching_rect" : [ 18.0, 287.0, 204.0, 22.0 ],
 													"text" : "fluid.dataset~ help.grid.1.normoutput"
 												}
 
@@ -3116,7 +3053,7 @@
 													"maxclass" : "outlet",
 													"numinlets" : 1,
 													"numoutlets" : 0,
-													"patching_rect" : [ 432.0, 354.0, 30.0, 30.0 ]
+													"patching_rect" : [ 203.0, 351.0, 30.0, 30.0 ]
 												}
 
 											}
@@ -3131,14 +3068,14 @@
 , 											{
 												"patchline" : 												{
 													"destination" : [ "obj-13", 0 ],
-													"source" : [ "obj-15", 2 ]
+													"source" : [ "obj-15", 1 ]
 												}
 
 											}
 , 											{
 												"patchline" : 												{
 													"destination" : [ "obj-20", 0 ],
-													"source" : [ "obj-17", 2 ]
+													"source" : [ "obj-17", 0 ]
 												}
 
 											}
@@ -3152,7 +3089,7 @@
 , 											{
 												"patchline" : 												{
 													"destination" : [ "obj-29", 0 ],
-													"source" : [ "obj-24", 2 ]
+													"source" : [ "obj-24", 0 ]
 												}
 
 											}
@@ -3217,8 +3154,8 @@
 									"id" : "obj-16",
 									"maxclass" : "jsui",
 									"numinlets" : 2,
-									"numoutlets" : 1,
-									"outlettype" : [ "" ],
+									"numoutlets" : 2,
+									"outlettype" : [ "", "" ],
 									"parameter_enable" : 0,
 									"patching_rect" : [ 410.0, 425.0, 265.0, 265.0 ]
 								}
@@ -3230,8 +3167,8 @@
 									"id" : "obj-1",
 									"maxclass" : "jsui",
 									"numinlets" : 2,
-									"numoutlets" : 1,
-									"outlettype" : [ "" ],
+									"numoutlets" : 2,
+									"outlettype" : [ "", "" ],
 									"parameter_enable" : 0,
 									"patching_rect" : [ 10.0, 425.0, 265.0, 265.0 ]
 								}
@@ -3361,8 +3298,8 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-18", 0 ],
-									"midpoints" : [ 182.5, 309.0, 19.5, 309.0 ],
-									"source" : [ "obj-69", 2 ]
+									"midpoints" : [ 182.5, 306.0, 19.5, 306.0 ],
+									"source" : [ "obj-69", 1 ]
 								}
 
 							}
@@ -3399,13 +3336,13 @@
 								"name" : "max6message",
 								"default" : 								{
 									"bgfillcolor" : 									{
-										"type" : "gradient",
+										"angle" : 270.0,
+										"autogradient" : 0,
+										"color" : [ 0.290196, 0.309804, 0.301961, 1.0 ],
 										"color1" : [ 0.866667, 0.866667, 0.866667, 1.0 ],
 										"color2" : [ 0.788235, 0.788235, 0.788235, 1.0 ],
-										"color" : [ 0.290196, 0.309804, 0.301961, 1.0 ],
-										"angle" : 270.0,
 										"proportion" : 0.39,
-										"autogradient" : 0
+										"type" : "gradient"
 									}
 ,
 									"textcolor_inverse" : [ 0.0, 0.0, 0.0, 1.0 ]
@@ -3450,8 +3387,8 @@
 						"fileversion" : 1,
 						"appversion" : 						{
 							"major" : 8,
-							"minor" : 2,
-							"revision" : 2,
+							"minor" : 3,
+							"revision" : 0,
 							"architecture" : "x64",
 							"modernui" : 1
 						}
@@ -3505,45 +3442,6 @@
 			}
  ],
 		"lines" : [  ],
-		"dependency_cache" : [ 			{
-				"name" : "fluid.dataloader.maxpat",
-				"bootpath" : "~/dev/flucoma/max/patchers",
-				"patcherrelativepath" : "../patchers",
-				"type" : "JSON",
-				"implicit" : 1
-			}
-, 			{
-				"name" : "fluid.flucomaorg.maxpat",
-				"bootpath" : "~/dev/flucoma/max/help",
-				"patcherrelativepath" : ".",
-				"type" : "JSON",
-				"implicit" : 1
-			}
-, 			{
-				"name" : "fluid.learn.maxpat",
-				"bootpath" : "~/dev/flucoma/max/help",
-				"patcherrelativepath" : ".",
-				"type" : "JSON",
-				"implicit" : 1
-			}
-, 			{
-				"name" : "fluid.libmanipulation.mxo",
-				"type" : "iLaX"
-			}
-, 			{
-				"name" : "fluid.plotter.js",
-				"bootpath" : "~/dev/flucoma/max/jsui",
-				"patcherrelativepath" : "../jsui",
-				"type" : "TEXT",
-				"implicit" : 1
-			}
-, 			{
-				"name" : "helpdetails.js",
-				"bootpath" : "C74:/help/resources",
-				"type" : "TEXT",
-				"implicit" : 1
-			}
- ],
 		"autosave" : 0
 	}
 

--- a/help/fluid.kdtree~.maxhelp
+++ b/help/fluid.kdtree~.maxhelp
@@ -3,8 +3,8 @@
 		"fileversion" : 1,
 		"appversion" : 		{
 			"major" : 8,
-			"minor" : 2,
-			"revision" : 2,
+			"minor" : 3,
+			"revision" : 0,
 			"architecture" : "x64",
 			"modernui" : 1
 		}
@@ -50,8 +50,8 @@
 						"fileversion" : 1,
 						"appversion" : 						{
 							"major" : 8,
-							"minor" : 2,
-							"revision" : 2,
+							"minor" : 3,
+							"revision" : 0,
 							"architecture" : "x64",
 							"modernui" : 1
 						}
@@ -88,6 +88,19 @@
 						"assistshowspatchername" : 0,
 						"boxes" : [ 							{
 								"box" : 								{
+									"id" : "obj-5",
+									"maxclass" : "comment",
+									"numinlets" : 1,
+									"numoutlets" : 0,
+									"patching_rect" : [ 10.0, 62.0, 330.0, 21.0 ],
+									"presentation_linecount" : 3,
+									"text" : "A stripped back example for how the fluid.kdtree~ works",
+									"textcolor" : [ 0.501960784313725, 0.501960784313725, 0.501960784313725, 1.0 ]
+								}
+
+							}
+, 							{
+								"box" : 								{
 									"bgcolor" : [ 1.0, 0.788235, 0.470588, 1.0 ],
 									"fontname" : "Arial Bold",
 									"hint" : "",
@@ -99,7 +112,7 @@
 									"numoutlets" : 3,
 									"outlettype" : [ "", "", "int" ],
 									"parameter_enable" : 0,
-									"patching_rect" : [ 578.0, 202.0, 20.0, 20.0 ],
+									"patching_rect" : [ 628.0, 172.0, 20.0, 20.0 ],
 									"rounded" : 60.0,
 									"text" : "3",
 									"textcolor" : [ 0.34902, 0.34902, 0.34902, 1.0 ]
@@ -114,7 +127,7 @@
 									"maxclass" : "comment",
 									"numinlets" : 1,
 									"numoutlets" : 0,
-									"patching_rect" : [ 604.0, 192.0, 288.0, 40.0 ],
+									"patching_rect" : [ 654.0, 162.0, 288.0, 40.0 ],
 									"text" : "Move the knob around to create a \"query\" for the kdtree"
 								}
 
@@ -132,7 +145,7 @@
 									"numoutlets" : 3,
 									"outlettype" : [ "", "", "int" ],
 									"parameter_enable" : 0,
-									"patching_rect" : [ 130.0, 350.0, 20.0, 20.0 ],
+									"patching_rect" : [ 160.0, 340.0, 20.0, 20.0 ],
 									"rounded" : 60.0,
 									"text" : "2",
 									"textcolor" : [ 0.34902, 0.34902, 0.34902, 1.0 ]
@@ -146,7 +159,7 @@
 									"maxclass" : "comment",
 									"numinlets" : 1,
 									"numoutlets" : 0,
-									"patching_rect" : [ 152.0, 348.0, 285.0, 25.0 ],
+									"patching_rect" : [ 182.0, 338.0, 285.0, 25.0 ],
 									"text" : "Fit a kdtree to the dataset that was just made"
 								}
 
@@ -164,7 +177,7 @@
 									"numoutlets" : 3,
 									"outlettype" : [ "", "", "int" ],
 									"parameter_enable" : 0,
-									"patching_rect" : [ 41.0, 122.0, 20.0, 20.0 ],
+									"patching_rect" : [ 71.0, 112.0, 20.0, 20.0 ],
 									"rounded" : 60.0,
 									"text" : "1",
 									"textcolor" : [ 0.34902, 0.34902, 0.34902, 1.0 ]
@@ -178,7 +191,7 @@
 									"maxclass" : "comment",
 									"numinlets" : 1,
 									"numoutlets" : 0,
-									"patching_rect" : [ 63.0, 120.0, 313.0, 25.0 ],
+									"patching_rect" : [ 93.0, 110.0, 313.0, 25.0 ],
 									"text" : "Create a dataset with four, two-dimensional points"
 								}
 
@@ -193,14 +206,14 @@
 										"fileversion" : 1,
 										"appversion" : 										{
 											"major" : 8,
-											"minor" : 2,
-											"revision" : 2,
+											"minor" : 3,
+											"revision" : 0,
 											"architecture" : "x64",
 											"modernui" : 1
 										}
 ,
 										"classnamespace" : "box",
-										"rect" : [ 0.0, 0.0, 640.0, 480.0 ],
+										"rect" : [ 84.0, 131.0, 640.0, 480.0 ],
 										"bglocked" : 0,
 										"openinpresentation" : 0,
 										"default_fontsize" : 12.0,
@@ -235,7 +248,7 @@
 													"numinlets" : 2,
 													"numoutlets" : 1,
 													"outlettype" : [ "" ],
-													"patching_rect" : [ 50.0, 220.0, 29.5, 23.0 ],
+													"patching_rect" : [ 50.0, 220.0, 29.5, 22.0 ],
 													"text" : "join"
 												}
 
@@ -247,7 +260,7 @@
 													"numinlets" : 2,
 													"numoutlets" : 1,
 													"outlettype" : [ "" ],
-													"patching_rect" : [ 142.0, 183.0, 29.5, 23.0 ],
+													"patching_rect" : [ 155.0, 183.0, 29.5, 22.0 ],
 													"text" : "$2"
 												}
 
@@ -259,7 +272,7 @@
 													"numinlets" : 1,
 													"numoutlets" : 1,
 													"outlettype" : [ "list" ],
-													"patching_rect" : [ 142.0, 150.0, 77.0, 23.0 ],
+													"patching_rect" : [ 155.0, 150.0, 77.0, 22.0 ],
 													"text" : "fluid.list2buf"
 												}
 
@@ -271,7 +284,7 @@
 													"numinlets" : 5,
 													"numoutlets" : 4,
 													"outlettype" : [ "int", "", "", "int" ],
-													"patching_rect" : [ 50.0, 150.0, 61.0, 23.0 ],
+													"patching_rect" : [ 50.0, 150.0, 89.0, 22.0 ],
 													"text" : "counter"
 												}
 
@@ -283,7 +296,7 @@
 													"numinlets" : 1,
 													"numoutlets" : 2,
 													"outlettype" : [ "bang", "" ],
-													"patching_rect" : [ 50.0, 100.0, 29.5, 23.0 ],
+													"patching_rect" : [ 50.0, 100.0, 29.5, 22.0 ],
 													"text" : "t b l"
 												}
 
@@ -295,7 +308,7 @@
 													"numinlets" : 2,
 													"numoutlets" : 1,
 													"outlettype" : [ "" ],
-													"patching_rect" : [ 50.0, 260.0, 90.0, 23.0 ],
+													"patching_rect" : [ 50.0, 260.0, 90.0, 22.0 ],
 													"text" : "setpoint $1 $2"
 												}
 
@@ -306,9 +319,9 @@
 													"id" : "obj-1",
 													"maxclass" : "newobj",
 													"numinlets" : 1,
-													"numoutlets" : 3,
-													"outlettype" : [ "bang", "float", "" ],
-													"patching_rect" : [ 50.0, 300.0, 182.0, 23.0 ],
+													"numoutlets" : 2,
+													"outlettype" : [ "", "" ],
+													"patching_rect" : [ 50.0, 300.0, 182.0, 22.0 ],
 													"text" : "fluid.dataset~ kdtree.help.2.ds"
 												}
 
@@ -350,7 +363,7 @@
 , 											{
 												"patchline" : 												{
 													"destination" : [ "obj-19", 1 ],
-													"midpoints" : [ 151.5, 217.0, 70.0, 217.0 ],
+													"midpoints" : [ 164.5, 217.0, 70.0, 217.0 ],
 													"source" : [ "obj-18", 0 ]
 												}
 
@@ -372,7 +385,7 @@
 , 											{
 												"patchline" : 												{
 													"destination" : [ "obj-16", 0 ],
-													"midpoints" : [ 70.0, 136.0, 151.5, 136.0 ],
+													"midpoints" : [ 70.0, 136.0, 164.5, 136.0 ],
 													"source" : [ "obj-7", 1 ]
 												}
 
@@ -409,7 +422,7 @@
  ]
 									}
 ,
-									"patching_rect" : [ 10.0, 310.0, 270.0, 23.0 ],
+									"patching_rect" : [ 40.0, 300.0, 270.0, 23.0 ],
 									"saved_object_attributes" : 									{
 										"description" : "",
 										"digest" : "",
@@ -428,7 +441,7 @@
 									"maxclass" : "comment",
 									"numinlets" : 1,
 									"numoutlets" : 0,
-									"patching_rect" : [ 770.0, 593.0, 152.0, 50.0 ],
+									"patching_rect" : [ 655.0, 563.0, 152.0, 50.0 ],
 									"text" : "This is the identifier of the point as it was entered in the dataset.",
 									"textcolor" : [ 0.501960784313725, 0.501960784313725, 0.501960784313725, 1.0 ]
 								}
@@ -441,7 +454,7 @@
 									"maxclass" : "comment",
 									"numinlets" : 1,
 									"numoutlets" : 0,
-									"patching_rect" : [ 604.0, 593.0, 152.0, 65.0 ],
+									"patching_rect" : [ 489.0, 563.0, 152.0, 65.0 ],
 									"text" : "This is the value of the closest points. Compare them to the input to see how \"close\" they are.",
 									"textcolor" : [ 0.501960784313725, 0.501960784313725, 0.501960784313725, 1.0 ]
 								}
@@ -454,7 +467,7 @@
 									"maxclass" : "comment",
 									"numinlets" : 1,
 									"numoutlets" : 0,
-									"patching_rect" : [ 430.0, 593.0, 152.0, 65.0 ],
+									"patching_rect" : [ 750.0, 367.0, 152.0, 65.0 ],
 									"text" : "This is our input or \"query\". We want to find which stored point in the dataset is closest to this.",
 									"textcolor" : [ 0.501960784313725, 0.501960784313725, 0.501960784313725, 1.0 ]
 								}
@@ -466,7 +479,7 @@
 									"maxclass" : "comment",
 									"numinlets" : 1,
 									"numoutlets" : 0,
-									"patching_rect" : [ 41.0, 200.0, 30.0, 21.0 ],
+									"patching_rect" : [ 71.0, 190.0, 30.0, 21.0 ],
 									"text" : "\"3\""
 								}
 
@@ -477,7 +490,7 @@
 									"maxclass" : "comment",
 									"numinlets" : 1,
 									"numoutlets" : 0,
-									"patching_rect" : [ 112.0, 223.0, 30.0, 21.0 ],
+									"patching_rect" : [ 142.0, 213.0, 30.0, 21.0 ],
 									"text" : "\"2\""
 								}
 
@@ -488,7 +501,7 @@
 									"maxclass" : "comment",
 									"numinlets" : 1,
 									"numoutlets" : 0,
-									"patching_rect" : [ 167.0, 244.0, 30.0, 21.0 ],
+									"patching_rect" : [ 197.0, 234.0, 30.0, 21.0 ],
 									"text" : "\"1\""
 								}
 
@@ -499,7 +512,7 @@
 									"maxclass" : "comment",
 									"numinlets" : 1,
 									"numoutlets" : 0,
-									"patching_rect" : [ 237.25, 261.0, 30.0, 21.0 ],
+									"patching_rect" : [ 267.25, 251.0, 30.0, 21.0 ],
 									"text" : "\"0\""
 								}
 
@@ -511,8 +524,8 @@
 									"numinlets" : 2,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 770.0, 566.0, 50.0, 23.0 ],
-									"text" : "\"2\""
+									"patching_rect" : [ 690.0, 536.0, 50.0, 23.0 ],
+									"text" : "\"0\""
 								}
 
 							}
@@ -527,8 +540,8 @@
 										"fileversion" : 1,
 										"appversion" : 										{
 											"major" : 8,
-											"minor" : 2,
-											"revision" : 2,
+											"minor" : 3,
+											"revision" : 0,
 											"architecture" : "x64",
 											"modernui" : 1
 										}
@@ -569,7 +582,7 @@
 													"numinlets" : 2,
 													"numoutlets" : 1,
 													"outlettype" : [ "list" ],
-													"patching_rect" : [ 213.0, 220.0, 248.0, 22.0 ],
+													"patching_rect" : [ 50.0, 218.0, 248.0, 22.0 ],
 													"text" : "fluid.buf2list @source kdtree.help.2.query"
 												}
 
@@ -581,8 +594,8 @@
 													"numinlets" : 2,
 													"numoutlets" : 2,
 													"outlettype" : [ "", "" ],
-													"patching_rect" : [ 213.0, 180.0, 88.0, 22.0 ],
-													"text" : "route getpoint"
+													"patching_rect" : [ 50.0, 178.0, 140.0, 22.0 ],
+													"text" : "substitute getpoint buffer"
 												}
 
 											}
@@ -616,8 +629,8 @@
 													"id" : "obj-39",
 													"maxclass" : "newobj",
 													"numinlets" : 1,
-													"numoutlets" : 3,
-													"outlettype" : [ "bang", "float", "" ],
+													"numoutlets" : 2,
+													"outlettype" : [ "", "" ],
 													"patching_rect" : [ 50.0, 140.0, 182.0, 22.0 ],
 													"text" : "fluid.dataset~ kdtree.help.2.ds"
 												}
@@ -644,7 +657,7 @@
 													"maxclass" : "outlet",
 													"numinlets" : 1,
 													"numoutlets" : 0,
-													"patching_rect" : [ 213.0, 303.0, 30.0, 30.0 ]
+													"patching_rect" : [ 50.0, 259.0, 30.0, 30.0 ]
 												}
 
 											}
@@ -652,7 +665,7 @@
 										"lines" : [ 											{
 												"patchline" : 												{
 													"destination" : [ "obj-45", 0 ],
-													"source" : [ "obj-39", 2 ]
+													"source" : [ "obj-39", 0 ]
 												}
 
 											}
@@ -687,7 +700,7 @@
  ]
 									}
 ,
-									"patching_rect" : [ 635.0, 533.0, 200.0, 23.0 ],
+									"patching_rect" : [ 520.0, 503.0, 200.0, 23.0 ],
 									"saved_object_attributes" : 									{
 										"description" : "",
 										"digest" : "",
@@ -706,8 +719,8 @@
 									"numinlets" : 2,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 430.0, 566.0, 151.0, 23.0 ],
-									"text" : "0. 1."
+									"patching_rect" : [ 750.0, 340.0, 151.0, 23.0 ],
+									"text" : "1. 0."
 								}
 
 							}
@@ -718,7 +731,7 @@
 									"numinlets" : 1,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 470.0, 320.0, 97.0, 23.0 ],
+									"patching_rect" : [ 520.0, 290.0, 97.0, 23.0 ],
 									"text" : "vexpr $i1 / 127."
 								}
 
@@ -730,7 +743,7 @@
 									"numinlets" : 2,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 470.0, 280.0, 29.5, 23.0 ],
+									"patching_rect" : [ 520.0, 250.0, 29.5, 23.0 ],
 									"text" : "join"
 								}
 
@@ -743,7 +756,7 @@
 									"numoutlets" : 2,
 									"outlettype" : [ "int", "int" ],
 									"parameter_enable" : 0,
-									"patching_rect" : [ 470.0, 160.0, 100.0, 100.0 ]
+									"patching_rect" : [ 520.0, 130.0, 100.0, 100.0 ]
 								}
 
 							}
@@ -754,8 +767,8 @@
 									"numinlets" : 2,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 604.0, 566.0, 50.0, 23.0 ],
-									"text" : "0. 0.5"
+									"patching_rect" : [ 489.0, 536.0, 50.0, 23.0 ],
+									"text" : "1. 0.2"
 								}
 
 							}
@@ -766,7 +779,7 @@
 									"numinlets" : 2,
 									"numoutlets" : 2,
 									"outlettype" : [ "", "" ],
-									"patching_rect" : [ 635.0, 490.0, 92.0, 23.0 ],
+									"patching_rect" : [ 520.0, 460.0, 92.0, 23.0 ],
 									"text" : "route knearest"
 								}
 
@@ -778,7 +791,7 @@
 									"numinlets" : 1,
 									"numoutlets" : 1,
 									"outlettype" : [ "list" ],
-									"patching_rect" : [ 470.0, 370.0, 77.0, 23.0 ],
+									"patching_rect" : [ 520.0, 340.0, 77.0, 23.0 ],
 									"text" : "fluid.list2buf"
 								}
 
@@ -790,7 +803,7 @@
 									"numinlets" : 2,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 470.0, 410.0, 76.0, 23.0 ],
+									"patching_rect" : [ 520.0, 380.0, 76.0, 23.0 ],
 									"text" : "knearest $2"
 								}
 
@@ -801,9 +814,9 @@
 									"id" : "obj-27",
 									"maxclass" : "newobj",
 									"numinlets" : 1,
-									"numoutlets" : 3,
-									"outlettype" : [ "bang", "float", "" ],
-									"patching_rect" : [ 470.0, 450.0, 184.0, 23.0 ],
+									"numoutlets" : 2,
+									"outlettype" : [ "", "" ],
+									"patching_rect" : [ 520.0, 420.0, 184.0, 23.0 ],
 									"text" : "fluid.kdtree~ kdtree.help.2.tree"
 								}
 
@@ -815,7 +828,7 @@
 									"numinlets" : 2,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 10.0, 350.0, 115.0, 23.0 ],
+									"patching_rect" : [ 40.0, 340.0, 115.0, 23.0 ],
 									"text" : "fit kdtree.help.2.ds"
 								}
 
@@ -828,7 +841,7 @@
 									"numoutlets" : 1,
 									"outlettype" : [ "bang" ],
 									"parameter_enable" : 0,
-									"patching_rect" : [ 10.0, 120.0, 24.0, 24.0 ]
+									"patching_rect" : [ 40.0, 110.0, 24.0, 24.0 ]
 								}
 
 							}
@@ -839,7 +852,7 @@
 									"numinlets" : 1,
 									"numoutlets" : 5,
 									"outlettype" : [ "bang", "bang", "bang", "bang", "int" ],
-									"patching_rect" : [ 10.0, 160.0, 270.0, 23.0 ],
+									"patching_rect" : [ 40.0, 150.0, 270.0, 23.0 ],
 									"text" : "t b b b b 0"
 								}
 
@@ -851,7 +864,7 @@
 									"numinlets" : 2,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 198.25, 260.0, 37.0, 23.0 ],
+									"patching_rect" : [ 228.25, 250.0, 37.0, 23.0 ],
 									"text" : "1 0.2"
 								}
 
@@ -863,7 +876,7 @@
 									"numinlets" : 2,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 135.5, 243.0, 29.5, 23.0 ],
+									"patching_rect" : [ 165.5, 233.0, 29.5, 23.0 ],
 									"text" : "1 1"
 								}
 
@@ -875,7 +888,7 @@
 									"numinlets" : 2,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 73.0, 223.0, 37.0, 23.0 ],
+									"patching_rect" : [ 103.0, 213.0, 37.0, 23.0 ],
 									"text" : "0 0.5"
 								}
 
@@ -887,7 +900,7 @@
 									"numinlets" : 2,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 10.0, 200.0, 29.5, 23.0 ],
+									"patching_rect" : [ 40.0, 190.0, 29.5, 23.0 ],
 									"text" : "0 0"
 								}
 
@@ -898,31 +911,10 @@
 									"id" : "obj-3",
 									"maxclass" : "newobj",
 									"numinlets" : 1,
-									"numoutlets" : 3,
-									"outlettype" : [ "bang", "float", "" ],
-									"patching_rect" : [ 10.0, 380.0, 184.0, 23.0 ],
+									"numoutlets" : 2,
+									"outlettype" : [ "", "" ],
+									"patching_rect" : [ 40.0, 380.0, 184.0, 23.0 ],
 									"text" : "fluid.kdtree~ kdtree.help.2.tree"
-								}
-
-							}
-, 							{
-								"box" : 								{
-									"args" : [ "kdtree" ],
-									"bgmode" : 0,
-									"border" : 0,
-									"clickthrough" : 0,
-									"enablehscroll" : 0,
-									"enablevscroll" : 0,
-									"id" : "obj-75",
-									"lockeddragscroll" : 0,
-									"lockedsize" : 0,
-									"maxclass" : "bpatcher",
-									"name" : "fluid.learn.maxpat",
-									"numinlets" : 0,
-									"numoutlets" : 0,
-									"offset" : [ -10.0, -8.0 ],
-									"patching_rect" : [ 510.0, 10.0, 240.0, 95.0 ],
-									"viewvisibility" : 1
 								}
 
 							}
@@ -938,7 +930,7 @@
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
 									"parameter_enable" : 0,
-									"patching_rect" : [ 10.0, 10.0, 495.0, 95.0 ]
+									"patching_rect" : [ 10.0, 10.0, 270.0, 50.0 ]
 								}
 
 							}
@@ -946,7 +938,7 @@
 						"lines" : [ 							{
 								"patchline" : 								{
 									"destination" : [ "obj-77", 0 ],
-									"midpoints" : [ 19.5, 226.0, 19.5, 226.0 ],
+									"midpoints" : [ 49.5, 216.0, 49.5, 216.0 ],
 									"source" : [ "obj-10", 0 ]
 								}
 
@@ -954,7 +946,7 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-77", 0 ],
-									"midpoints" : [ 82.5, 295.0, 19.5, 295.0 ],
+									"midpoints" : [ 112.5, 285.0, 49.5, 285.0 ],
 									"source" : [ "obj-11", 0 ]
 								}
 
@@ -962,7 +954,7 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-77", 0 ],
-									"midpoints" : [ 145.0, 295.0, 19.5, 295.0 ],
+									"midpoints" : [ 175.0, 285.0, 49.5, 285.0 ],
 									"source" : [ "obj-12", 0 ]
 								}
 
@@ -970,7 +962,7 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-77", 0 ],
-									"midpoints" : [ 207.75, 295.0, 19.5, 295.0 ],
+									"midpoints" : [ 237.75, 285.0, 49.5, 285.0 ],
 									"source" : [ "obj-13", 0 ]
 								}
 
@@ -1027,7 +1019,7 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-37", 0 ],
-									"source" : [ "obj-27", 2 ]
+									"source" : [ "obj-27", 0 ]
 								}
 
 							}
@@ -1056,7 +1048,7 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-64", 1 ],
-									"midpoints" : [ 644.5, 526.0, 845.0, 526.0, 845.0, 560.0, 810.5, 560.0 ],
+									"midpoints" : [ 529.5, 491.0, 730.0, 491.0, 730.0, 530.0, 730.5, 530.0 ],
 									"order" : 0,
 									"source" : [ "obj-37", 0 ]
 								}
@@ -1086,7 +1078,7 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-31", 0 ],
-									"midpoints" : [ 479.5, 345.0, 479.5, 345.0 ],
+									"midpoints" : [ 529.5, 315.0, 529.5, 315.0 ],
 									"order" : 1,
 									"source" : [ "obj-57", 0 ]
 								}
@@ -1095,7 +1087,7 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-59", 1 ],
-									"midpoints" : [ 479.5, 357.0, 456.0, 357.0, 456.0, 552.0, 571.5, 552.0 ],
+									"midpoints" : [ 529.5, 326.0, 891.5, 326.0 ],
 									"order" : 0,
 									"source" : [ "obj-57", 0 ]
 								}
@@ -1133,13 +1125,13 @@
 								"name" : "max6message",
 								"default" : 								{
 									"bgfillcolor" : 									{
-										"type" : "gradient",
+										"angle" : 270.0,
+										"autogradient" : 0,
+										"color" : [ 0.290196, 0.309804, 0.301961, 1.0 ],
 										"color1" : [ 0.866667, 0.866667, 0.866667, 1.0 ],
 										"color2" : [ 0.788235, 0.788235, 0.788235, 1.0 ],
-										"color" : [ 0.290196, 0.309804, 0.301961, 1.0 ],
-										"angle" : 270.0,
 										"proportion" : 0.39,
-										"autogradient" : 0
+										"type" : "gradient"
 									}
 ,
 									"textcolor_inverse" : [ 0.0, 0.0, 0.0, 1.0 ]
@@ -1184,8 +1176,8 @@
 						"fileversion" : 1,
 						"appversion" : 						{
 							"major" : 8,
-							"minor" : 2,
-							"revision" : 2,
+							"minor" : 3,
+							"revision" : 0,
 							"architecture" : "x64",
 							"modernui" : 1
 						}
@@ -1222,13 +1214,26 @@
 						"assistshowspatchername" : 0,
 						"boxes" : [ 							{
 								"box" : 								{
+									"id" : "obj-14",
+									"maxclass" : "comment",
+									"numinlets" : 1,
+									"numoutlets" : 0,
+									"patching_rect" : [ 10.0, 62.0, 574.0, 21.0 ],
+									"presentation_linecount" : 2,
+									"text" : "Change the specificity of searches by constraining the distance and number of nearest neighbours",
+									"textcolor" : [ 0.129411764705882, 0.129411764705882, 0.129411764705882, 0.51 ]
+								}
+
+							}
+, 							{
+								"box" : 								{
 									"bubble" : 1,
 									"id" : "obj-8",
 									"linecount" : 2,
 									"maxclass" : "comment",
 									"numinlets" : 1,
 									"numoutlets" : 0,
-									"patching_rect" : [ 730.0, 156.0, 242.0, 40.0 ],
+									"patching_rect" : [ 737.0, 136.5, 242.0, 40.0 ],
 									"text" : "Experiment with the numneighbours and radius constraints."
 								}
 
@@ -1246,7 +1251,7 @@
 									"numoutlets" : 3,
 									"outlettype" : [ "", "", "int" ],
 									"parameter_enable" : 0,
-									"patching_rect" : [ 320.0, 338.0, 20.0, 20.0 ],
+									"patching_rect" : [ 450.0, 317.0, 20.0, 20.0 ],
 									"rounded" : 60.0,
 									"text" : "2",
 									"textcolor" : [ 0.34902, 0.34902, 0.34902, 1.0 ]
@@ -1261,29 +1266,8 @@
 									"maxclass" : "comment",
 									"numinlets" : 1,
 									"numoutlets" : 0,
-									"patching_rect" : [ 342.0, 321.0, 107.0, 54.0 ],
+									"patching_rect" : [ 340.0, 300.0, 107.0, 54.0 ],
 									"text" : "Click and drag around this space"
-								}
-
-							}
-, 							{
-								"box" : 								{
-									"args" : [ "kdtree" ],
-									"bgmode" : 0,
-									"border" : 0,
-									"clickthrough" : 0,
-									"enablehscroll" : 0,
-									"enablevscroll" : 0,
-									"id" : "obj-75",
-									"lockeddragscroll" : 0,
-									"lockedsize" : 0,
-									"maxclass" : "bpatcher",
-									"name" : "fluid.learn.maxpat",
-									"numinlets" : 0,
-									"numoutlets" : 0,
-									"offset" : [ -10.0, -8.0 ],
-									"patching_rect" : [ 510.0, 10.0, 240.0, 95.0 ],
-									"viewvisibility" : 1
 								}
 
 							}
@@ -1294,7 +1278,7 @@
 									"numinlets" : 1,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 190.0, 705.0, 108.0, 23.0 ],
+									"patching_rect" : [ 40.0, 695.0, 108.0, 23.0 ],
 									"text" : "prepend highlight"
 								}
 
@@ -1306,7 +1290,7 @@
 									"numinlets" : 2,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 10.0, 548.0, 76.0, 23.0 ],
+									"patching_rect" : [ 40.0, 528.0, 76.0, 23.0 ],
 									"text" : "knearest $2"
 								}
 
@@ -1318,7 +1302,7 @@
 									"numinlets" : 1,
 									"numoutlets" : 1,
 									"outlettype" : [ "list" ],
-									"patching_rect" : [ 10.0, 515.0, 77.0, 23.0 ],
+									"patching_rect" : [ 40.0, 495.0, 77.0, 23.0 ],
 									"text" : "fluid.list2buf"
 								}
 
@@ -1329,9 +1313,9 @@
 									"id" : "obj-21",
 									"maxclass" : "newobj",
 									"numinlets" : 1,
-									"numoutlets" : 3,
-									"outlettype" : [ "bang", "float", "" ],
-									"patching_rect" : [ 182.0, 154.0, 194.0, 23.0 ],
+									"numoutlets" : 2,
+									"outlettype" : [ "", "" ],
+									"patching_rect" : [ 212.0, 134.0, 194.0, 23.0 ],
 									"text" : "fluid.dataset~ kdtree.help.3.data"
 								}
 
@@ -1353,7 +1337,7 @@
 									"numinlets" : 2,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 92.0, 548.0, 126.0, 23.0 ],
+									"patching_rect" : [ 100.0, 570.0, 126.0, 23.0 ],
 									"text" : "fit kdtree.help.3.data"
 								}
 
@@ -1367,7 +1351,7 @@
 									"numoutlets" : 2,
 									"outlettype" : [ "", "" ],
 									"parameter_enable" : 0,
-									"patching_rect" : [ 10.0, 210.0, 290.0, 290.0 ]
+									"patching_rect" : [ 40.0, 190.0, 290.0, 290.0 ]
 								}
 
 							}
@@ -1382,8 +1366,8 @@
 										"fileversion" : 1,
 										"appversion" : 										{
 											"major" : 8,
-											"minor" : 2,
-											"revision" : 2,
+											"minor" : 3,
+											"revision" : 0,
 											"architecture" : "x64",
 											"modernui" : 1
 										}
@@ -1419,18 +1403,6 @@
 										"assistshowspatchername" : 0,
 										"boxes" : [ 											{
 												"box" : 												{
-													"id" : "obj-39",
-													"maxclass" : "newobj",
-													"numinlets" : 1,
-													"numoutlets" : 1,
-													"outlettype" : [ "" ],
-													"patching_rect" : [ 287.0, 428.0, 159.0, 22.0 ],
-													"text" : "loadmess pointsizescale 0.4"
-												}
-
-											}
-, 											{
-												"box" : 												{
 													"id" : "obj-43",
 													"maxclass" : "newobj",
 													"numinlets" : 1,
@@ -1461,7 +1433,7 @@
 													"maxclass" : "outlet",
 													"numinlets" : 1,
 													"numoutlets" : 0,
-													"patching_rect" : [ 190.0, 500.0, 30.0, 30.0 ]
+													"patching_rect" : [ 129.0, 518.0, 30.0, 30.0 ]
 												}
 
 											}
@@ -1485,7 +1457,7 @@
 													"maxclass" : "outlet",
 													"numinlets" : 1,
 													"numoutlets" : 0,
-													"patching_rect" : [ 242.25, 500.0, 30.0, 30.0 ]
+													"patching_rect" : [ 190.0, 518.0, 30.0, 30.0 ]
 												}
 
 											}
@@ -1590,8 +1562,8 @@
 													"id" : "obj-54",
 													"maxclass" : "newobj",
 													"numinlets" : 1,
-													"numoutlets" : 3,
-													"outlettype" : [ "bang", "float", "" ],
+													"numoutlets" : 2,
+													"outlettype" : [ "", "" ],
 													"patching_rect" : [ 114.5, 89.0, 180.0, 22.0 ],
 													"text" : "fluid.dataset~ kdtree.help.3.data"
 												}
@@ -1614,8 +1586,8 @@
 													"id" : "obj-21",
 													"maxclass" : "newobj",
 													"numinlets" : 1,
-													"numoutlets" : 3,
-													"outlettype" : [ "bang", "float", "" ],
+													"numoutlets" : 2,
+													"outlettype" : [ "", "" ],
 													"patching_rect" : [ 29.0, 394.0, 180.0, 22.0 ],
 													"text" : "fluid.dataset~ kdtree.help.3.data"
 												}
@@ -1675,6 +1647,7 @@
 , 											{
 												"patchline" : 												{
 													"destination" : [ "obj-10", 0 ],
+													"midpoints" : [ 199.5, 483.0, 199.5, 483.0 ],
 													"source" : [ "obj-12", 0 ]
 												}
 
@@ -1682,6 +1655,7 @@
 , 											{
 												"patchline" : 												{
 													"destination" : [ "obj-13", 0 ],
+													"midpoints" : [ 258.25, 504.0, 138.5, 504.0 ],
 													"source" : [ "obj-12", 1 ]
 												}
 
@@ -1689,7 +1663,7 @@
 , 											{
 												"patchline" : 												{
 													"destination" : [ "obj-1", 0 ],
-													"source" : [ "obj-21", 2 ]
+													"source" : [ "obj-21", 1 ]
 												}
 
 											}
@@ -1711,14 +1685,6 @@
 												"patchline" : 												{
 													"destination" : [ "obj-43", 0 ],
 													"source" : [ "obj-3", 1 ]
-												}
-
-											}
-, 											{
-												"patchline" : 												{
-													"destination" : [ "obj-13", 0 ],
-													"midpoints" : [ 296.5, 495.0, 199.5, 495.0 ],
-													"source" : [ "obj-39", 0 ]
 												}
 
 											}
@@ -1810,13 +1776,13 @@
 												"name" : "max6message",
 												"default" : 												{
 													"bgfillcolor" : 													{
-														"type" : "gradient",
+														"angle" : 270.0,
+														"autogradient" : 0,
+														"color" : [ 0.290196, 0.309804, 0.301961, 1.0 ],
 														"color1" : [ 0.866667, 0.866667, 0.866667, 1.0 ],
 														"color2" : [ 0.788235, 0.788235, 0.788235, 1.0 ],
-														"color" : [ 0.290196, 0.309804, 0.301961, 1.0 ],
-														"angle" : 270.0,
 														"proportion" : 0.39,
-														"autogradient" : 0
+														"type" : "gradient"
 													}
 ,
 													"textcolor_inverse" : [ 0.0, 0.0, 0.0, 1.0 ]
@@ -1837,7 +1803,7 @@
  ]
 									}
 ,
-									"patching_rect" : [ 10.0, 154.0, 170.0, 23.0 ],
+									"patching_rect" : [ 40.0, 134.0, 170.0, 23.0 ],
 									"saved_object_attributes" : 									{
 										"description" : "",
 										"digest" : "",
@@ -1862,7 +1828,7 @@
 									"numoutlets" : 3,
 									"outlettype" : [ "", "", "int" ],
 									"parameter_enable" : 0,
-									"patching_rect" : [ 40.0, 122.0, 20.0, 20.0 ],
+									"patching_rect" : [ 413.0, 102.5, 20.0, 20.0 ],
 									"rounded" : 60.0,
 									"text" : "1",
 									"textcolor" : [ 0.34902, 0.34902, 0.34902, 1.0 ]
@@ -1876,7 +1842,7 @@
 									"maxclass" : "comment",
 									"numinlets" : 1,
 									"numoutlets" : 0,
-									"patching_rect" : [ 62.0, 122.0, 345.0, 25.0 ],
+									"patching_rect" : [ 66.0, 100.0, 345.0, 25.0 ],
 									"text" : "Generate random data to be stored in the fluid.dataset~"
 								}
 
@@ -1889,7 +1855,7 @@
 									"numoutlets" : 1,
 									"outlettype" : [ "bang" ],
 									"parameter_enable" : 0,
-									"patching_rect" : [ 10.0, 120.0, 24.0, 24.0 ]
+									"patching_rect" : [ 40.0, 100.0, 24.0, 24.0 ]
 								}
 
 							}
@@ -1900,7 +1866,7 @@
 									"numinlets" : 2,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 720.5, 461.0, 45.0, 23.0 ],
+									"patching_rect" : [ 750.5, 441.0, 45.0, 23.0 ],
 									"text" : "0 0.09"
 								}
 
@@ -1912,7 +1878,7 @@
 									"numinlets" : 2,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 680.5, 461.0, 37.0, 23.0 ],
+									"patching_rect" : [ 710.5, 441.0, 37.0, 23.0 ],
 									"text" : "0 0.3"
 								}
 
@@ -1924,7 +1890,7 @@
 									"numinlets" : 2,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 725.0, 368.0, 52.0, 23.0 ],
+									"patching_rect" : [ 755.0, 348.0, 52.0, 23.0 ],
 									"text" : "10 0.09"
 								}
 
@@ -1936,7 +1902,7 @@
 									"numinlets" : 2,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 676.0, 368.0, 45.0, 23.0 ],
+									"patching_rect" : [ 706.0, 348.0, 45.0, 23.0 ],
 									"text" : "30 0.3"
 								}
 
@@ -1948,7 +1914,7 @@
 									"numinlets" : 1,
 									"numoutlets" : 3,
 									"outlettype" : [ "", "", "" ],
-									"patching_rect" : [ 800.0, 526.391296000000011, 43.0, 23.0 ],
+									"patching_rect" : [ 830.0, 506.391296000000011, 43.0, 23.0 ],
 									"text" : "unjoin"
 								}
 
@@ -1960,7 +1926,7 @@
 									"numinlets" : 2,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 676.0, 304.0, 34.0, 23.0 ],
+									"patching_rect" : [ 706.0, 284.0, 34.0, 23.0 ],
 									"text" : "10 0"
 								}
 
@@ -1972,7 +1938,7 @@
 									"maxclass" : "comment",
 									"numinlets" : 1,
 									"numoutlets" : 0,
-									"patching_rect" : [ 506.0, 487.0, 186.0, 50.0 ],
+									"patching_rect" : [ 536.0, 467.0, 186.0, 50.0 ],
 									"text" : "only the extent within radius is searched; number of returned points is uncapped",
 									"textcolor" : [ 0.129411764705882, 0.129411764705882, 0.129411764705882, 0.53 ]
 								}
@@ -1984,7 +1950,7 @@
 									"maxclass" : "comment",
 									"numinlets" : 1,
 									"numoutlets" : 0,
-									"patching_rect" : [ 492.0, 461.0, 185.0, 21.0 ],
+									"patching_rect" : [ 522.0, 441.0, 185.0, 21.0 ],
 									"text" : "numneighbours = 0, radius > 0"
 								}
 
@@ -1996,7 +1962,7 @@
 									"maxclass" : "comment",
 									"numinlets" : 1,
 									"numoutlets" : 0,
-									"patching_rect" : [ 501.0, 394.0, 186.0, 65.0 ],
+									"patching_rect" : [ 531.0, 374.0, 186.0, 65.0 ],
 									"text" : "only the extent within radius is searched; number of returned points is capped at numneighbours",
 									"textcolor" : [ 0.129411764705882, 0.129411764705882, 0.129411764705882, 0.51 ]
 								}
@@ -2008,7 +1974,7 @@
 									"maxclass" : "comment",
 									"numinlets" : 1,
 									"numoutlets" : 0,
-									"patching_rect" : [ 487.0, 368.0, 185.0, 21.0 ],
+									"patching_rect" : [ 517.0, 348.0, 185.0, 21.0 ],
 									"text" : "numneighbours > 0, radius > 0"
 								}
 
@@ -2020,7 +1986,7 @@
 									"maxclass" : "comment",
 									"numinlets" : 1,
 									"numoutlets" : 0,
-									"patching_rect" : [ 501.0, 330.0, 185.0, 36.0 ],
+									"patching_rect" : [ 531.0, 310.0, 185.0, 36.0 ],
 									"text" : "radius is ignored: the whole extent of the tree is searched",
 									"textcolor" : [ 0.129411764705882, 0.129411764705882, 0.129411764705882, 0.51 ]
 								}
@@ -2032,7 +1998,7 @@
 									"maxclass" : "comment",
 									"numinlets" : 1,
 									"numoutlets" : 0,
-									"patching_rect" : [ 487.0, 304.0, 185.0, 21.0 ],
+									"patching_rect" : [ 517.0, 284.0, 185.0, 21.0 ],
 									"text" : "numneighbours > 0, radius = 0"
 								}
 
@@ -2044,7 +2010,7 @@
 									"maxclass" : "comment",
 									"numinlets" : 1,
 									"numoutlets" : 0,
-									"patching_rect" : [ 487.0, 248.0, 312.0, 50.0 ],
+									"patching_rect" : [ 517.0, 228.0, 312.0, 50.0 ],
 									"text" : "Because the range of distances is hard to predict a priori, you can use the knearestdist message to get an idea of useful values for radius. ",
 									"textcolor" : [ 0.129411764705882, 0.129411764705882, 0.129411764705882, 0.51 ]
 								}
@@ -2057,7 +2023,7 @@
 									"maxclass" : "comment",
 									"numinlets" : 1,
 									"numoutlets" : 0,
-									"patching_rect" : [ 487.0, 193.0, 312.0, 50.0 ],
+									"patching_rect" : [ 517.0, 173.0, 312.0, 50.0 ],
 									"text" : "We can query the tree in terms of either a (maximum) number of neighbouring points to return, or a radius around the query point.  "
 								}
 
@@ -2069,7 +2035,7 @@
 									"maxclass" : "comment",
 									"numinlets" : 1,
 									"numoutlets" : 0,
-									"patching_rect" : [ 487.0, 166.0, 218.0, 21.0 ],
+									"patching_rect" : [ 517.0, 146.0, 218.0, 21.0 ],
 									"text" : "Radius vs Number of Neighbours "
 								}
 
@@ -2087,7 +2053,7 @@
 									"numoutlets" : 3,
 									"outlettype" : [ "", "", "int" ],
 									"parameter_enable" : 0,
-									"patching_rect" : [ 707.0, 166.0, 20.0, 20.0 ],
+									"patching_rect" : [ 980.0, 147.0, 20.0, 20.0 ],
 									"rounded" : 60.0,
 									"text" : "3",
 									"textcolor" : [ 0.34902, 0.34902, 0.34902, 1.0 ]
@@ -2101,7 +2067,7 @@
 									"numinlets" : 2,
 									"numoutlets" : 2,
 									"outlettype" : [ "", "" ],
-									"patching_rect" : [ 190.0, 670.0, 92.0, 23.0 ],
+									"patching_rect" : [ 40.0, 660.0, 92.0, 23.0 ],
 									"text" : "route knearest"
 								}
 
@@ -2111,9 +2077,9 @@
 									"id" : "obj-13",
 									"maxclass" : "newobj",
 									"numinlets" : 1,
-									"numoutlets" : 3,
-									"outlettype" : [ "bang", "float", "" ],
-									"patching_rect" : [ 10.0, 640.0, 199.0, 23.0 ],
+									"numoutlets" : 2,
+									"outlettype" : [ "", "" ],
+									"patching_rect" : [ 40.0, 620.0, 199.0, 23.0 ],
 									"text" : "fluid.kdtree~ @numneighbours 5"
 								}
 
@@ -2130,7 +2096,7 @@
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
 									"parameter_enable" : 0,
-									"patching_rect" : [ 10.0, 10.0, 495.0, 95.0 ]
+									"patching_rect" : [ 10.0, 10.0, 280.0, 50.0 ]
 								}
 
 							}
@@ -2142,7 +2108,8 @@
 									"numinlets" : 1,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 676.0, 575.52172900000005, 150.0, 23.0 ]
+									"parameter_enable" : 0,
+									"patching_rect" : [ 706.0, 555.52172900000005, 150.0, 23.0 ]
 								}
 
 							}
@@ -2154,7 +2121,8 @@
 									"numinlets" : 1,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 487.0, 575.52172900000005, 185.0, 23.0 ],
+									"parameter_enable" : 0,
+									"patching_rect" : [ 517.0, 555.52172900000005, 185.0, 23.0 ],
 									"text_width" : 118.0
 								}
 
@@ -2171,7 +2139,7 @@
 									"mode" : 0,
 									"numinlets" : 1,
 									"numoutlets" : 0,
-									"patching_rect" : [ 470.0, 154.0, 390.0, 486.0 ],
+									"patching_rect" : [ 500.0, 134.0, 390.0, 486.0 ],
 									"proportion" : 0.5
 								}
 
@@ -2180,7 +2148,7 @@
 						"lines" : [ 							{
 								"patchline" : 								{
 									"destination" : [ "obj-13", 0 ],
-									"midpoints" : [ 685.5, 627.0, 19.5, 627.0 ],
+									"midpoints" : [ 715.5, 607.0, 49.5, 607.0 ],
 									"source" : [ "obj-1", 0 ]
 								}
 
@@ -2195,14 +2163,14 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-10", 0 ],
-									"source" : [ "obj-13", 2 ]
+									"source" : [ "obj-13", 0 ]
 								}
 
 							}
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-13", 0 ],
-									"midpoints" : [ 101.5, 627.0, 19.5, 627.0 ],
+									"midpoints" : [ 109.5, 607.0, 49.5, 607.0 ],
 									"source" : [ "obj-18", 0 ]
 								}
 
@@ -2217,7 +2185,7 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-18", 0 ],
-									"midpoints" : [ 170.5, 195.0, 312.0, 195.0, 312.0, 534.0, 101.5, 534.0 ],
+									"midpoints" : [ 200.5, 177.0, 27.0, 177.0, 27.0, 564.0, 109.5, 564.0 ],
 									"source" : [ "obj-25", 1 ]
 								}
 
@@ -2232,7 +2200,7 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-27", 0 ],
-									"midpoints" : [ 685.5, 343.0, 809.5, 343.0 ],
+									"midpoints" : [ 715.5, 323.0, 839.5, 323.0 ],
 									"source" : [ "obj-26", 0 ]
 								}
 
@@ -2240,7 +2208,7 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-1", 0 ],
-									"midpoints" : [ 821.5, 572.760864500000025, 685.5, 572.760864500000025 ],
+									"midpoints" : [ 851.5, 552.760864500000025, 715.5, 552.760864500000025 ],
 									"source" : [ "obj-27", 1 ]
 								}
 
@@ -2248,7 +2216,7 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-3", 0 ],
-									"midpoints" : [ 809.5, 563.760864500000025, 496.5, 563.760864500000025 ],
+									"midpoints" : [ 839.5, 543.760864500000025, 526.5, 543.760864500000025 ],
 									"source" : [ "obj-27", 0 ]
 								}
 
@@ -2256,7 +2224,7 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-27", 0 ],
-									"midpoints" : [ 685.5, 417.0, 809.5, 417.0 ],
+									"midpoints" : [ 715.5, 397.0, 839.5, 397.0 ],
 									"source" : [ "obj-28", 0 ]
 								}
 
@@ -2264,7 +2232,7 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-13", 0 ],
-									"midpoints" : [ 496.5, 627.0, 19.5, 627.0 ],
+									"midpoints" : [ 526.5, 607.0, 49.5, 607.0 ],
 									"source" : [ "obj-3", 0 ]
 								}
 
@@ -2272,7 +2240,7 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-27", 0 ],
-									"midpoints" : [ 734.5, 417.0, 809.5, 417.0 ],
+									"midpoints" : [ 764.5, 397.0, 839.5, 397.0 ],
 									"source" : [ "obj-30", 0 ]
 								}
 
@@ -2280,7 +2248,7 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-27", 0 ],
-									"midpoints" : [ 730.0, 506.5, 809.5, 506.5 ],
+									"midpoints" : [ 760.0, 486.5, 839.5, 486.5 ],
 									"source" : [ "obj-31", 0 ]
 								}
 
@@ -2288,7 +2256,7 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-27", 0 ],
-									"midpoints" : [ 690.0, 506.5, 809.5, 506.5 ],
+									"midpoints" : [ 720.0, 486.5, 839.5, 486.5 ],
 									"source" : [ "obj-33", 0 ]
 								}
 
@@ -2296,7 +2264,7 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-13", 0 ],
-									"midpoints" : [ 19.5, 573.0, 19.5, 573.0 ],
+									"midpoints" : [ 49.5, 553.0, 49.5, 553.0 ],
 									"source" : [ "obj-34", 0 ]
 								}
 
@@ -2304,7 +2272,7 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-6", 1 ],
-									"midpoints" : [ 199.5, 738.0, 312.0, 738.0, 312.0, 204.0, 290.5, 204.0 ],
+									"midpoints" : [ 49.5, 720.0, 27.0, 720.0, 27.0, 177.0, 320.5, 177.0 ],
 									"source" : [ "obj-35", 0 ]
 								}
 
@@ -2348,13 +2316,13 @@
 								"name" : "max6message",
 								"default" : 								{
 									"bgfillcolor" : 									{
-										"type" : "gradient",
+										"angle" : 270.0,
+										"autogradient" : 0,
+										"color" : [ 0.290196, 0.309804, 0.301961, 1.0 ],
 										"color1" : [ 0.866667, 0.866667, 0.866667, 1.0 ],
 										"color2" : [ 0.788235, 0.788235, 0.788235, 1.0 ],
-										"color" : [ 0.290196, 0.309804, 0.301961, 1.0 ],
-										"angle" : 270.0,
 										"proportion" : 0.39,
-										"autogradient" : 0
+										"type" : "gradient"
 									}
 ,
 									"textcolor_inverse" : [ 0.0, 0.0, 0.0, 1.0 ]
@@ -2399,8 +2367,8 @@
 						"fileversion" : 1,
 						"appversion" : 						{
 							"major" : 8,
-							"minor" : 2,
-							"revision" : 2,
+							"minor" : 3,
+							"revision" : 0,
 							"architecture" : "x64",
 							"modernui" : 1
 						}
@@ -2448,7 +2416,7 @@
 									"numinlets" : 1,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 324.0, 463.0, 370.0, 40.0 ],
+									"patching_rect" : [ 391.0, 461.0, 370.0, 40.0 ],
 									"text" : "For a relevant tutorial, see here: <link href=\"; max launchbrowser https://learn.flucoma.org/overviews/2d-sound-browsing-tutorial\" >https://learn.flucoma.org/overviews/2d-sound-browsing-tutorial</link>",
 									"textcolor" : [ 0.501960784313725, 0.501960784313725, 0.501960784313725, 1.0 ]
 								}
@@ -2474,8 +2442,8 @@
 										"fileversion" : 1,
 										"appversion" : 										{
 											"major" : 8,
-											"minor" : 2,
-											"revision" : 2,
+											"minor" : 3,
+											"revision" : 0,
 											"architecture" : "x64",
 											"modernui" : 1
 										}
@@ -2545,8 +2513,8 @@
 														"fileversion" : 1,
 														"appversion" : 														{
 															"major" : 8,
-															"minor" : 2,
-															"revision" : 2,
+															"minor" : 3,
+															"revision" : 0,
 															"architecture" : "x64",
 															"modernui" : 1
 														}
@@ -2784,8 +2752,8 @@
 														"fileversion" : 1,
 														"appversion" : 														{
 															"major" : 8,
-															"minor" : 2,
-															"revision" : 2,
+															"minor" : 3,
+															"revision" : 0,
 															"architecture" : "x64",
 															"modernui" : 1
 														}
@@ -3051,13 +3019,13 @@
 												"name" : "max6message",
 												"default" : 												{
 													"bgfillcolor" : 													{
-														"type" : "gradient",
+														"angle" : 270.0,
+														"autogradient" : 0,
+														"color" : [ 0.290196, 0.309804, 0.301961, 1.0 ],
 														"color1" : [ 0.866667, 0.866667, 0.866667, 1.0 ],
 														"color2" : [ 0.788235, 0.788235, 0.788235, 1.0 ],
-														"color" : [ 0.290196, 0.309804, 0.301961, 1.0 ],
-														"angle" : 270.0,
 														"proportion" : 0.39,
-														"autogradient" : 0
+														"type" : "gradient"
 													}
 ,
 													"textcolor_inverse" : [ 0.0, 0.0, 0.0, 1.0 ]
@@ -3078,7 +3046,7 @@
  ]
 									}
 ,
-									"patching_rect" : [ 460.0, 590.0, 160.0, 60.0 ],
+									"patching_rect" : [ 210.0, 618.0, 160.0, 60.0 ],
 									"viewvisibility" : 1
 								}
 
@@ -3092,7 +3060,7 @@
 									"maxclass" : "comment",
 									"numinlets" : 1,
 									"numoutlets" : 0,
-									"patching_rect" : [ 320.0, 250.0, 281.0, 210.0 ],
+									"patching_rect" : [ 387.0, 248.0, 281.0, 210.0 ],
 									"text" : "Each of these points on this space represents a small segment of a large sound file.\n\nUsing audio descriptors each segment is assigned two values, loudness and spectral centroid, that attempt to represent perceived qualities of the sound.\n\nThe fluid.kdtree~ performs the function of mapping our mouse inside the space, to the point that has the most similar set of descriptor values. In effect, it is a fast lookup mechanism so that we can scrub through the analysis space.",
 									"textcolor" : [ 0.50196099281311, 0.50196099281311, 0.50196099281311, 1.0 ]
 								}
@@ -3111,7 +3079,7 @@
 									"numoutlets" : 3,
 									"outlettype" : [ "", "", "int" ],
 									"parameter_enable" : 0,
-									"patching_rect" : [ 320.0, 210.0, 20.0, 20.0 ],
+									"patching_rect" : [ 387.0, 208.0, 20.0, 20.0 ],
 									"rounded" : 60.0,
 									"text" : "3",
 									"textcolor" : [ 0.34902, 0.34902, 0.34902, 1.0 ]
@@ -3126,7 +3094,7 @@
 									"maxclass" : "comment",
 									"numinlets" : 1,
 									"numoutlets" : 0,
-									"patching_rect" : [ 342.0, 200.0, 146.0, 40.0 ],
+									"patching_rect" : [ 409.0, 198.0, 146.0, 40.0 ],
 									"text" : "Click and drag around this space"
 								}
 
@@ -3144,7 +3112,7 @@
 									"numoutlets" : 3,
 									"outlettype" : [ "", "", "int" ],
 									"parameter_enable" : 0,
-									"patching_rect" : [ 509.5, 682.5, 20.0, 20.0 ],
+									"patching_rect" : [ 259.5, 710.5, 20.0, 20.0 ],
 									"rounded" : 60.0,
 									"text" : "2",
 									"textcolor" : [ 0.34902, 0.34902, 0.34902, 1.0 ]
@@ -3158,7 +3126,7 @@
 									"maxclass" : "comment",
 									"numinlets" : 1,
 									"numoutlets" : 0,
-									"patching_rect" : [ 531.5, 682.5, 127.0, 25.0 ],
+									"patching_rect" : [ 281.5, 710.5, 127.0, 25.0 ],
 									"text" : "Turn the audio on"
 								}
 
@@ -3170,7 +3138,7 @@
 									"maxclass" : "ezdac~",
 									"numinlets" : 2,
 									"numoutlets" : 0,
-									"patching_rect" : [ 460.0, 670.0, 45.0, 45.0 ]
+									"patching_rect" : [ 210.0, 698.0, 45.0, 45.0 ]
 								}
 
 							}
@@ -3182,7 +3150,7 @@
 									"numoutlets" : 1,
 									"outlettype" : [ "bang" ],
 									"parameter_enable" : 0,
-									"patching_rect" : [ 20.0, 120.0, 24.0, 24.0 ]
+									"patching_rect" : [ 87.0, 118.0, 24.0, 24.0 ]
 								}
 
 							}
@@ -3199,7 +3167,7 @@
 									"numoutlets" : 3,
 									"outlettype" : [ "", "", "int" ],
 									"parameter_enable" : 0,
-									"patching_rect" : [ 51.0, 122.0, 20.0, 20.0 ],
+									"patching_rect" : [ 118.0, 120.0, 20.0, 20.0 ],
 									"rounded" : 60.0,
 									"text" : "1",
 									"textcolor" : [ 0.34902, 0.34902, 0.34902, 1.0 ]
@@ -3214,7 +3182,7 @@
 									"maxclass" : "comment",
 									"numinlets" : 1,
 									"numoutlets" : 0,
-									"patching_rect" : [ 73.0, 112.0, 455.0, 40.0 ],
+									"patching_rect" : [ 140.0, 110.0, 455.0, 40.0 ],
 									"text" : "For demonstrative purposes much of this first example is preanalysed and pretrained data. This loads in this subpatch when the help file is opened."
 								}
 
@@ -3230,8 +3198,8 @@
 										"fileversion" : 1,
 										"appversion" : 										{
 											"major" : 8,
-											"minor" : 2,
-											"revision" : 2,
+											"minor" : 3,
+											"revision" : 0,
 											"architecture" : "x64",
 											"modernui" : 1
 										}
@@ -3265,6 +3233,7 @@
 										"style" : "",
 										"subpatcher_template" : "",
 										"assistshowspatchername" : 0,
+										"visible" : 1,
 										"boxes" : [ 											{
 												"box" : 												{
 													"id" : "obj-26",
@@ -3288,8 +3257,8 @@
 														"fileversion" : 1,
 														"appversion" : 														{
 															"major" : 8,
-															"minor" : 2,
-															"revision" : 2,
+															"minor" : 3,
+															"revision" : 0,
 															"architecture" : "x64",
 															"modernui" : 1
 														}
@@ -3330,7 +3299,7 @@
 																	"numinlets" : 1,
 																	"numoutlets" : 2,
 																	"outlettype" : [ "", "" ],
-																	"patching_rect" : [ 16.0, 125.0, 439.5, 22.0 ],
+																	"patching_rect" : [ 16.0, 131.0, 360.0, 22.0 ],
 																	"text" : "t l l"
 																}
 
@@ -3342,7 +3311,7 @@
 																	"numinlets" : 3,
 																	"numoutlets" : 2,
 																	"outlettype" : [ "", "" ],
-																	"patching_rect" : [ 201.0, 380.0, 181.0, 22.0 ],
+																	"patching_rect" : [ 142.0, 435.0, 181.0, 22.0 ],
 																	"text" : "combine s /media/ s @triggers 2"
 																}
 
@@ -3354,7 +3323,7 @@
 																	"numinlets" : 2,
 																	"numoutlets" : 2,
 																	"outlettype" : [ "", "" ],
-																	"patching_rect" : [ 189.5, 434.0, 51.0, 22.0 ],
+																	"patching_rect" : [ 79.0, 480.0, 51.0, 22.0 ],
 																	"text" : "zl.group"
 																}
 
@@ -3366,7 +3335,7 @@
 																	"numinlets" : 2,
 																	"numoutlets" : 2,
 																	"outlettype" : [ "", "" ],
-																	"patching_rect" : [ 363.0, 312.0, 81.0, 22.0 ],
+																	"patching_rect" : [ 142.0, 387.0, 81.0, 22.0 ],
 																	"text" : "route getlabel"
 																}
 
@@ -3378,7 +3347,7 @@
 																	"numinlets" : 2,
 																	"numoutlets" : 1,
 																	"outlettype" : [ "" ],
-																	"patching_rect" : [ 202.0, 262.0, 67.0, 22.0 ],
+																	"patching_rect" : [ 142.0, 319.0, 67.0, 22.0 ],
 																	"text" : "getlabel $1"
 																}
 
@@ -3390,7 +3359,7 @@
 																	"numinlets" : 2,
 																	"numoutlets" : 3,
 																	"outlettype" : [ "bang", "bang", "int" ],
-																	"patching_rect" : [ 177.0, 238.0, 44.0, 22.0 ],
+																	"patching_rect" : [ 16.0, 282.0, 145.0, 22.0 ],
 																	"text" : "uzi 0 0"
 																}
 
@@ -3400,9 +3369,9 @@
 																	"id" : "obj-17",
 																	"maxclass" : "newobj",
 																	"numinlets" : 1,
-																	"numoutlets" : 3,
-																	"outlettype" : [ "bang", "float", "" ],
-																	"patching_rect" : [ 202.0, 286.0, 180.0, 22.0 ],
+																	"numoutlets" : 2,
+																	"outlettype" : [ "", "" ],
+																	"patching_rect" : [ 142.0, 352.0, 180.0, 22.0 ],
 																	"text" : "fluid.labelset~ kdtree.files.loader"
 																}
 
@@ -3414,7 +3383,7 @@
 																	"numinlets" : 2,
 																	"numoutlets" : 2,
 																	"outlettype" : [ "", "" ],
-																	"patching_rect" : [ 177.0, 211.0, 61.0, 22.0 ],
+																	"patching_rect" : [ 16.0, 244.0, 61.0, 22.0 ],
 																	"text" : "route size"
 																}
 
@@ -3424,9 +3393,9 @@
 																	"id" : "obj-10",
 																	"maxclass" : "newobj",
 																	"numinlets" : 1,
-																	"numoutlets" : 3,
-																	"outlettype" : [ "bang", "float", "" ],
-																	"patching_rect" : [ 16.0, 183.0, 180.0, 22.0 ],
+																	"numoutlets" : 2,
+																	"outlettype" : [ "", "" ],
+																	"patching_rect" : [ 16.0, 206.0, 180.0, 22.0 ],
 																	"text" : "fluid.labelset~ kdtree.files.loader"
 																}
 
@@ -3438,7 +3407,7 @@
 																	"numinlets" : 2,
 																	"numoutlets" : 1,
 																	"outlettype" : [ "" ],
-																	"patching_rect" : [ 16.0, 154.0, 247.0, 22.0 ],
+																	"patching_rect" : [ 16.0, 169.0, 247.0, 22.0 ],
 																	"text" : "read $1/misc/flucoma_corpus_files.json, size"
 																}
 
@@ -3450,7 +3419,7 @@
 																	"numinlets" : 2,
 																	"numoutlets" : 2,
 																	"outlettype" : [ "", "" ],
-																	"patching_rect" : [ 16.0, 71.0, 73.0, 22.0 ],
+																	"patching_rect" : [ 16.0, 61.0, 73.0, 22.0 ],
 																	"text" : "combine s .."
 																}
 
@@ -3462,7 +3431,7 @@
 																	"numinlets" : 1,
 																	"numoutlets" : 2,
 																	"outlettype" : [ "", "int" ],
-																	"patching_rect" : [ 16.0, 98.0, 75.0, 22.0 ],
+																	"patching_rect" : [ 16.0, 94.0, 75.0, 22.0 ],
 																	"text" : "conformpath"
 																}
 
@@ -3488,7 +3457,7 @@
 																	"maxclass" : "outlet",
 																	"numinlets" : 1,
 																	"numoutlets" : 0,
-																	"patching_rect" : [ 189.5, 465.625, 30.0, 30.0 ]
+																	"patching_rect" : [ 79.0, 517.625, 30.0, 30.0 ]
 																}
 
 															}
@@ -3496,7 +3465,7 @@
 														"lines" : [ 															{
 																"patchline" : 																{
 																	"destination" : [ "obj-15", 0 ],
-																	"source" : [ "obj-10", 2 ]
+																	"source" : [ "obj-10", 0 ]
 																}
 
 															}
@@ -3524,7 +3493,7 @@
 , 															{
 																"patchline" : 																{
 																	"destination" : [ "obj-21", 0 ],
-																	"source" : [ "obj-17", 2 ]
+																	"source" : [ "obj-17", 0 ]
 																}
 
 															}
@@ -3552,6 +3521,7 @@
 , 															{
 																"patchline" : 																{
 																	"destination" : [ "obj-29", 2 ],
+																	"midpoints" : [ 151.5, 420.0, 313.5, 420.0 ],
 																	"source" : [ "obj-21", 0 ]
 																}
 
@@ -3573,6 +3543,7 @@
 , 															{
 																"patchline" : 																{
 																	"destination" : [ "obj-22", 0 ],
+																	"midpoints" : [ 151.5, 468.0, 88.5, 468.0 ],
 																	"source" : [ "obj-29", 0 ]
 																}
 
@@ -3580,7 +3551,7 @@
 , 															{
 																"patchline" : 																{
 																	"destination" : [ "obj-29", 0 ],
-																	"midpoints" : [ 446.0, 349.5, 210.5, 349.5 ],
+																	"midpoints" : [ 366.5, 420.0, 151.5, 420.0 ],
 																	"source" : [ "obj-30", 1 ]
 																}
 
@@ -3620,13 +3591,13 @@
 													"maxclass" : "newobj",
 													"numinlets" : 1,
 													"numoutlets" : 1,
-													"outlettype" : [ "bang" ],
+													"outlettype" : [ "" ],
 													"patcher" : 													{
 														"fileversion" : 1,
 														"appversion" : 														{
 															"major" : 8,
-															"minor" : 2,
-															"revision" : 2,
+															"minor" : 3,
+															"revision" : 0,
 															"architecture" : "x64",
 															"modernui" : 1
 														}
@@ -3677,8 +3648,8 @@
 																	"id" : "obj-13",
 																	"maxclass" : "newobj",
 																	"numinlets" : 1,
-																	"numoutlets" : 3,
-																	"outlettype" : [ "bang", "float", "" ],
+																	"numoutlets" : 2,
+																	"outlettype" : [ "", "" ],
 																	"patching_rect" : [ 15.0, 118.0, 588.0, 22.0 ],
 																	"text" : "fluid.bufcompose~ @source kdtree.help.1.temp @destination kdtree.help.1.src @destgain 0.5 @numchans 1"
 																}
@@ -3743,18 +3714,6 @@
 													}
 ,
 													"text" : "p stereo -> mono"
-												}
-
-											}
-, 											{
-												"box" : 												{
-													"id" : "obj-17",
-													"maxclass" : "message",
-													"numinlets" : 2,
-													"numoutlets" : 1,
-													"outlettype" : [ "" ],
-													"patching_rect" : [ 375.0, 385.75, 104.0, 22.0 ],
-													"text" : "pointsizescale 0.4"
 												}
 
 											}
@@ -3898,8 +3857,8 @@
 													"id" : "obj-5",
 													"maxclass" : "newobj",
 													"numinlets" : 1,
-													"numoutlets" : 3,
-													"outlettype" : [ "bang", "float", "" ],
+													"numoutlets" : 2,
+													"outlettype" : [ "", "" ],
 													"patching_rect" : [ 67.0, 347.125, 216.0, 22.0 ],
 													"text" : "fluid.dataset~ kdtree.help.1.analysis"
 												}
@@ -3910,8 +3869,8 @@
 													"id" : "obj-1",
 													"maxclass" : "newobj",
 													"numinlets" : 1,
-													"numoutlets" : 3,
-													"outlettype" : [ "bang", "float", "" ],
+													"numoutlets" : 2,
+													"outlettype" : [ "", "" ],
 													"patching_rect" : [ 67.0, 481.0, 184.0, 22.0 ],
 													"text" : "fluid.kdtree~ kdtree.help.1.tree"
 												}
@@ -3922,14 +3881,6 @@
 												"patchline" : 												{
 													"destination" : [ "obj-9", 0 ],
 													"source" : [ "obj-10", 0 ]
-												}
-
-											}
-, 											{
-												"patchline" : 												{
-													"destination" : [ "obj-18", 0 ],
-													"midpoints" : [ 384.5, 467.0, 312.5, 467.0 ],
-													"source" : [ "obj-17", 0 ]
 												}
 
 											}
@@ -3987,7 +3938,7 @@
 , 											{
 												"patchline" : 												{
 													"destination" : [ "obj-22", 0 ],
-													"source" : [ "obj-5", 2 ]
+													"source" : [ "obj-5", 1 ]
 												}
 
 											}
@@ -4000,17 +3951,7 @@
 											}
 , 											{
 												"patchline" : 												{
-													"destination" : [ "obj-17", 0 ],
-													"midpoints" : [ 23.5, 55.0, 539.0, 55.0, 539.0, 375.0, 384.5, 375.0 ],
-													"order" : 0,
-													"source" : [ "obj-8", 0 ]
-												}
-
-											}
-, 											{
-												"patchline" : 												{
 													"destination" : [ "obj-2", 0 ],
-													"order" : 1,
 													"source" : [ "obj-8", 0 ]
 												}
 
@@ -4047,13 +3988,13 @@
 												"name" : "max6message",
 												"default" : 												{
 													"bgfillcolor" : 													{
-														"type" : "gradient",
+														"angle" : 270.0,
+														"autogradient" : 0,
+														"color" : [ 0.290196, 0.309804, 0.301961, 1.0 ],
 														"color1" : [ 0.866667, 0.866667, 0.866667, 1.0 ],
 														"color2" : [ 0.788235, 0.788235, 0.788235, 1.0 ],
-														"color" : [ 0.290196, 0.309804, 0.301961, 1.0 ],
-														"angle" : 270.0,
 														"proportion" : 0.39,
-														"autogradient" : 0
+														"type" : "gradient"
 													}
 ,
 													"textcolor_inverse" : [ 0.0, 0.0, 0.0, 1.0 ]
@@ -4074,7 +4015,7 @@
  ]
 									}
 ,
-									"patching_rect" : [ 20.0, 160.0, 82.0, 23.0 ],
+									"patching_rect" : [ 87.0, 158.0, 82.0, 23.0 ],
 									"saved_object_attributes" : 									{
 										"description" : "",
 										"digest" : "",
@@ -4103,7 +4044,7 @@
 									"numinlets" : 0,
 									"numoutlets" : 0,
 									"offset" : [ -10.0, -8.0 ],
-									"patching_rect" : [ 510.0, 10.0, 240.0, 95.0 ],
+									"patching_rect" : [ 521.0, 10.0, 240.0, 95.0 ],
 									"viewvisibility" : 1
 								}
 
@@ -4115,7 +4056,7 @@
 									"numinlets" : 1,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 303.0, 625.0, 108.0, 23.0 ],
+									"patching_rect" : [ 87.0, 618.0, 108.0, 23.0 ],
 									"text" : "prepend highlight"
 								}
 
@@ -4127,7 +4068,7 @@
 									"numinlets" : 2,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 20.0, 528.0, 76.0, 23.0 ],
+									"patching_rect" : [ 87.0, 524.25, 76.0, 23.0 ],
 									"text" : "knearest $2"
 								}
 
@@ -4139,7 +4080,7 @@
 									"numinlets" : 1,
 									"numoutlets" : 1,
 									"outlettype" : [ "list" ],
-									"patching_rect" : [ 20.0, 495.0, 77.0, 23.0 ],
+									"patching_rect" : [ 87.0, 493.0, 77.0, 23.0 ],
 									"text" : "fluid.list2buf"
 								}
 
@@ -4148,12 +4089,13 @@
 								"box" : 								{
 									"filename" : "fluid.plotter",
 									"id" : "obj-6",
+									"jsarguments" : [ 0.5 ],
 									"maxclass" : "jsui",
 									"numinlets" : 2,
 									"numoutlets" : 2,
 									"outlettype" : [ "", "" ],
 									"parameter_enable" : 0,
-									"patching_rect" : [ 20.0, 200.0, 290.0, 290.0 ]
+									"patching_rect" : [ 87.0, 190.0, 290.0, 290.0 ]
 								}
 
 							}
@@ -4164,7 +4106,7 @@
 									"numinlets" : 2,
 									"numoutlets" : 2,
 									"outlettype" : [ "", "" ],
-									"patching_rect" : [ 303.0, 590.0, 92.0, 23.0 ],
+									"patching_rect" : [ 87.0, 586.75, 92.0, 23.0 ],
 									"text" : "route knearest"
 								}
 
@@ -4174,9 +4116,9 @@
 									"id" : "obj-13",
 									"maxclass" : "newobj",
 									"numinlets" : 1,
-									"numoutlets" : 3,
-									"outlettype" : [ "bang", "float", "" ],
-									"patching_rect" : [ 20.0, 560.0, 302.0, 23.0 ],
+									"numoutlets" : 2,
+									"outlettype" : [ "", "" ],
+									"patching_rect" : [ 87.0, 555.5, 302.0, 23.0 ],
 									"text" : "fluid.kdtree~ kdtree.help.1.tree @numneighbours 1"
 								}
 
@@ -4201,7 +4143,7 @@
 						"lines" : [ 							{
 								"patchline" : 								{
 									"destination" : [ "obj-26", 0 ],
-									"midpoints" : [ 312.5, 615.0, 405.0, 615.0, 405.0, 585.0, 469.5, 585.0 ],
+									"midpoints" : [ 96.5, 613.375, 219.5, 613.375 ],
 									"order" : 1,
 									"source" : [ "obj-10", 0 ]
 								}
@@ -4218,7 +4160,7 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-10", 0 ],
-									"source" : [ "obj-13", 2 ]
+									"source" : [ "obj-13", 0 ]
 								}
 
 							}
@@ -4262,7 +4204,7 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-13", 0 ],
-									"midpoints" : [ 29.5, 562.789124000000015, 29.5, 562.789124000000015 ],
+									"midpoints" : [ 96.5, 560.789124000000015, 96.5, 560.789124000000015 ],
 									"source" : [ "obj-34", 0 ]
 								}
 
@@ -4270,7 +4212,7 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-6", 0 ],
-									"midpoints" : [ 312.5, 650.0, 14.0, 650.0, 14.0, 185.0, 29.5, 185.0 ],
+									"midpoints" : [ 96.5, 642.0, 72.0, 642.0, 72.0, 186.0, 96.5, 186.0 ],
 									"source" : [ "obj-35", 0 ]
 								}
 
@@ -4307,13 +4249,13 @@
 								"name" : "max6message",
 								"default" : 								{
 									"bgfillcolor" : 									{
-										"type" : "gradient",
+										"angle" : 270.0,
+										"autogradient" : 0,
+										"color" : [ 0.290196, 0.309804, 0.301961, 1.0 ],
 										"color1" : [ 0.866667, 0.866667, 0.866667, 1.0 ],
 										"color2" : [ 0.788235, 0.788235, 0.788235, 1.0 ],
-										"color" : [ 0.290196, 0.309804, 0.301961, 1.0 ],
-										"angle" : 270.0,
 										"proportion" : 0.39,
-										"autogradient" : 0
+										"type" : "gradient"
 									}
 ,
 									"textcolor_inverse" : [ 0.0, 0.0, 0.0, 1.0 ]
@@ -4374,8 +4316,8 @@
 						"fileversion" : 1,
 						"appversion" : 						{
 							"major" : 8,
-							"minor" : 2,
-							"revision" : 2,
+							"minor" : 3,
+							"revision" : 0,
 							"architecture" : "x64",
 							"modernui" : 1
 						}
@@ -4438,63 +4380,6 @@
 			"inherited_shortname" : 1
 		}
 ,
-		"dependency_cache" : [ 			{
-				"name" : "fluid.buf2list.mxo",
-				"type" : "iLaX"
-			}
-, 			{
-				"name" : "fluid.bufcompose~.mxo",
-				"type" : "iLaX"
-			}
-, 			{
-				"name" : "fluid.concataudiofiles.maxpat",
-				"bootpath" : "~/Documents/documents@hudd/research/projects/fluid corpus navigation/research/nightly_builds/Max/FluidCorpusManipulation/patchers",
-				"patcherrelativepath" : "../../nightly_builds/Max/FluidCorpusManipulation/patchers",
-				"type" : "JSON",
-				"implicit" : 1
-			}
-, 			{
-				"name" : "fluid.flucomaorg.maxpat",
-				"bootpath" : "~/Documents/documents@hudd/research/projects/fluid corpus navigation/research/flucoma-max/help",
-				"patcherrelativepath" : ".",
-				"type" : "JSON",
-				"implicit" : 1
-			}
-, 			{
-				"name" : "fluid.learn.maxpat",
-				"bootpath" : "~/Documents/documents@hudd/research/projects/fluid corpus navigation/research/flucoma-max/help",
-				"patcherrelativepath" : ".",
-				"type" : "JSON",
-				"implicit" : 1
-			}
-, 			{
-				"name" : "fluid.libmanipulation.mxo",
-				"type" : "iLaX"
-			}
-, 			{
-				"name" : "fluid.list2buf.mxo",
-				"type" : "iLaX"
-			}
-, 			{
-				"name" : "fluid.plotter.js",
-				"bootpath" : "~/Documents/documents@hudd/research/projects/fluid corpus navigation/research/nightly_builds/Max/FluidCorpusManipulation/jsui",
-				"patcherrelativepath" : "../../nightly_builds/Max/FluidCorpusManipulation/jsui",
-				"type" : "TEXT",
-				"implicit" : 1
-			}
-, 			{
-				"name" : "helpdetails.js",
-				"bootpath" : "C74:/help/resources",
-				"type" : "TEXT",
-				"implicit" : 1
-			}
-, 			{
-				"name" : "helpname.js",
-				"bootpath" : "C74:/help/resources",
-				"type" : "TEXT",
-				"implicit" : 1
-			}
- ],
 		"autosave" : 0
 	}
 

--- a/help/fluid.kmeans~.maxhelp
+++ b/help/fluid.kmeans~.maxhelp
@@ -57,7 +57,7 @@
 						}
 ,
 						"classnamespace" : "box",
-						"rect" : [ 0.0, 26.0, 987.0, 751.0 ],
+						"rect" : [ 35.0, 114.0, 987.0, 751.0 ],
 						"bglocked" : 0,
 						"openinpresentation" : 0,
 						"default_fontsize" : 13.0,
@@ -88,13 +88,25 @@
 						"assistshowspatchername" : 0,
 						"boxes" : [ 							{
 								"box" : 								{
+									"id" : "obj-12",
+									"maxclass" : "comment",
+									"numinlets" : 1,
+									"numoutlets" : 0,
+									"patching_rect" : [ 10.0, 70.0, 670.0, 21.0 ],
+									"text" : "You can also retrieve the \"means\" i.e the centres of each cluster either for visualisation or perhaps further analysis.",
+									"textcolor" : [ 0.501960784313725, 0.501960784313725, 0.501960784313725, 1.0 ]
+								}
+
+							}
+, 							{
+								"box" : 								{
 									"bubbleusescolors" : 1,
 									"id" : "obj-15",
 									"linecount" : 3,
 									"maxclass" : "comment",
 									"numinlets" : 1,
 									"numoutlets" : 0,
-									"patching_rect" : [ 290.0, 580.0, 150.0, 50.0 ],
+									"patching_rect" : [ 302.5, 447.5, 150.0, 50.0 ],
 									"text" : "The larger black circles are the means of each cluster.",
 									"textcolor" : [ 0.501960784313725, 0.501960784313725, 0.501960784313725, 1.0 ]
 								}
@@ -107,7 +119,7 @@
 									"maxclass" : "comment",
 									"numinlets" : 1,
 									"numoutlets" : 0,
-									"patching_rect" : [ 486.0, 255.318183999999945, 372.0, 25.0 ],
+									"patching_rect" : [ 498.5, 232.818184000000002, 372.0, 25.0 ],
 									"text" : "Plot the means that are now stored in help.kmeans.4.means",
 									"textcolor" : [ 0.0, 0.0, 0.0, 1.0 ]
 								}
@@ -121,7 +133,7 @@
 									"maxclass" : "comment",
 									"numinlets" : 1,
 									"numoutlets" : 0,
-									"patching_rect" : [ 17.5, 132.499999999999972, 160.0, 40.0 ],
+									"patching_rect" : [ 30.0, 110.0, 160.0, 40.0 ],
 									"text" : "Select a dataset to cluster",
 									"textcolor" : [ 0.0, 0.0, 0.0, 1.0 ]
 								}
@@ -140,7 +152,7 @@
 									"numoutlets" : 3,
 									"outlettype" : [ "", "", "int" ],
 									"parameter_enable" : 0,
-									"patching_rect" : [ 182.5, 135.499999999999972, 20.0, 20.0 ],
+									"patching_rect" : [ 195.0, 113.0, 20.0, 20.0 ],
 									"rounded" : 60.0,
 									"text" : "1",
 									"textcolor" : [ 0.34902, 0.34902, 0.34902, 1.0 ]
@@ -160,7 +172,7 @@
 									"numoutlets" : 3,
 									"outlettype" : [ "", "", "int" ],
 									"parameter_enable" : 0,
-									"patching_rect" : [ 816.0, 137.999999999999972, 20.0, 20.0 ],
+									"patching_rect" : [ 839.5, 115.499999999999972, 20.0, 20.0 ],
 									"rounded" : 60.0,
 									"text" : "2",
 									"textcolor" : [ 0.34902, 0.34902, 0.34902, 1.0 ]
@@ -175,7 +187,7 @@
 									"numoutlets" : 1,
 									"outlettype" : [ "bang" ],
 									"parameter_enable" : 0,
-									"patching_rect" : [ 460.0, 255.318183999999945, 24.0, 24.0 ]
+									"patching_rect" : [ 472.5, 232.818184000000002, 24.0, 24.0 ]
 								}
 
 							}
@@ -278,8 +290,8 @@
 													"id" : "obj-7",
 													"maxclass" : "newobj",
 													"numinlets" : 1,
-													"numoutlets" : 3,
-													"outlettype" : [ "bang", "float", "" ],
+													"numoutlets" : 2,
+													"outlettype" : [ "", "" ],
 													"patching_rect" : [ 15.0, 98.0, 217.0, 22.0 ],
 													"text" : "fluid.dataset~ help.kmeans.4.means"
 												}
@@ -500,7 +512,7 @@
 , 											{
 												"patchline" : 												{
 													"destination" : [ "obj-6", 0 ],
-													"source" : [ "obj-7", 2 ]
+													"source" : [ "obj-7", 1 ]
 												}
 
 											}
@@ -536,13 +548,13 @@
 												"name" : "max6message",
 												"default" : 												{
 													"bgfillcolor" : 													{
-														"type" : "gradient",
+														"angle" : 270.0,
+														"autogradient" : 0,
+														"color" : [ 0.290196, 0.309804, 0.301961, 1.0 ],
 														"color1" : [ 0.866667, 0.866667, 0.866667, 1.0 ],
 														"color2" : [ 0.788235, 0.788235, 0.788235, 1.0 ],
-														"color" : [ 0.290196, 0.309804, 0.301961, 1.0 ],
-														"angle" : 270.0,
 														"proportion" : 0.39,
-														"autogradient" : 0
+														"type" : "gradient"
 													}
 ,
 													"textcolor_inverse" : [ 0.0, 0.0, 0.0, 1.0 ]
@@ -563,7 +575,7 @@
  ]
 									}
 ,
-									"patching_rect" : [ 460.0, 295.318183999999974, 92.0, 23.0 ],
+									"patching_rect" : [ 472.5, 272.818183999999974, 92.0, 23.0 ],
 									"saved_object_attributes" : 									{
 										"description" : "",
 										"digest" : "",
@@ -582,7 +594,7 @@
 									"numinlets" : 2,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 310.0, 191.0, 196.0, 23.0 ],
+									"patching_rect" : [ 333.5, 168.5, 196.0, 23.0 ],
 									"text" : "getmeans help.kmeans.4.means"
 								}
 
@@ -603,7 +615,7 @@
 									"numoutlets" : 1,
 									"offset" : [ 0.0, 0.0 ],
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 10.0, 170.818183999999974, 175.0, 63.363631999999996 ],
+									"patching_rect" : [ 22.5, 148.318184000000002, 175.0, 63.363631999999996 ],
 									"viewvisibility" : 1
 								}
 
@@ -621,7 +633,7 @@
 									"numoutlets" : 3,
 									"outlettype" : [ "", "", "int" ],
 									"parameter_enable" : 0,
-									"patching_rect" : [ 860.0, 257.818183999999974, 20.0, 20.0 ],
+									"patching_rect" : [ 872.5, 235.318184000000002, 20.0, 20.0 ],
 									"rounded" : 60.0,
 									"text" : "4",
 									"textcolor" : [ 0.34902, 0.34902, 0.34902, 1.0 ]
@@ -635,7 +647,7 @@
 									"maxclass" : "comment",
 									"numinlets" : 1,
 									"numoutlets" : 0,
-									"patching_rect" : [ 508.0, 191.0, 416.0, 25.0 ],
+									"patching_rect" : [ 531.5, 168.5, 416.0, 25.0 ],
 									"text" : "Retrieve the means that fluid.kmeans learned and store in a dataset",
 									"textcolor" : [ 0.0, 0.0, 0.0, 1.0 ]
 								}
@@ -659,7 +671,7 @@
 										}
 ,
 										"classnamespace" : "box",
-										"rect" : [ 84.0, 131.0, 640.0, 480.0 ],
+										"rect" : [ 84.0, 131.0, 278.0, 241.0 ],
 										"bglocked" : 0,
 										"openinpresentation" : 0,
 										"default_fontsize" : 12.0,
@@ -694,7 +706,7 @@
 													"numinlets" : 2,
 													"numoutlets" : 1,
 													"outlettype" : [ "" ],
-													"patching_rect" : [ 50.0, 130.0, 41.0, 22.0 ],
+													"patching_rect" : [ 15.0, 91.0, 41.0, 22.0 ],
 													"text" : "dump"
 												}
 
@@ -706,7 +718,7 @@
 													"numinlets" : 2,
 													"numoutlets" : 2,
 													"outlettype" : [ "", "" ],
-													"patching_rect" : [ 50.0, 100.0, 91.0, 22.0 ],
+													"patching_rect" : [ 15.0, 56.0, 91.0, 22.0 ],
 													"text" : "route fitpredict"
 												}
 
@@ -718,7 +730,7 @@
 													"numinlets" : 2,
 													"numoutlets" : 2,
 													"outlettype" : [ "", "" ],
-													"patching_rect" : [ 245.0, 197.5, 74.0, 22.0 ],
+													"patching_rect" : [ 194.0, 159.5, 74.0, 22.0 ],
 													"text" : "route dump"
 												}
 
@@ -728,9 +740,9 @@
 													"id" : "obj-55",
 													"maxclass" : "newobj",
 													"numinlets" : 1,
-													"numoutlets" : 3,
-													"outlettype" : [ "bang", "float", "" ],
-													"patching_rect" : [ 50.0, 165.0, 198.0, 22.0 ],
+													"numoutlets" : 2,
+													"outlettype" : [ "", "" ],
+													"patching_rect" : [ 15.0, 126.0, 198.0, 22.0 ],
 													"text" : "fluid.labelset~ help.kmeans.4.labels"
 												}
 
@@ -744,7 +756,7 @@
 													"numinlets" : 0,
 													"numoutlets" : 1,
 													"outlettype" : [ "" ],
-													"patching_rect" : [ 50.0, 40.0, 30.0, 30.0 ]
+													"patching_rect" : [ 15.0, 12.0, 30.0, 30.0 ]
 												}
 
 											}
@@ -756,7 +768,7 @@
 													"maxclass" : "outlet",
 													"numinlets" : 1,
 													"numoutlets" : 0,
-													"patching_rect" : [ 245.0, 280.5, 30.0, 30.0 ]
+													"patching_rect" : [ 194.0, 196.5, 30.0, 30.0 ]
 												}
 
 											}
@@ -785,8 +797,7 @@
 , 											{
 												"patchline" : 												{
 													"destination" : [ "obj-15", 0 ],
-													"midpoints" : [ 238.5, 190.5, 254.5, 190.5 ],
-													"source" : [ "obj-55", 2 ]
+													"source" : [ "obj-55", 1 ]
 												}
 
 											}
@@ -800,7 +811,7 @@
  ]
 									}
 ,
-									"patching_rect" : [ 261.0, 410.0, 104.0, 23.0 ],
+									"patching_rect" : [ 273.5, 272.818183999999974, 104.0, 23.0 ],
 									"saved_object_attributes" : 									{
 										"description" : "",
 										"digest" : "",
@@ -824,7 +835,7 @@
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
 									"parameter_enable" : 0,
-									"patching_rect" : [ 10.0, 10.0, 395.0, 115.0 ]
+									"patching_rect" : [ 10.0, 10.0, 400.0, 50.0 ]
 								}
 
 							}
@@ -915,8 +926,8 @@
 													"id" : "obj-7",
 													"maxclass" : "newobj",
 													"numinlets" : 1,
-													"numoutlets" : 3,
-													"outlettype" : [ "bang", "float", "" ],
+													"numoutlets" : 2,
+													"outlettype" : [ "", "" ],
 													"patching_rect" : [ 11.0, 132.0, 188.0, 22.0 ],
 													"text" : "fluid.dataset~ help.kmeans.4.data"
 												}
@@ -988,7 +999,7 @@
 , 											{
 												"patchline" : 												{
 													"destination" : [ "obj-10", 0 ],
-													"source" : [ "obj-7", 2 ]
+													"source" : [ "obj-7", 1 ]
 												}
 
 											}
@@ -1025,13 +1036,13 @@
 												"name" : "max6message",
 												"default" : 												{
 													"bgfillcolor" : 													{
-														"type" : "gradient",
+														"angle" : 270.0,
+														"autogradient" : 0,
+														"color" : [ 0.290196, 0.309804, 0.301961, 1.0 ],
 														"color1" : [ 0.866667, 0.866667, 0.866667, 1.0 ],
 														"color2" : [ 0.788235, 0.788235, 0.788235, 1.0 ],
-														"color" : [ 0.290196, 0.309804, 0.301961, 1.0 ],
-														"angle" : 270.0,
 														"proportion" : 0.39,
-														"autogradient" : 0
+														"type" : "gradient"
 													}
 ,
 													"textcolor_inverse" : [ 0.0, 0.0, 0.0, 1.0 ]
@@ -1052,7 +1063,7 @@
  ]
 									}
 ,
-									"patching_rect" : [ 10.0, 255.318183999999945, 78.0, 23.0 ],
+									"patching_rect" : [ 22.5, 232.818184000000002, 78.0, 23.0 ],
 									"saved_object_attributes" : 									{
 										"description" : "",
 										"digest" : "",
@@ -1071,7 +1082,7 @@
 									"numinlets" : 2,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 250.0, 135.499999999999972, 335.0, 23.0 ],
+									"patching_rect" : [ 273.5, 112.999999999999972, 335.0, 23.0 ],
 									"text" : "clear, fitpredict help.kmeans.4.data help.kmeans.4.labels"
 								}
 
@@ -1081,9 +1092,9 @@
 									"id" : "obj-44",
 									"maxclass" : "newobj",
 									"numinlets" : 1,
-									"numoutlets" : 3,
-									"outlettype" : [ "bang", "float", "" ],
-									"patching_rect" : [ 250.0, 255.318183999999945, 187.0, 23.0 ],
+									"numoutlets" : 2,
+									"outlettype" : [ "", "" ],
+									"patching_rect" : [ 273.5, 232.818184000000002, 187.0, 23.0 ],
 									"text" : "fluid.kmeans~ @numclusters 4"
 								}
 
@@ -1094,10 +1105,10 @@
 									"id" : "obj-9",
 									"maxclass" : "jsui",
 									"numinlets" : 2,
-									"numoutlets" : 1,
-									"outlettype" : [ "" ],
+									"numoutlets" : 2,
+									"outlettype" : [ "", "" ],
 									"parameter_enable" : 0,
-									"patching_rect" : [ 10.0, 470.0, 270.0, 270.0 ]
+									"patching_rect" : [ 22.5, 337.5, 270.0, 270.0 ]
 								}
 
 							}
@@ -1108,7 +1119,7 @@
 									"maxclass" : "comment",
 									"numinlets" : 1,
 									"numoutlets" : 0,
-									"patching_rect" : [ 587.0, 135.499999999999972, 227.0, 25.0 ],
+									"patching_rect" : [ 610.5, 112.999999999999972, 227.0, 25.0 ],
 									"text" : "Predict four clusters for the dataset",
 									"textcolor" : [ 0.0, 0.0, 0.0, 1.0 ]
 								}
@@ -1127,7 +1138,7 @@
 									"numoutlets" : 3,
 									"outlettype" : [ "", "", "int" ],
 									"parameter_enable" : 0,
-									"patching_rect" : [ 926.0, 193.5, 20.0, 20.0 ],
+									"patching_rect" : [ 949.5, 171.0, 20.0, 20.0 ],
 									"rounded" : 60.0,
 									"text" : "3",
 									"textcolor" : [ 0.34902, 0.34902, 0.34902, 1.0 ]
@@ -1138,7 +1149,7 @@
 						"lines" : [ 							{
 								"patchline" : 								{
 									"destination" : [ "obj-5", 0 ],
-									"midpoints" : [ 19.5, 237.0, 19.5, 237.0 ],
+									"midpoints" : [ 32.0, 214.500000000000028, 32.0, 214.500000000000028 ],
 									"source" : [ "obj-1", 0 ]
 								}
 
@@ -1146,7 +1157,7 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-9", 1 ],
-									"midpoints" : [ 469.5, 456.0, 270.5, 456.0 ],
+									"midpoints" : [ 482.0, 322.5, 283.0, 322.5 ],
 									"source" : [ "obj-10", 0 ]
 								}
 
@@ -1154,7 +1165,7 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-44", 0 ],
-									"midpoints" : [ 259.5, 159.0, 259.5, 159.0 ],
+									"midpoints" : [ 283.0, 136.5, 283.0, 136.5 ],
 									"source" : [ "obj-14", 0 ]
 								}
 
@@ -1169,7 +1180,7 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-44", 0 ],
-									"midpoints" : [ 319.5, 240.0, 259.5, 240.0 ],
+									"midpoints" : [ 343.0, 217.500000000000028, 283.0, 217.500000000000028 ],
 									"source" : [ "obj-4", 0 ]
 								}
 
@@ -1177,6 +1188,7 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-9", 1 ],
+									"midpoints" : [ 283.0, 298.5, 283.0, 298.5 ],
 									"source" : [ "obj-41", 0 ]
 								}
 
@@ -1184,15 +1196,14 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-41", 0 ],
-									"midpoints" : [ 427.5, 311.0, 270.5, 311.0 ],
-									"source" : [ "obj-44", 2 ]
+									"source" : [ "obj-44", 0 ]
 								}
 
 							}
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-9", 0 ],
-									"midpoints" : [ 19.5, 279.0, 19.5, 279.0 ],
+									"midpoints" : [ 32.0, 256.5, 32.0, 256.5 ],
 									"source" : [ "obj-5", 0 ]
 								}
 
@@ -1222,13 +1233,13 @@
 								"name" : "max6message",
 								"default" : 								{
 									"bgfillcolor" : 									{
-										"type" : "gradient",
+										"angle" : 270.0,
+										"autogradient" : 0,
+										"color" : [ 0.290196, 0.309804, 0.301961, 1.0 ],
 										"color1" : [ 0.866667, 0.866667, 0.866667, 1.0 ],
 										"color2" : [ 0.788235, 0.788235, 0.788235, 1.0 ],
-										"color" : [ 0.290196, 0.309804, 0.301961, 1.0 ],
-										"angle" : 270.0,
 										"proportion" : 0.39,
-										"autogradient" : 0
+										"type" : "gradient"
 									}
 ,
 									"textcolor_inverse" : [ 0.0, 0.0, 0.0, 1.0 ]
@@ -1311,6 +1322,21 @@
 						"assistshowspatchername" : 0,
 						"boxes" : [ 							{
 								"box" : 								{
+									"fontname" : "Arial",
+									"fontsize" : 13.0,
+									"id" : "obj-6",
+									"linecount" : 2,
+									"maxclass" : "comment",
+									"numinlets" : 1,
+									"numoutlets" : 0,
+									"patching_rect" : [ 10.0, 60.0, 385.0, 36.0 ],
+									"text" : "You can incrementally \"fit\" a dataset, allowing you to iterate slowly through the learning process of the kmeans algorithm",
+									"textcolor" : [ 0.50196099281311, 0.50196099281311, 0.50196099281311, 1.0 ]
+								}
+
+							}
+, 							{
+								"box" : 								{
 									"bgcolor" : [ 1.0, 0.788235, 0.470588, 1.0 ],
 									"fontname" : "Arial Bold",
 									"hint" : "",
@@ -1322,7 +1348,7 @@
 									"numoutlets" : 3,
 									"outlettype" : [ "", "", "int" ],
 									"parameter_enable" : 0,
-									"patching_rect" : [ 785.0, 256.5, 20.0, 20.0 ],
+									"patching_rect" : [ 919.0, 192.5, 20.0, 20.0 ],
 									"rounded" : 60.0,
 									"text" : "3",
 									"textcolor" : [ 0.34902, 0.34902, 0.34902, 1.0 ]
@@ -1337,7 +1363,7 @@
 									"maxclass" : "comment",
 									"numinlets" : 1,
 									"numoutlets" : 0,
-									"patching_rect" : [ 582.0, 217.5, 195.0, 98.0 ],
+									"patching_rect" : [ 716.0, 153.5, 195.0, 98.0 ],
 									"text" : "Click this several times while looking at the plot. Notice how the clustering slightly shifts each time as the algorithm learns a more optimal clustering."
 								}
 
@@ -1349,7 +1375,7 @@
 									"numinlets" : 2,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 223.0, 205.0, 37.0, 23.0 ],
+									"patching_rect" : [ 357.0, 141.0, 37.0, 23.0 ],
 									"text" : "clear"
 								}
 
@@ -1372,7 +1398,7 @@
 										}
 ,
 										"classnamespace" : "box",
-										"rect" : [ 0.0, 0.0, 640.0, 480.0 ],
+										"rect" : [ 59.0, 106.0, 287.0, 236.0 ],
 										"bglocked" : 0,
 										"openinpresentation" : 0,
 										"default_fontsize" : 12.0,
@@ -1407,7 +1433,7 @@
 													"numinlets" : 2,
 													"numoutlets" : 1,
 													"outlettype" : [ "" ],
-													"patching_rect" : [ 50.0, 130.0, 41.0, 23.0 ],
+													"patching_rect" : [ 12.0, 79.0, 41.0, 22.0 ],
 													"text" : "dump"
 												}
 
@@ -1419,7 +1445,7 @@
 													"numinlets" : 2,
 													"numoutlets" : 2,
 													"outlettype" : [ "", "" ],
-													"patching_rect" : [ 50.0, 100.0, 91.0, 23.0 ],
+													"patching_rect" : [ 12.0, 49.0, 91.0, 22.0 ],
 													"text" : "route fitpredict"
 												}
 
@@ -1431,7 +1457,7 @@
 													"numinlets" : 2,
 													"numoutlets" : 2,
 													"outlettype" : [ "", "" ],
-													"patching_rect" : [ 245.0, 197.5, 74.0, 23.0 ],
+													"patching_rect" : [ 207.0, 146.5, 74.0, 22.0 ],
 													"text" : "route dump"
 												}
 
@@ -1441,9 +1467,9 @@
 													"id" : "obj-55",
 													"maxclass" : "newobj",
 													"numinlets" : 1,
-													"numoutlets" : 3,
-													"outlettype" : [ "bang", "float", "" ],
-													"patching_rect" : [ 50.0, 165.0, 214.0, 23.0 ],
+													"numoutlets" : 2,
+													"outlettype" : [ "", "" ],
+													"patching_rect" : [ 12.0, 114.0, 214.0, 22.0 ],
 													"text" : "fluid.labelset~ help.kmeans.2.labels"
 												}
 
@@ -1457,7 +1483,7 @@
 													"numinlets" : 0,
 													"numoutlets" : 1,
 													"outlettype" : [ "" ],
-													"patching_rect" : [ 50.0, 40.0, 30.0, 30.0 ]
+													"patching_rect" : [ 12.0, 8.0, 30.0, 30.0 ]
 												}
 
 											}
@@ -1469,7 +1495,7 @@
 													"maxclass" : "outlet",
 													"numinlets" : 1,
 													"numoutlets" : 0,
-													"patching_rect" : [ 245.0, 280.5, 30.0, 30.0 ]
+													"patching_rect" : [ 207.0, 179.5, 30.0, 30.0 ]
 												}
 
 											}
@@ -1498,8 +1524,7 @@
 , 											{
 												"patchline" : 												{
 													"destination" : [ "obj-15", 0 ],
-													"midpoints" : [ 254.5, 190.5, 254.5, 190.5 ],
-													"source" : [ "obj-55", 2 ]
+													"source" : [ "obj-55", 1 ]
 												}
 
 											}
@@ -1513,7 +1538,7 @@
  ]
 									}
 ,
-									"patching_rect" : [ 317.0, 370.0, 104.0, 23.0 ],
+									"patching_rect" : [ 357.0, 311.0, 104.0, 23.0 ],
 									"saved_object_attributes" : 									{
 										"description" : "",
 										"digest" : "",
@@ -1537,7 +1562,7 @@
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
 									"parameter_enable" : 0,
-									"patching_rect" : [ 10.0, 10.0, 395.0, 115.0 ]
+									"patching_rect" : [ 10.0, 10.0, 400.0, 60.0 ]
 								}
 
 							}
@@ -1548,7 +1573,7 @@
 									"maxclass" : "comment",
 									"numinlets" : 1,
 									"numoutlets" : 0,
-									"patching_rect" : [ 340.0, 535.5, 115.0, 65.0 ],
+									"patching_rect" : [ 380.0, 476.5, 115.0, 65.0 ],
 									"text" : "The colour denotes which cluster the point belongs to.",
 									"textcolor" : [ 0.501960784313725, 0.501960784313725, 0.501960784313725, 1.0 ]
 								}
@@ -1567,7 +1592,7 @@
 									"numoutlets" : 3,
 									"outlettype" : [ "", "", "int" ],
 									"parameter_enable" : 0,
-									"patching_rect" : [ 459.5, 206.5, 20.0, 20.0 ],
+									"patching_rect" : [ 593.5, 142.5, 20.0, 20.0 ],
 									"rounded" : 60.0,
 									"text" : "2",
 									"textcolor" : [ 0.34902, 0.34902, 0.34902, 1.0 ]
@@ -1581,7 +1606,7 @@
 									"maxclass" : "comment",
 									"numinlets" : 1,
 									"numoutlets" : 0,
-									"patching_rect" : [ 263.5, 204.0, 194.0, 25.0 ],
+									"patching_rect" : [ 397.5, 140.0, 194.0, 25.0 ],
 									"text" : "Clear any learning of clusters"
 								}
 
@@ -1599,7 +1624,7 @@
 									"numoutlets" : 3,
 									"outlettype" : [ "", "", "int" ],
 									"parameter_enable" : 0,
-									"patching_rect" : [ 316.0, 132.5, 20.0, 20.0 ],
+									"patching_rect" : [ 268.0, 215.0, 20.0, 20.0 ],
 									"rounded" : 60.0,
 									"text" : "1",
 									"textcolor" : [ 0.34902, 0.34902, 0.34902, 1.0 ]
@@ -1609,11 +1634,12 @@
 , 							{
 								"box" : 								{
 									"bubble" : 1,
+									"bubbleside" : 0,
 									"id" : "obj-11",
 									"maxclass" : "comment",
 									"numinlets" : 1,
 									"numoutlets" : 0,
-									"patching_rect" : [ 187.0, 130.0, 127.0, 25.0 ],
+									"patching_rect" : [ 139.0, 198.0, 127.0, 40.0 ],
 									"text" : "Choose a dataset"
 								}
 
@@ -1705,8 +1731,8 @@
 													"id" : "obj-7",
 													"maxclass" : "newobj",
 													"numinlets" : 1,
-													"numoutlets" : 3,
-													"outlettype" : [ "bang", "float", "" ],
+													"numoutlets" : 2,
+													"outlettype" : [ "", "" ],
 													"patching_rect" : [ 11.0, 132.0, 188.0, 22.0 ],
 													"text" : "fluid.dataset~ help.kmeans.2.data"
 												}
@@ -1778,7 +1804,7 @@
 , 											{
 												"patchline" : 												{
 													"destination" : [ "obj-10", 0 ],
-													"source" : [ "obj-7", 2 ]
+													"source" : [ "obj-7", 1 ]
 												}
 
 											}
@@ -1793,7 +1819,7 @@
  ]
 									}
 ,
-									"patching_rect" : [ 10.0, 205.0, 78.0, 23.0 ],
+									"patching_rect" : [ 50.0, 215.0, 78.0, 23.0 ],
 									"saved_object_attributes" : 									{
 										"description" : "",
 										"digest" : "",
@@ -1812,7 +1838,7 @@
 									"numinlets" : 2,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 280.0, 255.0, 300.0, 23.0 ],
+									"patching_rect" : [ 414.0, 191.0, 300.0, 23.0 ],
 									"text" : "fitpredict help.kmeans.2.data help.kmeans.2.labels"
 								}
 
@@ -1823,9 +1849,9 @@
 									"linecount" : 3,
 									"maxclass" : "newobj",
 									"numinlets" : 1,
-									"numoutlets" : 3,
-									"outlettype" : [ "bang", "float", "" ],
-									"patching_rect" : [ 223.0, 305.0, 113.0, 52.0 ],
+									"numoutlets" : 2,
+									"outlettype" : [ "", "" ],
+									"patching_rect" : [ 357.0, 241.0, 113.0, 52.0 ],
 									"text" : "fluid.kmeans~ @maxiter 1 @numclusters 4"
 								}
 
@@ -1836,10 +1862,10 @@
 									"id" : "obj-9",
 									"maxclass" : "jsui",
 									"numinlets" : 2,
-									"numoutlets" : 1,
-									"outlettype" : [ "" ],
+									"numoutlets" : 2,
+									"outlettype" : [ "", "" ],
 									"parameter_enable" : 0,
-									"patching_rect" : [ 10.0, 405.0, 326.0, 326.0 ]
+									"patching_rect" : [ 50.0, 346.0, 326.0, 326.0 ]
 								}
 
 							}
@@ -1859,7 +1885,7 @@
 									"numoutlets" : 1,
 									"offset" : [ 0.0, 0.0 ],
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 10.0, 130.0, 175.0, 63.363631999999996 ],
+									"patching_rect" : [ 50.0, 140.0, 175.0, 63.363631999999996 ],
 									"viewvisibility" : 1
 								}
 
@@ -1882,14 +1908,14 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-10", 0 ],
-									"source" : [ "obj-12", 2 ]
+									"source" : [ "obj-12", 0 ]
 								}
 
 							}
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-12", 0 ],
-									"midpoints" : [ 289.5, 290.0, 232.5, 290.0 ],
+									"midpoints" : [ 423.5, 226.0, 366.5, 226.0 ],
 									"source" : [ "obj-14", 0 ]
 								}
 
@@ -1904,7 +1930,7 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-9", 0 ],
-									"midpoints" : [ 19.5, 230.0, 19.5, 230.0 ],
+									"midpoints" : [ 59.5, 171.0, 59.5, 171.0 ],
 									"source" : [ "obj-5", 0 ]
 								}
 
@@ -1934,13 +1960,13 @@
 								"name" : "max6message",
 								"default" : 								{
 									"bgfillcolor" : 									{
-										"type" : "gradient",
+										"angle" : 270.0,
+										"autogradient" : 0,
+										"color" : [ 0.290196, 0.309804, 0.301961, 1.0 ],
 										"color1" : [ 0.866667, 0.866667, 0.866667, 1.0 ],
 										"color2" : [ 0.788235, 0.788235, 0.788235, 1.0 ],
-										"color" : [ 0.290196, 0.309804, 0.301961, 1.0 ],
-										"angle" : 270.0,
 										"proportion" : 0.39,
-										"autogradient" : 0
+										"type" : "gradient"
 									}
 ,
 									"textcolor_inverse" : [ 0.0, 0.0, 0.0, 1.0 ]
@@ -2023,12 +2049,27 @@
 						"assistshowspatchername" : 0,
 						"boxes" : [ 							{
 								"box" : 								{
+									"fontname" : "Arial",
+									"fontsize" : 13.0,
+									"id" : "obj-6",
+									"linecount" : 2,
+									"maxclass" : "comment",
+									"numinlets" : 1,
+									"numoutlets" : 0,
+									"patching_rect" : [ 10.0, 62.0, 420.0, 36.0 ],
+									"text" : "You can also \"set\" the means from which kmeans will learn clusters. With low iteration counts, this allows you to bias the clustering process",
+									"textcolor" : [ 0.50196099281311, 0.50196099281311, 0.50196099281311, 1.0 ]
+								}
+
+							}
+, 							{
+								"box" : 								{
 									"id" : "obj-26",
 									"linecount" : 12,
 									"maxclass" : "comment",
 									"numinlets" : 1,
 									"numoutlets" : 0,
-									"patching_rect" : [ 290.0, 514.5, 152.0, 181.0 ],
+									"patching_rect" : [ 290.0, 484.5, 154.0, 181.0 ],
 									"text" : "You will notice that after one interation, the space is roughly around the 4 means that were set in step 2.\n\nThis means that we can \"seed\" kmeans to find certain clusters rather than letting it come to its own conclusions from a random starting point.",
 									"textcolor" : [ 0.501960784313725, 0.501960784313725, 0.501960784313725, 1.0 ]
 								}
@@ -2047,7 +2088,7 @@
 									"numoutlets" : 3,
 									"outlettype" : [ "", "", "int" ],
 									"parameter_enable" : 0,
-									"patching_rect" : [ 905.0, 310.0, 20.0, 20.0 ],
+									"patching_rect" : [ 945.0, 310.0, 20.0, 20.0 ],
 									"rounded" : 60.0,
 									"text" : "4",
 									"textcolor" : [ 0.34902, 0.34902, 0.34902, 1.0 ]
@@ -2061,7 +2102,7 @@
 									"maxclass" : "comment",
 									"numinlets" : 1,
 									"numoutlets" : 0,
-									"patching_rect" : [ 490.0, 370.0, 150.0, 137.0 ],
+									"patching_rect" : [ 528.0, 380.0, 150.0, 137.0 ],
 									"text" : "fluid.kmeans~ can converge on similar clustering even with extreme means set as the seed. By keeping the iterations low it is more obvious how it affects the clustering process.",
 									"textcolor" : [ 0.501960784313725, 0.501960784313725, 0.501960784313725, 1.0 ]
 								}
@@ -2075,7 +2116,7 @@
 									"maxclass" : "comment",
 									"numinlets" : 1,
 									"numoutlets" : 0,
-									"patching_rect" : [ 610.0, 301.5, 293.0, 40.0 ],
+									"patching_rect" : [ 650.0, 301.5, 293.0, 40.0 ],
 									"text" : "Then fitpredict to predict the cluster for each point based on the means we provided.",
 									"textcolor" : [ 0.0, 0.0, 0.0, 1.0 ]
 								}
@@ -2180,8 +2221,8 @@
 													"id" : "obj-10",
 													"maxclass" : "newobj",
 													"numinlets" : 1,
-													"numoutlets" : 3,
-													"outlettype" : [ "bang", "float", "" ],
+													"numoutlets" : 2,
+													"outlettype" : [ "", "" ],
 													"patching_rect" : [ 21.0, 179.954543999999942, 217.0, 22.0 ],
 													"text" : "fluid.dataset~ help.kmeans.3.means"
 												}
@@ -2271,13 +2312,13 @@
 												"name" : "max6message",
 												"default" : 												{
 													"bgfillcolor" : 													{
-														"type" : "gradient",
+														"angle" : 270.0,
+														"autogradient" : 0,
+														"color" : [ 0.290196, 0.309804, 0.301961, 1.0 ],
 														"color1" : [ 0.866667, 0.866667, 0.866667, 1.0 ],
 														"color2" : [ 0.788235, 0.788235, 0.788235, 1.0 ],
-														"color" : [ 0.290196, 0.309804, 0.301961, 1.0 ],
-														"angle" : 270.0,
 														"proportion" : 0.39,
-														"autogradient" : 0
+														"type" : "gradient"
 													}
 ,
 													"textcolor_inverse" : [ 0.0, 0.0, 0.0, 1.0 ]
@@ -2600,7 +2641,7 @@
 									"numinlets" : 2,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 223.0, 240.0, 230.0, 23.0 ],
+									"patching_rect" : [ 261.0, 250.0, 230.0, 23.0 ],
 									"text" : "clear, setmeans help.kmeans.3.means"
 								}
 
@@ -2656,7 +2697,7 @@
 										}
 ,
 										"classnamespace" : "box",
-										"rect" : [ 84.0, 131.0, 640.0, 480.0 ],
+										"rect" : [ 84.0, 131.0, 289.0, 247.0 ],
 										"bglocked" : 0,
 										"openinpresentation" : 0,
 										"default_fontsize" : 12.0,
@@ -2691,7 +2732,7 @@
 													"numinlets" : 2,
 													"numoutlets" : 1,
 													"outlettype" : [ "" ],
-													"patching_rect" : [ 50.0, 130.0, 41.0, 22.0 ],
+													"patching_rect" : [ 18.0, 85.0, 41.0, 22.0 ],
 													"text" : "dump"
 												}
 
@@ -2703,7 +2744,7 @@
 													"numinlets" : 2,
 													"numoutlets" : 2,
 													"outlettype" : [ "", "" ],
-													"patching_rect" : [ 50.0, 100.0, 91.0, 22.0 ],
+													"patching_rect" : [ 18.0, 55.0, 91.0, 22.0 ],
 													"text" : "route fitpredict"
 												}
 
@@ -2715,7 +2756,7 @@
 													"numinlets" : 2,
 													"numoutlets" : 2,
 													"outlettype" : [ "", "" ],
-													"patching_rect" : [ 245.0, 197.5, 74.0, 22.0 ],
+													"patching_rect" : [ 197.0, 153.5, 74.0, 22.0 ],
 													"text" : "route dump"
 												}
 
@@ -2725,9 +2766,9 @@
 													"id" : "obj-55",
 													"maxclass" : "newobj",
 													"numinlets" : 1,
-													"numoutlets" : 3,
-													"outlettype" : [ "bang", "float", "" ],
-													"patching_rect" : [ 50.0, 165.0, 198.0, 22.0 ],
+													"numoutlets" : 2,
+													"outlettype" : [ "", "" ],
+													"patching_rect" : [ 18.0, 120.0, 198.0, 22.0 ],
 													"text" : "fluid.labelset~ help.kmeans.3.labels"
 												}
 
@@ -2741,7 +2782,7 @@
 													"numinlets" : 0,
 													"numoutlets" : 1,
 													"outlettype" : [ "" ],
-													"patching_rect" : [ 50.0, 40.0, 30.0, 30.0 ]
+													"patching_rect" : [ 18.0, 9.0, 30.0, 30.0 ]
 												}
 
 											}
@@ -2753,7 +2794,7 @@
 													"maxclass" : "outlet",
 													"numinlets" : 1,
 													"numoutlets" : 0,
-													"patching_rect" : [ 245.0, 280.5, 30.0, 30.0 ]
+													"patching_rect" : [ 197.0, 189.5, 30.0, 30.0 ]
 												}
 
 											}
@@ -2782,8 +2823,7 @@
 , 											{
 												"patchline" : 												{
 													"destination" : [ "obj-15", 0 ],
-													"midpoints" : [ 238.5, 190.5, 254.5, 190.5 ],
-													"source" : [ "obj-55", 2 ]
+													"source" : [ "obj-55", 1 ]
 												}
 
 											}
@@ -2797,7 +2837,7 @@
  ]
 									}
 ,
-									"patching_rect" : [ 261.0, 430.0, 104.0, 23.0 ],
+									"patching_rect" : [ 261.0, 410.0, 104.0, 23.0 ],
 									"saved_object_attributes" : 									{
 										"description" : "",
 										"digest" : "",
@@ -2821,7 +2861,7 @@
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
 									"parameter_enable" : 0,
-									"patching_rect" : [ 10.0, 10.0, 395.0, 115.0 ]
+									"patching_rect" : [ 10.0, 10.0, 305.0, 50.0 ]
 								}
 
 							}
@@ -2843,7 +2883,7 @@
 										}
 ,
 										"classnamespace" : "box",
-										"rect" : [ 59.0, 106.0, 490.0, 257.0 ],
+										"rect" : [ 59.0, 106.0, 327.0, 258.0 ],
 										"bglocked" : 0,
 										"openinpresentation" : 0,
 										"default_fontsize" : 12.0,
@@ -2873,19 +2913,6 @@
 										"assistshowspatchername" : 0,
 										"boxes" : [ 											{
 												"box" : 												{
-													"id" : "obj-33",
-													"linecount" : 2,
-													"maxclass" : "newobj",
-													"numinlets" : 1,
-													"numoutlets" : 1,
-													"outlettype" : [ "" ],
-													"patching_rect" : [ 328.0, 154.0, 108.0, 35.0 ],
-													"text" : "loadmess pointsizescale 0.3"
-												}
-
-											}
-, 											{
-												"box" : 												{
 													"id" : "obj-8",
 													"maxclass" : "newobj",
 													"numinlets" : 1,
@@ -2901,10 +2928,10 @@
 													"id" : "obj-11",
 													"maxclass" : "newobj",
 													"numinlets" : 1,
-													"numoutlets" : 4,
-													"outlettype" : [ "dump", "", "clear", "bang" ],
-													"patching_rect" : [ 11.0, 51.0, 230.5, 22.0 ],
-													"text" : "t dump l clear b"
+													"numoutlets" : 3,
+													"outlettype" : [ "dump", "", "clear" ],
+													"patching_rect" : [ 11.0, 51.0, 160.0, 22.0 ],
+													"text" : "t dump l clear"
 												}
 
 											}
@@ -2925,8 +2952,8 @@
 													"id" : "obj-7",
 													"maxclass" : "newobj",
 													"numinlets" : 1,
-													"numoutlets" : 3,
-													"outlettype" : [ "bang", "float", "" ],
+													"numoutlets" : 2,
+													"outlettype" : [ "", "" ],
 													"patching_rect" : [ 11.0, 132.0, 188.0, 22.0 ],
 													"text" : "fluid.dataset~ help.kmeans.3.data"
 												}
@@ -2968,14 +2995,6 @@
 											}
 , 											{
 												"patchline" : 												{
-													"destination" : [ "obj-33", 0 ],
-													"midpoints" : [ 232.0, 141.0, 337.5, 141.0 ],
-													"source" : [ "obj-11", 3 ]
-												}
-
-											}
-, 											{
-												"patchline" : 												{
 													"destination" : [ "obj-4", 0 ],
 													"midpoints" : [ 161.5, 84.0, 288.5, 84.0 ],
 													"source" : [ "obj-11", 2 ]
@@ -3005,16 +3024,8 @@
 											}
 , 											{
 												"patchline" : 												{
-													"destination" : [ "obj-4", 0 ],
-													"midpoints" : [ 337.5, 207.0, 288.5, 207.0 ],
-													"source" : [ "obj-33", 0 ]
-												}
-
-											}
-, 											{
-												"patchline" : 												{
 													"destination" : [ "obj-10", 0 ],
-													"source" : [ "obj-7", 2 ]
+													"source" : [ "obj-7", 1 ]
 												}
 
 											}
@@ -3051,13 +3062,13 @@
 												"name" : "max6message",
 												"default" : 												{
 													"bgfillcolor" : 													{
-														"type" : "gradient",
+														"angle" : 270.0,
+														"autogradient" : 0,
+														"color" : [ 0.290196, 0.309804, 0.301961, 1.0 ],
 														"color1" : [ 0.866667, 0.866667, 0.866667, 1.0 ],
 														"color2" : [ 0.788235, 0.788235, 0.788235, 1.0 ],
-														"color" : [ 0.290196, 0.309804, 0.301961, 1.0 ],
-														"angle" : 270.0,
 														"proportion" : 0.39,
-														"autogradient" : 0
+														"type" : "gradient"
 													}
 ,
 													"textcolor_inverse" : [ 0.0, 0.0, 0.0, 1.0 ]
@@ -3097,7 +3108,7 @@
 									"numinlets" : 2,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 300.0, 310.0, 300.0, 23.0 ],
+									"patching_rect" : [ 340.0, 310.0, 300.0, 23.0 ],
 									"text" : "fitpredict help.kmeans.3.data help.kmeans.3.labels"
 								}
 
@@ -3107,9 +3118,9 @@
 									"id" : "obj-44",
 									"maxclass" : "newobj",
 									"numinlets" : 1,
-									"numoutlets" : 3,
-									"outlettype" : [ "bang", "float", "" ],
-									"patching_rect" : [ 223.0, 370.0, 257.0, 23.0 ],
+									"numoutlets" : 2,
+									"outlettype" : [ "", "" ],
+									"patching_rect" : [ 261.0, 370.0, 257.0, 23.0 ],
 									"text" : "fluid.kmeans~ @numclusters 4 @maxiter 1"
 								}
 
@@ -3118,12 +3129,13 @@
 								"box" : 								{
 									"filename" : "fluid.plotter.js",
 									"id" : "obj-9",
+									"jsarguments" : [ 0.3 ],
 									"maxclass" : "jsui",
 									"numinlets" : 2,
-									"numoutlets" : 1,
-									"outlettype" : [ "" ],
+									"numoutlets" : 2,
+									"outlettype" : [ "", "" ],
 									"parameter_enable" : 0,
-									"patching_rect" : [ 10.0, 470.0, 270.0, 270.0 ]
+									"patching_rect" : [ 10.0, 440.0, 270.0, 270.0 ]
 								}
 
 							}
@@ -3147,7 +3159,7 @@
 									"maxclass" : "comment",
 									"numinlets" : 1,
 									"numoutlets" : 0,
-									"patching_rect" : [ 455.0, 224.5, 248.0, 54.0 ],
+									"patching_rect" : [ 493.0, 234.5, 248.0, 54.0 ],
 									"text" : "Once the means have been stored in a dataset~ we then \"set\" those means in the fluid.kmeans~ object like so",
 									"textcolor" : [ 0.0, 0.0, 0.0, 1.0 ]
 								}
@@ -3166,7 +3178,7 @@
 									"numoutlets" : 3,
 									"outlettype" : [ "", "", "int" ],
 									"parameter_enable" : 0,
-									"patching_rect" : [ 701.0, 240.0, 20.0, 20.0 ],
+									"patching_rect" : [ 739.0, 250.0, 20.0, 20.0 ],
 									"rounded" : 60.0,
 									"text" : "3",
 									"textcolor" : [ 0.34902, 0.34902, 0.34902, 1.0 ]
@@ -3212,7 +3224,7 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-44", 0 ],
-									"midpoints" : [ 309.5, 357.0, 232.5, 357.0 ],
+									"midpoints" : [ 349.5, 357.0, 270.5, 357.0 ],
 									"source" : [ "obj-14", 0 ]
 								}
 
@@ -3220,7 +3232,7 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-44", 0 ],
-									"midpoints" : [ 232.5, 264.0, 232.5, 264.0 ],
+									"midpoints" : [ 270.5, 276.0, 270.5, 276.0 ],
 									"source" : [ "obj-15", 0 ]
 								}
 
@@ -3250,8 +3262,7 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-41", 0 ],
-									"midpoints" : [ 470.5, 417.0, 270.5, 417.0 ],
-									"source" : [ "obj-44", 2 ]
+									"source" : [ "obj-44", 0 ]
 								}
 
 							}
@@ -3288,13 +3299,13 @@
 								"name" : "max6message",
 								"default" : 								{
 									"bgfillcolor" : 									{
-										"type" : "gradient",
+										"angle" : 270.0,
+										"autogradient" : 0,
+										"color" : [ 0.290196, 0.309804, 0.301961, 1.0 ],
 										"color1" : [ 0.866667, 0.866667, 0.866667, 1.0 ],
 										"color2" : [ 0.788235, 0.788235, 0.788235, 1.0 ],
-										"color" : [ 0.290196, 0.309804, 0.301961, 1.0 ],
-										"angle" : 270.0,
 										"proportion" : 0.39,
-										"autogradient" : 0
+										"type" : "gradient"
 									}
 ,
 									"textcolor_inverse" : [ 0.0, 0.0, 0.0, 1.0 ]
@@ -3346,7 +3357,7 @@
 						}
 ,
 						"classnamespace" : "box",
-						"rect" : [ 35.0, 114.0, 987.0, 751.0 ],
+						"rect" : [ 0.0, 26.0, 987.0, 751.0 ],
 						"bglocked" : 0,
 						"openinpresentation" : 0,
 						"default_fontsize" : 13.0,
@@ -3393,7 +3404,7 @@
 										}
 ,
 										"classnamespace" : "box",
-										"rect" : [ 0.0, 0.0, 640.0, 480.0 ],
+										"rect" : [ 59.0, 106.0, 309.0, 264.0 ],
 										"bglocked" : 0,
 										"openinpresentation" : 0,
 										"default_fontsize" : 12.0,
@@ -3428,7 +3439,7 @@
 													"numinlets" : 2,
 													"numoutlets" : 1,
 													"outlettype" : [ "" ],
-													"patching_rect" : [ 50.0, 130.0, 41.0, 23.0 ],
+													"patching_rect" : [ 14.0, 97.0, 41.0, 22.0 ],
 													"text" : "dump"
 												}
 
@@ -3440,7 +3451,7 @@
 													"numinlets" : 2,
 													"numoutlets" : 2,
 													"outlettype" : [ "", "" ],
-													"patching_rect" : [ 50.0, 100.0, 91.0, 23.0 ],
+													"patching_rect" : [ 14.0, 62.0, 91.0, 22.0 ],
 													"text" : "route fitpredict"
 												}
 
@@ -3452,7 +3463,7 @@
 													"numinlets" : 2,
 													"numoutlets" : 2,
 													"outlettype" : [ "", "" ],
-													"patching_rect" : [ 245.0, 192.5, 74.0, 23.0 ],
+													"patching_rect" : [ 209.0, 166.5, 74.0, 22.0 ],
 													"text" : "route dump"
 												}
 
@@ -3462,9 +3473,9 @@
 													"id" : "obj-55",
 													"maxclass" : "newobj",
 													"numinlets" : 1,
-													"numoutlets" : 3,
-													"outlettype" : [ "bang", "float", "" ],
-													"patching_rect" : [ 50.0, 160.0, 214.0, 23.0 ],
+													"numoutlets" : 2,
+													"outlettype" : [ "", "" ],
+													"patching_rect" : [ 14.0, 134.0, 214.0, 22.0 ],
 													"text" : "fluid.labelset~ help.kmeans.1.labels"
 												}
 
@@ -3478,7 +3489,7 @@
 													"numinlets" : 0,
 													"numoutlets" : 1,
 													"outlettype" : [ "" ],
-													"patching_rect" : [ 50.0, 40.0, 30.0, 30.0 ]
+													"patching_rect" : [ 14.0, 14.0, 30.0, 30.0 ]
 												}
 
 											}
@@ -3490,7 +3501,7 @@
 													"maxclass" : "outlet",
 													"numinlets" : 1,
 													"numoutlets" : 0,
-													"patching_rect" : [ 245.0, 275.5, 30.0, 30.0 ]
+													"patching_rect" : [ 209.0, 204.5, 30.0, 30.0 ]
 												}
 
 											}
@@ -3526,15 +3537,14 @@
 , 											{
 												"patchline" : 												{
 													"destination" : [ "obj-15", 0 ],
-													"midpoints" : [ 254.5, 185.5, 254.5, 185.5 ],
-													"source" : [ "obj-55", 2 ]
+													"source" : [ "obj-55", 1 ]
 												}
 
 											}
  ]
 									}
 ,
-									"patching_rect" : [ 317.0, 340.0, 107.0, 23.0 ],
+									"patching_rect" : [ 317.0, 310.0, 110.0, 23.0 ],
 									"saved_object_attributes" : 									{
 										"description" : "",
 										"digest" : "",
@@ -3542,7 +3552,7 @@
 										"tags" : ""
 									}
 ,
-									"text" : "p \"dump dataset\""
+									"text" : "p \"dump labelset\""
 								}
 
 							}
@@ -3574,7 +3584,7 @@
 									"maxclass" : "comment",
 									"numinlets" : 1,
 									"numoutlets" : 0,
-									"patching_rect" : [ 542.5, 172.0, 215.0, 36.0 ],
+									"patching_rect" : [ 509.5, 209.5, 215.0, 36.0 ],
 									"text" : "Change the number of clusters and retrigger the prediction of clusters",
 									"textcolor" : [ 0.501960784313725, 0.501960784313725, 0.501960784313725, 1.0 ]
 								}
@@ -3587,7 +3597,7 @@
 									"maxclass" : "comment",
 									"numinlets" : 1,
 									"numoutlets" : 0,
-									"patching_rect" : [ 340.0, 535.5, 115.0, 65.0 ],
+									"patching_rect" : [ 340.0, 480.5, 115.0, 65.0 ],
 									"text" : "The colour denotes which cluster the point belongs to.",
 									"textcolor" : [ 0.501960784313725, 0.501960784313725, 0.501960784313725, 1.0 ]
 								}
@@ -3606,7 +3616,7 @@
 									"numoutlets" : 3,
 									"outlettype" : [ "", "", "int" ],
 									"parameter_enable" : 0,
-									"patching_rect" : [ 953.0, 135.0, 20.0, 20.0 ],
+									"patching_rect" : [ 920.0, 172.5, 20.0, 20.0 ],
 									"rounded" : 60.0,
 									"text" : "2",
 									"textcolor" : [ 0.34902, 0.34902, 0.34902, 1.0 ]
@@ -3620,7 +3630,7 @@
 									"maxclass" : "comment",
 									"numinlets" : 1,
 									"numoutlets" : 0,
-									"patching_rect" : [ 687.0, 132.5, 264.0, 25.0 ],
+									"patching_rect" : [ 654.0, 170.0, 264.0, 25.0 ],
 									"text" : "Predict clusters from the selected dataset"
 								}
 
@@ -3666,7 +3676,7 @@
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
 									"parameter_enable" : 0,
-									"patching_rect" : [ 390.5, 180.0, 150.0, 23.0 ]
+									"patching_rect" : [ 357.5, 217.5, 150.0, 23.0 ]
 								}
 
 							}
@@ -3757,8 +3767,8 @@
 													"id" : "obj-7",
 													"maxclass" : "newobj",
 													"numinlets" : 1,
-													"numoutlets" : 3,
-													"outlettype" : [ "bang", "float", "" ],
+													"numoutlets" : 2,
+													"outlettype" : [ "", "" ],
 													"patching_rect" : [ 11.0, 132.0, 203.0, 22.0 ],
 													"text" : "fluid.dataset~ help.kmeans.1.data"
 												}
@@ -3830,7 +3840,7 @@
 , 											{
 												"patchline" : 												{
 													"destination" : [ "obj-10", 0 ],
-													"source" : [ "obj-7", 2 ]
+													"source" : [ "obj-7", 1 ]
 												}
 
 											}
@@ -3864,7 +3874,7 @@
 									"numinlets" : 2,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 350.0, 132.5, 335.0, 23.0 ],
+									"patching_rect" : [ 317.0, 170.0, 335.0, 23.0 ],
 									"text" : "clear, fitpredict help.kmeans.1.data help.kmeans.1.labels"
 								}
 
@@ -3874,9 +3884,9 @@
 									"id" : "obj-12",
 									"maxclass" : "newobj",
 									"numinlets" : 1,
-									"numoutlets" : 3,
-									"outlettype" : [ "bang", "float", "" ],
-									"patching_rect" : [ 350.0, 230.0, 89.0, 23.0 ],
+									"numoutlets" : 2,
+									"outlettype" : [ "", "" ],
+									"patching_rect" : [ 317.0, 267.5, 89.0, 23.0 ],
 									"text" : "fluid.kmeans~"
 								}
 
@@ -3887,10 +3897,10 @@
 									"id" : "obj-9",
 									"maxclass" : "jsui",
 									"numinlets" : 2,
-									"numoutlets" : 1,
-									"outlettype" : [ "" ],
+									"numoutlets" : 2,
+									"outlettype" : [ "", "" ],
 									"parameter_enable" : 0,
-									"patching_rect" : [ 10.0, 405.0, 326.0, 326.0 ]
+									"patching_rect" : [ 10.0, 350.0, 326.0, 326.0 ]
 								}
 
 							}
@@ -3942,15 +3952,14 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-6", 0 ],
-									"midpoints" : [ 429.5, 301.0, 326.5, 301.0 ],
-									"source" : [ "obj-12", 2 ]
+									"source" : [ "obj-12", 0 ]
 								}
 
 							}
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-12", 0 ],
-									"midpoints" : [ 359.5, 157.5, 359.5, 157.5 ],
+									"midpoints" : [ 326.5, 195.0, 326.5, 195.0 ],
 									"source" : [ "obj-14", 0 ]
 								}
 
@@ -3973,7 +3982,7 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-12", 0 ],
-									"midpoints" : [ 400.0, 215.0, 359.5, 215.0 ],
+									"midpoints" : [ 367.0, 252.5, 326.5, 252.5 ],
 									"source" : [ "obj-8", 0 ]
 								}
 
@@ -4003,13 +4012,13 @@
 								"name" : "max6message",
 								"default" : 								{
 									"bgfillcolor" : 									{
-										"type" : "gradient",
+										"angle" : 270.0,
+										"autogradient" : 0,
+										"color" : [ 0.290196, 0.309804, 0.301961, 1.0 ],
 										"color1" : [ 0.866667, 0.866667, 0.866667, 1.0 ],
 										"color2" : [ 0.788235, 0.788235, 0.788235, 1.0 ],
-										"color" : [ 0.290196, 0.309804, 0.301961, 1.0 ],
-										"angle" : 270.0,
 										"proportion" : 0.39,
-										"autogradient" : 0
+										"type" : "gradient"
 									}
 ,
 									"textcolor_inverse" : [ 0.0, 0.0, 0.0, 1.0 ]
@@ -4109,45 +4118,6 @@
 			}
  ],
 		"lines" : [  ],
-		"dependency_cache" : [ 			{
-				"name" : "fluid.dataloader.maxpat",
-				"bootpath" : "~/dev/flucoma/max/patchers",
-				"patcherrelativepath" : "../patchers",
-				"type" : "JSON",
-				"implicit" : 1
-			}
-, 			{
-				"name" : "fluid.flucomaorg.maxpat",
-				"bootpath" : "~/dev/flucoma/max/help",
-				"patcherrelativepath" : ".",
-				"type" : "JSON",
-				"implicit" : 1
-			}
-, 			{
-				"name" : "fluid.learn.maxpat",
-				"bootpath" : "~/dev/flucoma/max/help",
-				"patcherrelativepath" : ".",
-				"type" : "JSON",
-				"implicit" : 1
-			}
-, 			{
-				"name" : "fluid.libmanipulation.mxo",
-				"type" : "iLaX"
-			}
-, 			{
-				"name" : "fluid.plotter.js",
-				"bootpath" : "~/dev/flucoma/max/jsui",
-				"patcherrelativepath" : "../jsui",
-				"type" : "TEXT",
-				"implicit" : 1
-			}
-, 			{
-				"name" : "helpdetails.js",
-				"bootpath" : "C74:/help/resources",
-				"type" : "TEXT",
-				"implicit" : 1
-			}
- ],
 		"autosave" : 0
 	}
 

--- a/help/fluid.labelset~.maxhelp
+++ b/help/fluid.labelset~.maxhelp
@@ -3,8 +3,8 @@
 		"fileversion" : 1,
 		"appversion" : 		{
 			"major" : 8,
-			"minor" : 2,
-			"revision" : 2,
+			"minor" : 3,
+			"revision" : 0,
 			"architecture" : "x64",
 			"modernui" : 1
 		}
@@ -50,8 +50,8 @@
 						"fileversion" : 1,
 						"appversion" : 						{
 							"major" : 8,
-							"minor" : 2,
-							"revision" : 2,
+							"minor" : 3,
+							"revision" : 0,
 							"architecture" : "x64",
 							"modernui" : 1
 						}
@@ -64,7 +64,7 @@
 						"default_fontface" : 0,
 						"default_fontname" : "Arial",
 						"gridonopen" : 2,
-						"gridsize" : [ 5.0, 5.0 ],
+						"gridsize" : [ 10.0, 10.0 ],
 						"gridsnaponopen" : 2,
 						"objectsnaponopen" : 1,
 						"statusbarvisible" : 2,
@@ -88,22 +88,60 @@
 						"assistshowspatchername" : 0,
 						"boxes" : [ 							{
 								"box" : 								{
-									"args" : [ "labelset" ],
-									"bgmode" : 0,
-									"border" : 0,
-									"clickthrough" : 0,
-									"enablehscroll" : 0,
-									"enablevscroll" : 0,
-									"id" : "obj-1",
-									"lockeddragscroll" : 0,
-									"lockedsize" : 0,
-									"maxclass" : "bpatcher",
-									"name" : "fluid.learn.maxpat",
-									"numinlets" : 0,
+									"id" : "obj-16",
+									"maxclass" : "button",
+									"numinlets" : 1,
+									"numoutlets" : 1,
+									"outlettype" : [ "bang" ],
+									"parameter_enable" : 0,
+									"patching_rect" : [ 50.0, 310.0, 24.0, 24.0 ]
+								}
+
+							}
+, 							{
+								"box" : 								{
+									"id" : "obj-9",
+									"maxclass" : "dict.view",
+									"numinlets" : 1,
 									"numoutlets" : 0,
-									"offset" : [ 0.0, 0.0 ],
-									"patching_rect" : [ 363.0, 5.0, 240.0, 111.5 ],
-									"viewvisibility" : 1
+									"patching_rect" : [ 208.0, 478.5, 156.0, 95.0 ]
+								}
+
+							}
+, 							{
+								"box" : 								{
+									"id" : "obj-11",
+									"maxclass" : "newobj",
+									"numinlets" : 2,
+									"numoutlets" : 2,
+									"outlettype" : [ "", "" ],
+									"patching_rect" : [ 208.0, 443.5, 74.0, 23.0 ],
+									"text" : "route dump"
+								}
+
+							}
+, 							{
+								"box" : 								{
+									"color" : [ 0.254901960784314, 0.905882352941176, 0.450980392156863, 1.0 ],
+									"id" : "obj-7",
+									"maxclass" : "newobj",
+									"numinlets" : 1,
+									"numoutlets" : 2,
+									"outlettype" : [ "float", "bang" ],
+									"patching_rect" : [ 320.0, 260.0, 152.0, 23.0 ],
+									"text" : "buffer~ features.stats.flat"
+								}
+
+							}
+, 							{
+								"box" : 								{
+									"id" : "obj-4",
+									"maxclass" : "comment",
+									"numinlets" : 1,
+									"numoutlets" : 0,
+									"patching_rect" : [ 10.0, 62.0, 603.0, 21.0 ],
+									"text" : "Create associations between identifiers shared across fluid.dataset~ objects and fluid.labelset~ objects.",
+									"textcolor" : [ 0.501960784313725, 0.501960784313725, 0.501960784313725, 1.0 ]
 								}
 
 							}
@@ -119,7 +157,7 @@
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
 									"parameter_enable" : 0,
-									"patching_rect" : [ 5.0, 5.0, 360.0, 105.0 ]
+									"patching_rect" : [ 10.0, 10.0, 310.0, 50.0 ]
 								}
 
 							}
@@ -136,7 +174,7 @@
 									"numoutlets" : 3,
 									"outlettype" : [ "", "", "int" ],
 									"parameter_enable" : 0,
-									"patching_rect" : [ 455.0, 370.0, 20.0, 20.0 ],
+									"patching_rect" : [ 80.0, 312.0, 20.0, 20.0 ],
 									"rounded" : 60.0,
 									"text" : "2",
 									"textcolor" : [ 0.34902, 0.34902, 0.34902, 1.0 ]
@@ -146,12 +184,12 @@
 , 							{
 								"box" : 								{
 									"id" : "obj-27",
-									"linecount" : 9,
+									"linecount" : 8,
 									"maxclass" : "comment",
 									"numinlets" : 1,
 									"numoutlets" : 0,
-									"patching_rect" : [ 480.0, 365.0, 282.0, 137.0 ],
-									"text" : "Once setpoint is sent to the fluid.dataset~ that contains our analysis, a message is sent to the fluid.labelset~ below associating the identifier \"scratch-synth\" with the label \"noisy\". Both the fluid.dataset~ and fluid.labelset~ have the identifier \"scratch-synth\". If for example, a fluid.mlpclassifier~ was trained with this data, the \"noisy\" label would be the training label for the data inside the dataset with that identifier.",
+									"patching_rect" : [ 670.0, 393.5, 282.0, 123.0 ],
+									"text" : "setlabel message is sent to the fluid.labelset~ below associating the identifier \"scratch-synth\" with the label \"noisy\". Both the fluid.dataset~ and fluid.labelset~ have the identifier \"scratch-synth\". If for example, a fluid.mlpclassifier~ was trained with this data, the \"noisy\" label would be the training label for the data inside the dataset with that identifier.",
 									"textcolor" : [ 0.501960784313725, 0.501960784313725, 0.501960784313725, 1.0 ]
 								}
 
@@ -162,19 +200,7 @@
 									"maxclass" : "dict.view",
 									"numinlets" : 1,
 									"numoutlets" : 0,
-									"patching_rect" : [ 289.0, 520.0, 156.0, 95.0 ]
-								}
-
-							}
-, 							{
-								"box" : 								{
-									"id" : "obj-23",
-									"maxclass" : "message",
-									"numinlets" : 2,
-									"numoutlets" : 1,
-									"outlettype" : [ "" ],
-									"patching_rect" : [ 237.0, 520.0, 41.0, 23.0 ],
-									"text" : "dump"
+									"patching_rect" : [ 507.0, 478.5, 156.0, 95.0 ]
 								}
 
 							}
@@ -182,11 +208,11 @@
 								"box" : 								{
 									"id" : "obj-19",
 									"maxclass" : "newobj",
-									"numinlets" : 3,
-									"numoutlets" : 3,
-									"outlettype" : [ "", "", "" ],
-									"patching_rect" : [ 237.0, 485.0, 123.0, 23.0 ],
-									"text" : "route setlabel dump"
+									"numinlets" : 2,
+									"numoutlets" : 2,
+									"outlettype" : [ "", "" ],
+									"patching_rect" : [ 507.0, 443.5, 74.0, 23.0 ],
+									"text" : "route dump"
 								}
 
 							}
@@ -197,20 +223,8 @@
 									"numinlets" : 2,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 168.0, 410.0, 168.0, 23.0 ],
-									"text" : "setlabel scratch-synth noisy"
-								}
-
-							}
-, 							{
-								"box" : 								{
-									"id" : "obj-14",
-									"maxclass" : "newobj",
-									"numinlets" : 2,
-									"numoutlets" : 2,
-									"outlettype" : [ "", "" ],
-									"patching_rect" : [ 168.0, 370.0, 87.0, 23.0 ],
-									"text" : "route setpoint"
+									"patching_rect" : [ 360.0, 370.0, 207.0, 23.0 ],
+									"text" : "setlabel scratch-synth noisy, dump"
 								}
 
 							}
@@ -219,21 +233,10 @@
 									"id" : "obj-12",
 									"maxclass" : "newobj",
 									"numinlets" : 1,
-									"numoutlets" : 3,
-									"outlettype" : [ "bang", "float", "" ],
-									"patching_rect" : [ 168.0, 450.0, 88.0, 23.0 ],
-									"text" : "fluid.labelset~"
-								}
-
-							}
-, 							{
-								"box" : 								{
-									"arrows" : 1,
-									"id" : "obj-15",
-									"maxclass" : "live.line",
-									"numinlets" : 1,
-									"numoutlets" : 0,
-									"patching_rect" : [ 41.25, 143.0, 540.75, 7.0 ]
+									"numoutlets" : 2,
+									"outlettype" : [ "", "" ],
+									"patching_rect" : [ 360.0, 410.0, 166.0, 23.0 ],
+									"text" : "fluid.labelset~ sound-labels"
 								}
 
 							}
@@ -250,7 +253,7 @@
 									"numoutlets" : 3,
 									"outlettype" : [ "", "", "int" ],
 									"parameter_enable" : 0,
-									"patching_rect" : [ 595.0, 178.0, 20.0, 20.0 ],
+									"patching_rect" : [ 620.0, 132.0, 20.0, 20.0 ],
 									"rounded" : 60.0,
 									"text" : "1",
 									"textcolor" : [ 0.34902, 0.34902, 0.34902, 1.0 ]
@@ -261,12 +264,12 @@
 								"box" : 								{
 									"bubble" : 1,
 									"id" : "obj-36",
-									"linecount" : 6,
+									"linecount" : 3,
 									"maxclass" : "comment",
 									"numinlets" : 1,
 									"numoutlets" : 0,
-									"patching_rect" : [ 617.0, 139.0, 230.0, 98.0 ],
-									"text" : "Analyse the buffer named src with the mel-frequency cepstrum coefficient descriptor. Calculate the statistics across each coefficient per spectral frame and flatten the data to a single dimension."
+									"patching_rect" : [ 60.0, 115.0, 549.0, 54.0 ],
+									"text" : "Calculate the MFCCs across a source buffer. Calculate the statistics across each coefficient per spectral frame and flatten the data to a single dimension. This is a common workflow for storing a large number of descriptors in a dataset"
 								}
 
 							}
@@ -275,21 +278,10 @@
 									"id" : "obj-21",
 									"maxclass" : "newobj",
 									"numinlets" : 1,
-									"numoutlets" : 3,
-									"outlettype" : [ "bang", "float", "" ],
-									"patching_rect" : [ 10.0, 335.0, 177.0, 23.0 ],
+									"numoutlets" : 2,
+									"outlettype" : [ "", "" ],
+									"patching_rect" : [ 50.0, 410.0, 177.0, 23.0 ],
 									"text" : "fluid.dataset~ sound-analysis"
-								}
-
-							}
-, 							{
-								"box" : 								{
-									"id" : "obj-20",
-									"maxclass" : "comment",
-									"numinlets" : 1,
-									"numoutlets" : 0,
-									"patching_rect" : [ 250.0, 297.0, 185.0, 21.0 ],
-									"text" : "setpoint <identifier> <buffer>"
 								}
 
 							}
@@ -300,8 +292,8 @@
 									"numinlets" : 2,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 10.0, 295.0, 238.0, 23.0 ],
-									"text" : "setpoint scratch-synth features.stats.flat"
+									"patching_rect" : [ 50.0, 370.0, 277.0, 23.0 ],
+									"text" : "setpoint scratch-synth features.stats.flat, dump"
 								}
 
 							}
@@ -313,46 +305,20 @@
 									"numoutlets" : 1,
 									"outlettype" : [ "bang" ],
 									"parameter_enable" : 0,
-									"patching_rect" : [ 10.0, 135.0, 24.0, 24.0 ]
+									"patching_rect" : [ 30.0, 130.0, 24.0, 24.0 ]
 								}
 
 							}
 , 							{
 								"box" : 								{
-									"color" : [ 0.309803921568627, 0.63921568627451, 0.988235294117647, 1.0 ],
-									"id" : "obj-11",
-									"maxclass" : "newobj",
-									"numinlets" : 1,
-									"numoutlets" : 2,
-									"outlettype" : [ "float", "bang" ],
-									"patching_rect" : [ 430.0, 250.0, 152.0, 23.0 ],
-									"text" : "buffer~ features.stats.flat"
-								}
-
-							}
-, 							{
-								"box" : 								{
-									"color" : [ 0.309803921568627, 0.63921568627451, 0.988235294117647, 1.0 ],
+									"color" : [ 0.254901960784314, 0.905882352941176, 0.450980392156863, 1.0 ],
 									"id" : "obj-10",
 									"maxclass" : "newobj",
 									"numinlets" : 1,
-									"numoutlets" : 3,
-									"outlettype" : [ "bang", "float", "" ],
-									"patching_rect" : [ 10.0, 250.0, 417.0, 23.0 ],
-									"text" : "fluid.bufflatten~ @source features.stats @destination features.stats.flat"
-								}
-
-							}
-, 							{
-								"box" : 								{
-									"color" : [ 1.0, 0.694117647058824, 0.0, 1.0 ],
-									"id" : "obj-9",
-									"maxclass" : "newobj",
-									"numinlets" : 1,
 									"numoutlets" : 2,
-									"outlettype" : [ "float", "bang" ],
-									"patching_rect" : [ 430.0, 210.0, 131.0, 23.0 ],
-									"text" : "buffer~ features.stats"
+									"outlettype" : [ "", "" ],
+									"patching_rect" : [ 30.0, 260.0, 279.0, 23.0 ],
+									"text" : "fluid.bufflatten~ @destination features.stats.flat"
 								}
 
 							}
@@ -361,24 +327,11 @@
 									"color" : [ 1.0, 0.694117647058824, 0.0, 1.0 ],
 									"id" : "obj-8",
 									"maxclass" : "newobj",
-									"numinlets" : 1,
-									"numoutlets" : 3,
-									"outlettype" : [ "bang", "float", "" ],
-									"patching_rect" : [ 10.0, 210.0, 321.0, 23.0 ],
-									"text" : "fluid.bufstats~ @source features @stats features.stats"
-								}
-
-							}
-, 							{
-								"box" : 								{
-									"color" : [ 0.968627450980392, 0.431372549019608, 0.431372549019608, 1.0 ],
-									"id" : "obj-7",
-									"maxclass" : "newobj",
-									"numinlets" : 1,
+									"numinlets" : 2,
 									"numoutlets" : 2,
-									"outlettype" : [ "float", "bang" ],
-									"patching_rect" : [ 430.0, 170.0, 100.0, 23.0 ],
-									"text" : "buffer~ features"
+									"outlettype" : [ "", "" ],
+									"patching_rect" : [ 30.0, 220.0, 89.0, 23.0 ],
+									"text" : "fluid.bufstats~"
 								}
 
 							}
@@ -388,10 +341,10 @@
 									"id" : "obj-6",
 									"maxclass" : "newobj",
 									"numinlets" : 1,
-									"numoutlets" : 3,
-									"outlettype" : [ "bang", "float", "" ],
-									"patching_rect" : [ 10.0, 170.0, 298.0, 23.0 ],
-									"text" : "fluid.bufmfcc~ 13 @source src @features features"
+									"numoutlets" : 2,
+									"outlettype" : [ "", "" ],
+									"patching_rect" : [ 30.0, 180.0, 292.0, 23.0 ],
+									"text" : "fluid.bufmfcc~ 13 @source help.labelset.srcaudio"
 								}
 
 							}
@@ -402,57 +355,23 @@
 									"numinlets" : 1,
 									"numoutlets" : 2,
 									"outlettype" : [ "float", "bang" ],
-									"patching_rect" : [ 595.0, 250.0, 313.0, 23.0 ],
-									"text" : "buffer~ src Tremblay-ASWINE-ScratchySynth-M.wav"
-								}
-
-							}
-, 							{
-								"box" : 								{
-									"angle" : 270.0,
-									"background" : 1,
-									"bgcolor" : [ 0.2, 0.2, 0.2, 0.0 ],
-									"border" : 2,
-									"bordercolor" : [ 1.0, 0.709803921568627, 0.196078431372549, 1.0 ],
-									"id" : "obj-25",
-									"maxclass" : "panel",
-									"mode" : 0,
-									"numinlets" : 1,
-									"numoutlets" : 0,
-									"patching_rect" : [ 160.0, 365.0, 290.0, 260.0 ],
-									"proportion" : 0.5
-								}
-
-							}
-, 							{
-								"box" : 								{
-									"angle" : 270.0,
-									"background" : 1,
-									"bgcolor" : [ 0.2, 0.2, 0.2, 0.0 ],
-									"border" : 2,
-									"bordercolor" : [ 1.0, 0.709803921568627, 0.196078431372549, 1.0 ],
-									"id" : "obj-45",
-									"maxclass" : "panel",
-									"mode" : 0,
-									"numinlets" : 1,
-									"numoutlets" : 0,
-									"patching_rect" : [ 5.0, 130.0, 585.0, 150.0 ],
-									"proportion" : 0.5
+									"patching_rect" : [ 333.0, 180.0, 421.0, 23.0 ],
+									"text" : "buffer~ help.labelset.srcaudio Tremblay-ASWINE-ScratchySynth-M.wav"
 								}
 
 							}
  ],
 						"lines" : [ 							{
 								"patchline" : 								{
-									"destination" : [ "obj-18", 0 ],
-									"source" : [ "obj-10", 0 ]
+									"destination" : [ "obj-9", 0 ],
+									"source" : [ "obj-11", 0 ]
 								}
 
 							}
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-19", 0 ],
-									"source" : [ "obj-12", 2 ]
+									"source" : [ "obj-12", 1 ]
 								}
 
 							}
@@ -466,7 +385,18 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-17", 0 ],
-									"source" : [ "obj-14", 0 ]
+									"midpoints" : [ 59.5, 356.0, 369.5, 356.0 ],
+									"order" : 0,
+									"source" : [ "obj-16", 0 ]
+								}
+
+							}
+, 							{
+								"patchline" : 								{
+									"destination" : [ "obj-18", 0 ],
+									"midpoints" : [ 59.5, 335.0, 59.5, 335.0 ],
+									"order" : 1,
+									"source" : [ "obj-16", 0 ]
 								}
 
 							}
@@ -486,30 +416,15 @@
 							}
 , 							{
 								"patchline" : 								{
-									"destination" : [ "obj-23", 0 ],
+									"destination" : [ "obj-24", 0 ],
 									"source" : [ "obj-19", 0 ]
 								}
 
 							}
 , 							{
 								"patchline" : 								{
-									"destination" : [ "obj-24", 0 ],
-									"source" : [ "obj-19", 1 ]
-								}
-
-							}
-, 							{
-								"patchline" : 								{
-									"destination" : [ "obj-14", 0 ],
-									"source" : [ "obj-21", 2 ]
-								}
-
-							}
-, 							{
-								"patchline" : 								{
-									"destination" : [ "obj-12", 0 ],
-									"midpoints" : [ 246.5, 545.0, 154.0, 545.0, 154.0, 446.0, 177.5, 446.0 ],
-									"source" : [ "obj-23", 0 ]
+									"destination" : [ "obj-11", 0 ],
+									"source" : [ "obj-21", 1 ]
 								}
 
 							}
@@ -552,13 +467,13 @@
 								"name" : "max6message",
 								"default" : 								{
 									"bgfillcolor" : 									{
-										"type" : "gradient",
+										"angle" : 270.0,
+										"autogradient" : 0,
+										"color" : [ 0.290196, 0.309804, 0.301961, 1.0 ],
 										"color1" : [ 0.866667, 0.866667, 0.866667, 1.0 ],
 										"color2" : [ 0.788235, 0.788235, 0.788235, 1.0 ],
-										"color" : [ 0.290196, 0.309804, 0.301961, 1.0 ],
-										"angle" : 270.0,
 										"proportion" : 0.39,
-										"autogradient" : 0
+										"type" : "gradient"
 									}
 ,
 									"textcolor_inverse" : [ 0.0, 0.0, 0.0, 1.0 ]
@@ -603,8 +518,8 @@
 						"fileversion" : 1,
 						"appversion" : 						{
 							"major" : 8,
-							"minor" : 2,
-							"revision" : 2,
+							"minor" : 3,
+							"revision" : 0,
 							"architecture" : "x64",
 							"modernui" : 1
 						}
@@ -617,7 +532,7 @@
 						"default_fontface" : 0,
 						"default_fontname" : "Arial",
 						"gridonopen" : 2,
-						"gridsize" : [ 5.0, 5.0 ],
+						"gridsize" : [ 10.0, 10.0 ],
 						"gridsnaponopen" : 2,
 						"objectsnaponopen" : 1,
 						"statusbarvisible" : 2,
@@ -641,22 +556,14 @@
 						"assistshowspatchername" : 0,
 						"boxes" : [ 							{
 								"box" : 								{
-									"args" : [ "labelset" ],
-									"bgmode" : 0,
-									"border" : 0,
-									"clickthrough" : 0,
-									"enablehscroll" : 0,
-									"enablevscroll" : 0,
 									"id" : "obj-2",
-									"lockeddragscroll" : 0,
-									"lockedsize" : 0,
-									"maxclass" : "bpatcher",
-									"name" : "fluid.learn.maxpat",
-									"numinlets" : 0,
+									"maxclass" : "comment",
+									"numinlets" : 1,
 									"numoutlets" : 0,
-									"offset" : [ 0.0, 0.0 ],
-									"patching_rect" : [ 363.0, 5.0, 240.0, 111.5 ],
-									"viewvisibility" : 1
+									"patching_rect" : [ 10.0, 62.0, 244.0, 21.0 ],
+									"presentation_linecount" : 2,
+									"text" : "Other useful messages for fluid.labelset~",
+									"textcolor" : [ 0.501960784313725, 0.501960784313725, 0.501960784313725, 1.0 ]
 								}
 
 							}
@@ -672,7 +579,7 @@
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
 									"parameter_enable" : 0,
-									"patching_rect" : [ 5.0, 5.0, 360.0, 105.0 ]
+									"patching_rect" : [ 10.0, 10.0, 300.0, 50.0 ]
 								}
 
 							}
@@ -683,7 +590,7 @@
 									"numinlets" : 1,
 									"numoutlets" : 1,
 									"outlettype" : [ "bang" ],
-									"patching_rect" : [ 5.0, 120.0, 62.0, 23.0 ],
+									"patching_rect" : [ 120.0, 120.0, 62.0, 23.0 ],
 									"text" : "loadbang"
 								}
 
@@ -699,8 +606,8 @@
 										"fileversion" : 1,
 										"appversion" : 										{
 											"major" : 8,
-											"minor" : 2,
-											"revision" : 2,
+											"minor" : 3,
+											"revision" : 0,
 											"architecture" : "x64",
 											"modernui" : 1
 										}
@@ -806,8 +713,8 @@
 														"fileversion" : 1,
 														"appversion" : 														{
 															"major" : 8,
-															"minor" : 2,
-															"revision" : 2,
+															"minor" : 3,
+															"revision" : 0,
 															"architecture" : "x64",
 															"modernui" : 1
 														}
@@ -987,8 +894,8 @@
 													"id" : "obj-54",
 													"maxclass" : "newobj",
 													"numinlets" : 1,
-													"numoutlets" : 3,
-													"outlettype" : [ "bang", "float", "" ],
+													"numoutlets" : 2,
+													"outlettype" : [ "", "" ],
 													"patching_rect" : [ 111.5, 99.0, 139.0, 22.0 ],
 													"text" : "fluid.labelset~ help.other"
 												}
@@ -1124,7 +1031,7 @@
  ]
 									}
 ,
-									"patching_rect" : [ 5.0, 153.0, 166.0, 23.0 ],
+									"patching_rect" : [ 120.0, 153.0, 166.0, 23.0 ],
 									"saved_object_attributes" : 									{
 										"description" : "",
 										"digest" : "",
@@ -1138,13 +1045,13 @@
 							}
 , 							{
 								"box" : 								{
-									"bubble" : 1,
 									"id" : "obj-27",
 									"maxclass" : "comment",
 									"numinlets" : 1,
 									"numoutlets" : 0,
-									"patching_rect" : [ 176.0, 315.0, 367.0, 25.0 ],
-									"text" : "Dump the contents of the fluid.dataset~ to a Max dictionary."
+									"patching_rect" : [ 294.5, 299.0, 350.0, 21.0 ],
+									"text" : "Dump the contents of the fluid.dataset~ to a Max dictionary.",
+									"textcolor" : [ 0.501960784313725, 0.501960784313725, 0.501960784313725, 1.0 ]
 								}
 
 							}
@@ -1155,28 +1062,8 @@
 									"numinlets" : 2,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 111.0, 315.0, 41.0, 23.0 ],
+									"patching_rect" : [ 250.0, 300.0, 41.0, 23.0 ],
 									"text" : "dump"
-								}
-
-							}
-, 							{
-								"box" : 								{
-									"bgcolor" : [ 0.968627450980392, 0.431372549019608, 0.431372549019608, 1.0 ],
-									"fontname" : "Arial Bold",
-									"hint" : "",
-									"id" : "obj-29",
-									"ignoreclick" : 1,
-									"legacytextcolor" : 1,
-									"maxclass" : "textbutton",
-									"numinlets" : 1,
-									"numoutlets" : 3,
-									"outlettype" : [ "", "", "int" ],
-									"parameter_enable" : 0,
-									"patching_rect" : [ 176.0, 353.0, 20.0, 20.0 ],
-									"rounded" : 60.0,
-									"text" : "5",
-									"textcolor" : [ 0.929411764705882, 0.941176470588235, 0.956862745098039, 1.0 ]
 								}
 
 							}
@@ -1186,27 +1073,7 @@
 									"maxclass" : "dict.view",
 									"numinlets" : 1,
 									"numoutlets" : 0,
-									"patching_rect" : [ 136.0, 535.0, 309.0, 180.0 ]
-								}
-
-							}
-, 							{
-								"box" : 								{
-									"bgcolor" : [ 0.968627450980392, 0.431372549019608, 0.431372549019608, 1.0 ],
-									"fontname" : "Arial Bold",
-									"hint" : "",
-									"id" : "obj-24",
-									"ignoreclick" : 1,
-									"legacytextcolor" : 1,
-									"maxclass" : "textbutton",
-									"numinlets" : 1,
-									"numoutlets" : 3,
-									"outlettype" : [ "", "", "int" ],
-									"parameter_enable" : 0,
-									"patching_rect" : [ 154.0, 316.5, 20.0, 20.0 ],
-									"rounded" : 60.0,
-									"text" : "4",
-									"textcolor" : [ 0.929411764705882, 0.941176470588235, 0.956862745098039, 1.0 ]
+									"patching_rect" : [ 299.0, 495.0, 161.0, 210.0 ]
 								}
 
 							}
@@ -1216,7 +1083,7 @@
 									"maxclass" : "newobj",
 									"numinlets" : 1,
 									"numoutlets" : 0,
-									"patching_rect" : [ 191.0, 505.0, 98.0, 23.0 ],
+									"patching_rect" : [ 354.0, 465.0, 98.0, 23.0 ],
 									"text" : "print @popup 1"
 								}
 
@@ -1228,20 +1095,20 @@
 									"numinlets" : 2,
 									"numoutlets" : 2,
 									"outlettype" : [ "", "" ],
-									"patching_rect" : [ 136.0, 465.0, 74.0, 23.0 ],
+									"patching_rect" : [ 299.0, 425.0, 74.0, 23.0 ],
 									"text" : "route dump"
 								}
 
 							}
 , 							{
 								"box" : 								{
-									"bubble" : 1,
 									"id" : "obj-13",
 									"maxclass" : "comment",
 									"numinlets" : 1,
 									"numoutlets" : 0,
-									"patching_rect" : [ 141.0, 276.5, 359.0, 25.0 ],
-									"text" : "Get the size (number of identifiers with associated labels)."
+									"patching_rect" : [ 259.5, 260.5, 342.0, 21.0 ],
+									"text" : "Get the size (number of identifiers with associated labels).",
+									"textcolor" : [ 0.501960784313725, 0.501960784313725, 0.501960784313725, 1.0 ]
 								}
 
 							}
@@ -1252,20 +1119,20 @@
 									"numinlets" : 2,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 83.0, 275.0, 32.0, 23.0 ],
+									"patching_rect" : [ 222.0, 260.0, 32.0, 23.0 ],
 									"text" : "size"
 								}
 
 							}
 , 							{
 								"box" : 								{
-									"bubble" : 1,
 									"id" : "obj-10",
 									"maxclass" : "comment",
 									"numinlets" : 1,
 									"numoutlets" : 0,
-									"patching_rect" : [ 120.5, 236.5, 211.0, 25.0 ],
-									"text" : "Read a fluid.labelset~ from disk."
+									"patching_rect" : [ 235.0, 220.5, 194.0, 21.0 ],
+									"text" : "Read a fluid.labelset~ from disk.",
+									"textcolor" : [ 0.501960784313725, 0.501960784313725, 0.501960784313725, 1.0 ]
 								}
 
 							}
@@ -1276,40 +1143,20 @@
 									"numinlets" : 2,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 59.0, 235.0, 35.0, 23.0 ],
+									"patching_rect" : [ 194.0, 220.0, 35.0, 23.0 ],
 									"text" : "read"
 								}
 
 							}
 , 							{
 								"box" : 								{
-									"bgcolor" : [ 0.968627450980392, 0.431372549019608, 0.431372549019608, 1.0 ],
-									"fontname" : "Arial Bold",
-									"hint" : "",
-									"id" : "obj-12",
-									"ignoreclick" : 1,
-									"legacytextcolor" : 1,
-									"maxclass" : "textbutton",
-									"numinlets" : 1,
-									"numoutlets" : 3,
-									"outlettype" : [ "", "", "int" ],
-									"parameter_enable" : 0,
-									"patching_rect" : [ 119.0, 276.5, 20.0, 20.0 ],
-									"rounded" : 60.0,
-									"text" : "3",
-									"textcolor" : [ 0.929411764705882, 0.941176470588235, 0.956862745098039, 1.0 ]
-								}
-
-							}
-, 							{
-								"box" : 								{
-									"bubble" : 1,
 									"id" : "obj-7",
 									"maxclass" : "comment",
 									"numinlets" : 1,
 									"numoutlets" : 0,
-									"patching_rect" : [ 91.0, 201.5, 195.0, 25.0 ],
-									"text" : "Write a fluid.labelset~ to disk."
+									"patching_rect" : [ 209.5, 185.5, 178.0, 21.0 ],
+									"text" : "Write a fluid.labelset~ to disk.",
+									"textcolor" : [ 0.501960784313725, 0.501960784313725, 0.501960784313725, 1.0 ]
 								}
 
 							}
@@ -1320,40 +1167,20 @@
 									"numinlets" : 2,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 31.0, 200.0, 36.0, 23.0 ],
+									"patching_rect" : [ 170.0, 185.0, 36.0, 23.0 ],
 									"text" : "write"
 								}
 
 							}
 , 							{
 								"box" : 								{
-									"bgcolor" : [ 0.968627450980392, 0.431372549019608, 0.431372549019608, 1.0 ],
-									"fontname" : "Arial Bold",
-									"hint" : "",
-									"id" : "obj-9",
-									"ignoreclick" : 1,
-									"legacytextcolor" : 1,
-									"maxclass" : "textbutton",
-									"numinlets" : 1,
-									"numoutlets" : 3,
-									"outlettype" : [ "", "", "int" ],
-									"parameter_enable" : 0,
-									"patching_rect" : [ 98.5, 236.5, 20.0, 20.0 ],
-									"rounded" : 60.0,
-									"text" : "2",
-									"textcolor" : [ 0.929411764705882, 0.941176470588235, 0.956862745098039, 1.0 ]
-								}
-
-							}
-, 							{
-								"box" : 								{
-									"bubble" : 1,
 									"id" : "obj-6",
 									"maxclass" : "comment",
 									"numinlets" : 1,
 									"numoutlets" : 0,
-									"patching_rect" : [ 198.0, 353.0, 221.0, 25.0 ],
-									"text" : "Completely reset a fluid.labelset~."
+									"patching_rect" : [ 316.5, 337.0, 204.0, 21.0 ],
+									"text" : "Completely reset a fluid.labelset~.",
+									"textcolor" : [ 0.501960784313725, 0.501960784313725, 0.501960784313725, 1.0 ]
 								}
 
 							}
@@ -1364,28 +1191,8 @@
 									"numinlets" : 2,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 137.0, 350.0, 37.0, 23.0 ],
+									"patching_rect" : [ 276.0, 335.0, 37.0, 23.0 ],
 									"text" : "clear"
-								}
-
-							}
-, 							{
-								"box" : 								{
-									"bgcolor" : [ 0.968627450980392, 0.431372549019608, 0.431372549019608, 1.0 ],
-									"fontname" : "Arial Bold",
-									"hint" : "",
-									"id" : "obj-42",
-									"ignoreclick" : 1,
-									"legacytextcolor" : 1,
-									"maxclass" : "textbutton",
-									"numinlets" : 1,
-									"numoutlets" : 3,
-									"outlettype" : [ "", "", "int" ],
-									"parameter_enable" : 0,
-									"patching_rect" : [ 69.0, 201.5, 20.0, 20.0 ],
-									"rounded" : 60.0,
-									"text" : "1",
-									"textcolor" : [ 0.929411764705882, 0.941176470588235, 0.956862745098039, 1.0 ]
 								}
 
 							}
@@ -1394,10 +1201,10 @@
 									"id" : "obj-1",
 									"maxclass" : "newobj",
 									"numinlets" : 1,
-									"numoutlets" : 3,
-									"outlettype" : [ "bang", "float", "" ],
-									"patching_rect" : [ 5.0, 430.0, 150.0, 23.0 ],
-									"text" : "fluid.labelset~ help.other"
+									"numoutlets" : 2,
+									"outlettype" : [ "", "" ],
+									"patching_rect" : [ 120.0, 385.0, 198.0, 23.0 ],
+									"text" : "fluid.labelset~ help.labelset.other"
 								}
 
 							}
@@ -1405,14 +1212,14 @@
 						"lines" : [ 							{
 								"patchline" : 								{
 									"destination" : [ "obj-16", 0 ],
-									"source" : [ "obj-1", 2 ]
+									"source" : [ "obj-1", 1 ]
 								}
 
 							}
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-1", 0 ],
-									"midpoints" : [ 68.5, 358.5, 14.5, 358.5 ],
+									"midpoints" : [ 203.5, 370.0, 129.5, 370.0 ],
 									"source" : [ "obj-11", 0 ]
 								}
 
@@ -1420,7 +1227,7 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-1", 0 ],
-									"midpoints" : [ 92.5, 378.5, 14.5, 378.5 ],
+									"midpoints" : [ 231.5, 370.0, 129.5, 370.0 ],
 									"source" : [ "obj-14", 0 ]
 								}
 
@@ -1449,7 +1256,7 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-1", 0 ],
-									"midpoints" : [ 120.5, 398.5, 14.5, 398.5 ],
+									"midpoints" : [ 259.5, 370.0, 129.5, 370.0 ],
 									"source" : [ "obj-28", 0 ]
 								}
 
@@ -1457,7 +1264,7 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-1", 0 ],
-									"midpoints" : [ 146.5, 416.0, 14.5, 416.0 ],
+									"midpoints" : [ 285.5, 370.0, 129.5, 370.0 ],
 									"source" : [ "obj-4", 0 ]
 								}
 
@@ -1465,7 +1272,7 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-1", 0 ],
-									"midpoints" : [ 14.5, 317.5, 14.5, 317.5 ],
+									"midpoints" : [ 129.5, 178.0, 129.5, 178.0 ],
 									"source" : [ "obj-5", 0 ]
 								}
 
@@ -1473,7 +1280,7 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-1", 0 ],
-									"midpoints" : [ 40.5, 341.0, 14.5, 341.0 ],
+									"midpoints" : [ 179.5, 370.0, 129.5, 370.0 ],
 									"source" : [ "obj-8", 0 ]
 								}
 
@@ -1503,13 +1310,13 @@
 								"name" : "max6message",
 								"default" : 								{
 									"bgfillcolor" : 									{
-										"type" : "gradient",
+										"angle" : 270.0,
+										"autogradient" : 0,
+										"color" : [ 0.290196, 0.309804, 0.301961, 1.0 ],
 										"color1" : [ 0.866667, 0.866667, 0.866667, 1.0 ],
 										"color2" : [ 0.788235, 0.788235, 0.788235, 1.0 ],
-										"color" : [ 0.290196, 0.309804, 0.301961, 1.0 ],
-										"angle" : 270.0,
 										"proportion" : 0.39,
-										"autogradient" : 0
+										"type" : "gradient"
 									}
 ,
 									"textcolor_inverse" : [ 0.0, 0.0, 0.0, 1.0 ]
@@ -1554,8 +1361,8 @@
 						"fileversion" : 1,
 						"appversion" : 						{
 							"major" : 8,
-							"minor" : 2,
-							"revision" : 2,
+							"minor" : 3,
+							"revision" : 0,
 							"architecture" : "x64",
 							"modernui" : 1
 						}
@@ -1568,7 +1375,7 @@
 						"default_fontface" : 0,
 						"default_fontname" : "Arial",
 						"gridonopen" : 2,
-						"gridsize" : [ 5.0, 5.0 ],
+						"gridsize" : [ 10.0, 10.0 ],
 						"gridsnaponopen" : 2,
 						"objectsnaponopen" : 1,
 						"statusbarvisible" : 2,
@@ -1592,22 +1399,55 @@
 						"assistshowspatchername" : 0,
 						"boxes" : [ 							{
 								"box" : 								{
-									"args" : [ "labelset" ],
-									"bgmode" : 0,
-									"border" : 0,
-									"clickthrough" : 0,
-									"enablehscroll" : 0,
-									"enablevscroll" : 0,
-									"id" : "obj-2",
-									"lockeddragscroll" : 0,
-									"lockedsize" : 0,
-									"maxclass" : "bpatcher",
-									"name" : "fluid.learn.maxpat",
-									"numinlets" : 0,
+									"id" : "obj-14",
+									"maxclass" : "comment",
+									"numinlets" : 1,
 									"numoutlets" : 0,
-									"offset" : [ 0.0, 0.0 ],
-									"patching_rect" : [ 363.0, 5.0, 240.0, 111.5 ],
-									"viewvisibility" : 1
+									"patching_rect" : [ 252.5, 420.0, 164.0, 20.0 ],
+									"text" : "look in here to see the format",
+									"textcolor" : [ 0.501960784313725, 0.501960784313725, 0.501960784313725, 1.0 ]
+								}
+
+							}
+, 							{
+								"box" : 								{
+									"id" : "obj-11",
+									"maxclass" : "newobj",
+									"numinlets" : 2,
+									"numoutlets" : 4,
+									"outlettype" : [ "dictionary", "", "", "" ],
+									"patching_rect" : [ 200.0, 420.0, 50.5, 22.0 ],
+									"saved_object_attributes" : 									{
+										"embed" : 0,
+										"parameter_enable" : 0,
+										"parameter_mappable" : 0
+									}
+,
+									"text" : "dict"
+								}
+
+							}
+, 							{
+								"box" : 								{
+									"id" : "obj-8",
+									"maxclass" : "newobj",
+									"numinlets" : 1,
+									"numoutlets" : 2,
+									"outlettype" : [ "dump", "" ],
+									"patching_rect" : [ 87.75, 460.0, 51.0, 22.0 ],
+									"text" : "t dump l"
+								}
+
+							}
+, 							{
+								"box" : 								{
+									"id" : "obj-2",
+									"maxclass" : "comment",
+									"numinlets" : 1,
+									"numoutlets" : 0,
+									"patching_rect" : [ 10.0, 62.0, 499.0, 20.0 ],
+									"text" : "You can load the contents of a dictionary into a fluid.abelset~ assuming the format is correct.",
+									"textcolor" : [ 0.501960784313725, 0.501960784313725, 0.501960784313725, 1.0 ]
 								}
 
 							}
@@ -1623,7 +1463,7 @@
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
 									"parameter_enable" : 0,
-									"patching_rect" : [ 5.0, 5.0, 360.0, 105.0 ]
+									"patching_rect" : [ 10.0, 10.0, 300.5, 50.0 ]
 								}
 
 							}
@@ -1638,8 +1478,8 @@
 										"fileversion" : 1,
 										"appversion" : 										{
 											"major" : 8,
-											"minor" : 2,
-											"revision" : 2,
+											"minor" : 3,
+											"revision" : 0,
 											"architecture" : "x64",
 											"modernui" : 1
 										}
@@ -1766,7 +1606,7 @@
  ]
 									}
 ,
-									"patching_rect" : [ 261.0, 275.0, 150.0, 22.0 ],
+									"patching_rect" : [ 316.0, 275.0, 150.0, 22.0 ],
 									"saved_object_attributes" : 									{
 										"description" : "",
 										"digest" : "",
@@ -1791,7 +1631,7 @@
 									"numoutlets" : 3,
 									"outlettype" : [ "", "", "int" ],
 									"parameter_enable" : 0,
-									"patching_rect" : [ 35.0, 132.0, 20.0, 20.0 ],
+									"patching_rect" : [ 90.0, 132.0, 20.0, 20.0 ],
 									"rounded" : 60.0,
 									"text" : "1",
 									"textcolor" : [ 0.34902, 0.34902, 0.34902, 1.0 ]
@@ -1805,7 +1645,7 @@
 									"maxclass" : "comment",
 									"numinlets" : 1,
 									"numoutlets" : 0,
-									"patching_rect" : [ 57.0, 132.0, 326.0, 24.0 ],
+									"patching_rect" : [ 112.0, 132.0, 326.0, 24.0 ],
 									"text" : "Generate random data to be stored in the fluid.dataset~"
 								}
 
@@ -1816,19 +1656,7 @@
 									"maxclass" : "dict.view",
 									"numinlets" : 1,
 									"numoutlets" : 0,
-									"patching_rect" : [ 440.0, 170.0, 170.0, 500.0 ]
-								}
-
-							}
-, 							{
-								"box" : 								{
-									"id" : "obj-107",
-									"maxclass" : "message",
-									"numinlets" : 2,
-									"numoutlets" : 1,
-									"outlettype" : [ "" ],
-									"patching_rect" : [ 171.75, 505.0, 39.0, 22.0 ],
-									"text" : "dump"
+									"patching_rect" : [ 495.0, 170.0, 170.0, 500.0 ]
 								}
 
 							}
@@ -1836,11 +1664,11 @@
 								"box" : 								{
 									"id" : "obj-104",
 									"maxclass" : "newobj",
-									"numinlets" : 3,
-									"numoutlets" : 3,
-									"outlettype" : [ "", "", "" ],
-									"patching_rect" : [ 171.75, 470.0, 133.75, 22.0 ],
-									"text" : "route load dump"
+									"numinlets" : 2,
+									"numoutlets" : 2,
+									"outlettype" : [ "", "" ],
+									"patching_rect" : [ 282.75, 540.0, 69.0, 22.0 ],
+									"text" : "route dump"
 								}
 
 							}
@@ -1851,7 +1679,7 @@
 									"numinlets" : 1,
 									"numoutlets" : 2,
 									"outlettype" : [ "int", "bang" ],
-									"patching_rect" : [ 60.5, 245.0, 219.5, 22.0 ],
+									"patching_rect" : [ 115.5, 245.0, 219.5, 22.0 ],
 									"text" : "t i b"
 								}
 
@@ -1863,7 +1691,7 @@
 									"numinlets" : 2,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 60.5, 305.0, 112.0, 22.0 ],
+									"patching_rect" : [ 115.5, 305.0, 112.0, 22.0 ],
 									"text" : "sprintf entry-%i: %s"
 								}
 
@@ -1875,7 +1703,7 @@
 									"numinlets" : 2,
 									"numoutlets" : 3,
 									"outlettype" : [ "bang", "bang", "int" ],
-									"patching_rect" : [ 5.0, 205.0, 74.5, 22.0 ],
+									"patching_rect" : [ 60.0, 205.0, 74.5, 22.0 ],
 									"text" : "uzi 100"
 								}
 
@@ -1887,7 +1715,7 @@
 									"numinlets" : 2,
 									"numoutlets" : 1,
 									"outlettype" : [ "dictionary" ],
-									"patching_rect" : [ 32.75, 370.0, 121.0, 22.0 ],
+									"patching_rect" : [ 87.75, 380.0, 121.0, 22.0 ],
 									"text" : "dict.pack data: cols:1"
 								}
 
@@ -1899,7 +1727,7 @@
 									"numinlets" : 1,
 									"numoutlets" : 1,
 									"outlettype" : [ "dictionary" ],
-									"patching_rect" : [ 32.75, 340.0, 61.0, 22.0 ],
+									"patching_rect" : [ 87.75, 340.0, 61.0, 22.0 ],
 									"text" : "dict.group"
 								}
 
@@ -1912,19 +1740,7 @@
 									"numoutlets" : 1,
 									"outlettype" : [ "bang" ],
 									"parameter_enable" : 0,
-									"patching_rect" : [ 5.0, 130.0, 24.0, 24.0 ]
-								}
-
-							}
-, 							{
-								"box" : 								{
-									"id" : "obj-54",
-									"maxclass" : "newobj",
-									"numinlets" : 1,
-									"numoutlets" : 3,
-									"outlettype" : [ "bang", "float", "" ],
-									"patching_rect" : [ 104.5, 205.0, 158.0, 22.0 ],
-									"text" : "fluid.labelset~ dictionary-fun"
+									"patching_rect" : [ 60.0, 130.0, 24.0, 24.0 ]
 								}
 
 							}
@@ -1935,7 +1751,7 @@
 									"numinlets" : 1,
 									"numoutlets" : 2,
 									"outlettype" : [ "bang", "clear" ],
-									"patching_rect" : [ 5.0, 170.0, 118.5, 22.0 ],
+									"patching_rect" : [ 60.0, 170.0, 118.5, 22.0 ],
 									"text" : "t b clear"
 								}
 
@@ -1947,7 +1763,7 @@
 									"numinlets" : 1,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 32.75, 405.0, 81.0, 22.0 ],
+									"patching_rect" : [ 87.75, 420.0, 81.0, 22.0 ],
 									"text" : "prepend load"
 								}
 
@@ -1957,10 +1773,10 @@
 									"id" : "obj-1",
 									"maxclass" : "newobj",
 									"numinlets" : 1,
-									"numoutlets" : 3,
-									"outlettype" : [ "bang", "float", "" ],
-									"patching_rect" : [ 32.75, 437.0, 158.0, 22.0 ],
-									"text" : "fluid.labelset~ dictionary-fun"
+									"numoutlets" : 2,
+									"outlettype" : [ "", "" ],
+									"patching_rect" : [ 87.75, 500.0, 214.0, 22.0 ],
+									"text" : "fluid.labelset~ help.labelset.dictloading"
 								}
 
 							}
@@ -1968,13 +1784,14 @@
 						"lines" : [ 							{
 								"patchline" : 								{
 									"destination" : [ "obj-104", 0 ],
-									"source" : [ "obj-1", 2 ]
+									"source" : [ "obj-1", 1 ]
 								}
 
 							}
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-70", 0 ],
+									"midpoints" : [ 125.0, 330.0, 99.0, 330.0, 99.0, 336.0, 97.25, 336.0 ],
 									"source" : [ "obj-102", 0 ]
 								}
 
@@ -1995,46 +1812,24 @@
 							}
 , 							{
 								"patchline" : 								{
-									"destination" : [ "obj-107", 0 ],
+									"destination" : [ "obj-108", 0 ],
+									"midpoints" : [ 292.25, 573.0, 480.0, 573.0, 480.0, 165.0, 504.5, 165.0 ],
 									"source" : [ "obj-104", 0 ]
 								}
 
 							}
 , 							{
 								"patchline" : 								{
-									"destination" : [ "obj-108", 0 ],
-									"midpoints" : [ 238.625, 502.0, 426.0, 502.0, 426.0, 166.0, 449.5, 166.0 ],
-									"source" : [ "obj-104", 1 ]
-								}
-
-							}
-, 							{
-								"patchline" : 								{
-									"destination" : [ "obj-1", 0 ],
-									"midpoints" : [ 181.25, 528.0, 25.5, 528.0, 25.5, 432.0, 42.25, 432.0 ],
-									"source" : [ "obj-107", 0 ]
-								}
-
-							}
-, 							{
-								"patchline" : 								{
 									"destination" : [ "obj-102", 1 ],
-									"midpoints" : [ 270.5, 298.0, 163.0, 298.0 ],
+									"midpoints" : [ 325.5, 298.0, 218.0, 298.0 ],
 									"source" : [ "obj-13", 0 ]
 								}
 
 							}
 , 							{
 								"patchline" : 								{
-									"destination" : [ "obj-1", 0 ],
+									"destination" : [ "obj-8", 0 ],
 									"source" : [ "obj-43", 0 ]
-								}
-
-							}
-, 							{
-								"patchline" : 								{
-									"destination" : [ "obj-54", 0 ],
-									"source" : [ "obj-52", 1 ]
 								}
 
 							}
@@ -2061,7 +1856,17 @@
 							}
 , 							{
 								"patchline" : 								{
+									"destination" : [ "obj-11", 0 ],
+									"midpoints" : [ 97.25, 410.5, 209.5, 410.5 ],
+									"order" : 0,
+									"source" : [ "obj-71", 0 ]
+								}
+
+							}
+, 							{
+								"patchline" : 								{
 									"destination" : [ "obj-43", 0 ],
+									"order" : 1,
 									"source" : [ "obj-71", 0 ]
 								}
 
@@ -2076,7 +1881,24 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-70", 0 ],
+									"midpoints" : [ 97.25, 228.0, 97.25, 228.0 ],
 									"source" : [ "obj-74", 1 ]
+								}
+
+							}
+, 							{
+								"patchline" : 								{
+									"destination" : [ "obj-1", 0 ],
+									"midpoints" : [ 129.25, 490.5, 97.25, 490.5 ],
+									"source" : [ "obj-8", 1 ]
+								}
+
+							}
+, 							{
+								"patchline" : 								{
+									"destination" : [ "obj-1", 0 ],
+									"midpoints" : [ 97.25, 490.5, 97.25, 490.5 ],
+									"source" : [ "obj-8", 0 ]
 								}
 
 							}
@@ -2105,13 +1927,13 @@
 								"name" : "max6message",
 								"default" : 								{
 									"bgfillcolor" : 									{
-										"type" : "gradient",
+										"angle" : 270.0,
+										"autogradient" : 0,
+										"color" : [ 0.290196, 0.309804, 0.301961, 1.0 ],
 										"color1" : [ 0.866667, 0.866667, 0.866667, 1.0 ],
 										"color2" : [ 0.788235, 0.788235, 0.788235, 1.0 ],
-										"color" : [ 0.290196, 0.309804, 0.301961, 1.0 ],
-										"angle" : 270.0,
 										"proportion" : 0.39,
-										"autogradient" : 0
+										"type" : "gradient"
 									}
 ,
 									"textcolor_inverse" : [ 0.0, 0.0, 0.0, 1.0 ]
@@ -2154,8 +1976,8 @@
 						"fileversion" : 1,
 						"appversion" : 						{
 							"major" : 8,
-							"minor" : 2,
-							"revision" : 2,
+							"minor" : 3,
+							"revision" : 0,
 							"architecture" : "x64",
 							"modernui" : 1
 						}
@@ -2168,7 +1990,7 @@
 						"default_fontface" : 0,
 						"default_fontname" : "Arial",
 						"gridonopen" : 2,
-						"gridsize" : [ 5.0, 5.0 ],
+						"gridsize" : [ 10.0, 10.0 ],
 						"gridsnaponopen" : 2,
 						"objectsnaponopen" : 1,
 						"statusbarvisible" : 2,
@@ -2206,7 +2028,7 @@
 									"numinlets" : 0,
 									"numoutlets" : 0,
 									"offset" : [ 0.0, 0.0 ],
-									"patching_rect" : [ 363.0, 5.0, 240.0, 111.5 ],
+									"patching_rect" : [ 368.0, 10.0, 240.0, 111.5 ],
 									"viewvisibility" : 1
 								}
 
@@ -2224,7 +2046,7 @@
 									"numoutlets" : 3,
 									"outlettype" : [ "", "", "int" ],
 									"parameter_enable" : 0,
-									"patching_rect" : [ 372.0, 384.5, 20.0, 20.0 ],
+									"patching_rect" : [ 397.0, 394.5, 20.0, 20.0 ],
 									"rounded" : 60.0,
 									"text" : "5",
 									"textcolor" : [ 0.34902, 0.34902, 0.34902, 1.0 ]
@@ -2239,7 +2061,7 @@
 									"maxclass" : "comment",
 									"numinlets" : 1,
 									"numoutlets" : 0,
-									"patching_rect" : [ 395.0, 374.5, 318.0, 40.0 ],
+									"patching_rect" : [ 420.0, 384.5, 318.0, 40.0 ],
 									"text" : "Delete the label with the identifier huddersfield, and dump the labelset to a dictionary again."
 								}
 
@@ -2251,7 +2073,7 @@
 									"numinlets" : 2,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 184.0, 384.5, 186.0, 23.0 ],
+									"patching_rect" : [ 209.0, 394.5, 186.0, 23.0 ],
 									"text" : "deletelabel huddersfield, dump"
 								}
 
@@ -2269,7 +2091,7 @@
 									"numoutlets" : 3,
 									"outlettype" : [ "", "", "int" ],
 									"parameter_enable" : 0,
-									"patching_rect" : [ 205.0, 336.0, 20.0, 20.0 ],
+									"patching_rect" : [ 230.0, 346.0, 20.0, 20.0 ],
 									"rounded" : 60.0,
 									"text" : "4",
 									"textcolor" : [ 0.34902, 0.34902, 0.34902, 1.0 ]
@@ -2283,7 +2105,7 @@
 									"maxclass" : "comment",
 									"numinlets" : 1,
 									"numoutlets" : 0,
-									"patching_rect" : [ 227.0, 336.0, 318.0, 25.0 ],
+									"patching_rect" : [ 252.0, 346.0, 318.0, 25.0 ],
 									"text" : "Dump again to see how the labels have changed."
 								}
 
@@ -2295,7 +2117,7 @@
 									"numinlets" : 2,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 157.0, 334.5, 41.0, 23.0 ],
+									"patching_rect" : [ 182.0, 344.5, 41.0, 23.0 ],
 									"text" : "dump"
 								}
 
@@ -2313,7 +2135,7 @@
 									"numoutlets" : 3,
 									"outlettype" : [ "", "", "int" ],
 									"parameter_enable" : 0,
-									"patching_rect" : [ 372.0, 269.25, 20.0, 20.0 ],
+									"patching_rect" : [ 397.0, 279.25, 20.0, 20.0 ],
 									"rounded" : 60.0,
 									"text" : "3",
 									"textcolor" : [ 0.34902, 0.34902, 0.34902, 1.0 ]
@@ -2327,7 +2149,7 @@
 									"numinlets" : 2,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 143.0, 284.5, 213.0, 23.0 ],
+									"patching_rect" : [ 168.0, 294.5, 213.0, 23.0 ],
 									"text" : "updatelabel huddersfield wet-winter"
 								}
 
@@ -2339,7 +2161,7 @@
 									"numinlets" : 2,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 105.0, 249.5, 138.0, 23.0 ],
+									"patching_rect" : [ 130.0, 259.5, 138.0, 23.0 ],
 									"text" : "setlabel perth dry-heat"
 								}
 
@@ -2352,7 +2174,7 @@
 									"maxclass" : "comment",
 									"numinlets" : 1,
 									"numoutlets" : 0,
-									"patching_rect" : [ 399.0, 252.25, 421.0, 54.0 ],
+									"patching_rect" : [ 424.0, 262.25, 421.0, 54.0 ],
 									"text" : "Set and update labels with the corresponding messages. The setlabel message will create the label if it doesn note exist, while updatelabel message assumes it already exists and will not make it."
 								}
 
@@ -2370,7 +2192,7 @@
 									"numoutlets" : 3,
 									"outlettype" : [ "", "", "int" ],
 									"parameter_enable" : 0,
-									"patching_rect" : [ 130.0, 206.5, 20.0, 20.0 ],
+									"patching_rect" : [ 155.0, 216.5, 20.0, 20.0 ],
 									"rounded" : 60.0,
 									"text" : "2",
 									"textcolor" : [ 0.34902, 0.34902, 0.34902, 1.0 ]
@@ -2384,7 +2206,7 @@
 									"maxclass" : "comment",
 									"numinlets" : 1,
 									"numoutlets" : 0,
-									"patching_rect" : [ 152.0, 204.0, 293.0, 25.0 ],
+									"patching_rect" : [ 177.0, 214.0, 293.0, 25.0 ],
 									"text" : "Dump the labelset to inspect the internal state."
 								}
 
@@ -2395,7 +2217,7 @@
 									"maxclass" : "dict.view",
 									"numinlets" : 1,
 									"numoutlets" : 0,
-									"patching_rect" : [ 156.0, 569.5, 191.0, 125.0 ]
+									"patching_rect" : [ 192.0, 533.5, 191.0, 125.0 ]
 								}
 
 							}
@@ -2406,7 +2228,7 @@
 									"numinlets" : 2,
 									"numoutlets" : 2,
 									"outlettype" : [ "", "" ],
-									"patching_rect" : [ 156.0, 539.5, 74.0, 23.0 ],
+									"patching_rect" : [ 192.0, 503.5, 74.0, 23.0 ],
 									"text" : "route dump"
 								}
 
@@ -2418,7 +2240,7 @@
 									"numinlets" : 2,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 82.0, 205.0, 41.0, 23.0 ],
+									"patching_rect" : [ 107.0, 215.0, 41.0, 23.0 ],
 									"text" : "dump"
 								}
 
@@ -2430,7 +2252,7 @@
 									"numinlets" : 2,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 40.0, 160.0, 160.0, 23.0 ],
+									"patching_rect" : [ 65.0, 170.0, 160.0, 23.0 ],
 									"text" : "addlabel huddersfield cold"
 								}
 
@@ -2440,10 +2262,10 @@
 									"id" : "obj-3",
 									"maxclass" : "newobj",
 									"numinlets" : 1,
-									"numoutlets" : 3,
-									"outlettype" : [ "bang", "float", "" ],
-									"patching_rect" : [ 10.0, 506.5, 165.0, 23.0 ],
-									"text" : "fluid.labelset~ help.labelset"
+									"numoutlets" : 2,
+									"outlettype" : [ "", "" ],
+									"patching_rect" : [ 35.0, 470.0, 176.0, 23.0 ],
+									"text" : "fluid.labelset~ help.labelset.1"
 								}
 
 							}
@@ -2460,7 +2282,7 @@
 									"numoutlets" : 3,
 									"outlettype" : [ "", "", "int" ],
 									"parameter_enable" : 0,
-									"patching_rect" : [ 215.0, 145.0, 20.0, 20.0 ],
+									"patching_rect" : [ 240.0, 155.0, 20.0, 20.0 ],
 									"rounded" : 60.0,
 									"text" : "1",
 									"textcolor" : [ 0.34902, 0.34902, 0.34902, 1.0 ]
@@ -2475,7 +2297,7 @@
 									"maxclass" : "comment",
 									"numinlets" : 1,
 									"numoutlets" : 0,
-									"patching_rect" : [ 240.0, 135.0, 259.0, 40.0 ],
+									"patching_rect" : [ 265.0, 145.0, 259.0, 40.0 ],
 									"text" : "Add labels with the addlabel <identifier> <label> structured message. "
 								}
 
@@ -2492,7 +2314,7 @@
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
 									"parameter_enable" : 0,
-									"patching_rect" : [ 5.0, 5.0, 360.0, 105.0 ]
+									"patching_rect" : [ 10.0, 10.0, 360.0, 105.0 ]
 								}
 
 							}
@@ -2503,7 +2325,7 @@
 									"numinlets" : 2,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 10.0, 125.0, 113.0, 23.0 ],
+									"patching_rect" : [ 35.0, 135.0, 113.0, 23.0 ],
 									"text" : "addlabel perth hot"
 								}
 
@@ -2520,7 +2342,7 @@
 									"mode" : 0,
 									"numinlets" : 1,
 									"numoutlets" : 0,
-									"patching_rect" : [ 5.0, 120.0, 205.0, 70.0 ],
+									"patching_rect" : [ 30.0, 130.0, 205.0, 70.0 ],
 									"proportion" : 0.5
 								}
 
@@ -2537,7 +2359,7 @@
 									"mode" : 0,
 									"numinlets" : 1,
 									"numoutlets" : 0,
-									"patching_rect" : [ 98.0, 244.5, 268.0, 69.5 ],
+									"patching_rect" : [ 123.0, 254.5, 268.0, 69.5 ],
 									"proportion" : 0.5
 								}
 
@@ -2546,14 +2368,14 @@
 						"lines" : [ 							{
 								"patchline" : 								{
 									"destination" : [ "obj-9", 0 ],
-									"source" : [ "obj-3", 2 ]
+									"source" : [ "obj-3", 1 ]
 								}
 
 							}
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-3", 0 ],
-									"midpoints" : [ 152.5, 406.5, 19.5, 406.5 ],
+									"midpoints" : [ 177.5, 330.0, 44.5, 330.0 ],
 									"source" : [ "obj-32", 0 ]
 								}
 
@@ -2561,7 +2383,7 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-3", 0 ],
-									"midpoints" : [ 114.5, 389.0, 19.5, 389.0 ],
+									"midpoints" : [ 139.5, 456.0, 44.5, 456.0 ],
 									"source" : [ "obj-33", 0 ]
 								}
 
@@ -2569,7 +2391,7 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-3", 0 ],
-									"midpoints" : [ 166.5, 431.5, 19.5, 431.5 ],
+									"midpoints" : [ 191.5, 456.0, 44.5, 456.0 ],
 									"source" : [ "obj-38", 0 ]
 								}
 
@@ -2577,7 +2399,7 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-3", 0 ],
-									"midpoints" : [ 19.5, 326.75, 19.5, 326.75 ],
+									"midpoints" : [ 44.5, 159.0, 44.5, 159.0 ],
 									"source" : [ "obj-4", 0 ]
 								}
 
@@ -2585,7 +2407,7 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-3", 0 ],
-									"midpoints" : [ 193.5, 456.5, 19.5, 456.5 ],
+									"midpoints" : [ 218.5, 456.0, 44.5, 456.0 ],
 									"source" : [ "obj-43", 0 ]
 								}
 
@@ -2593,7 +2415,7 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-3", 0 ],
-									"midpoints" : [ 49.5, 344.25, 19.5, 344.25 ],
+									"midpoints" : [ 74.5, 456.0, 44.5, 456.0 ],
 									"source" : [ "obj-6", 0 ]
 								}
 
@@ -2601,7 +2423,7 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-3", 0 ],
-									"midpoints" : [ 91.5, 366.75, 19.5, 366.75 ],
+									"midpoints" : [ 116.5, 240.0, 44.5, 240.0 ],
 									"source" : [ "obj-8", 0 ]
 								}
 
@@ -2638,13 +2460,13 @@
 								"name" : "max6message",
 								"default" : 								{
 									"bgfillcolor" : 									{
-										"type" : "gradient",
+										"angle" : 270.0,
+										"autogradient" : 0,
+										"color" : [ 0.290196, 0.309804, 0.301961, 1.0 ],
 										"color1" : [ 0.866667, 0.866667, 0.866667, 1.0 ],
 										"color2" : [ 0.788235, 0.788235, 0.788235, 1.0 ],
-										"color" : [ 0.290196, 0.309804, 0.301961, 1.0 ],
-										"angle" : 270.0,
 										"proportion" : 0.39,
-										"autogradient" : 0
+										"type" : "gradient"
 									}
 ,
 									"textcolor_inverse" : [ 0.0, 0.0, 0.0, 1.0 ]
@@ -2689,8 +2511,8 @@
 						"fileversion" : 1,
 						"appversion" : 						{
 							"major" : 8,
-							"minor" : 2,
-							"revision" : 2,
+							"minor" : 3,
+							"revision" : 0,
 							"architecture" : "x64",
 							"modernui" : 1
 						}
@@ -2744,43 +2566,6 @@
 			}
  ],
 		"lines" : [  ],
-		"dependency_cache" : [ 			{
-				"name" : "fluid.bufflatten~.mxo",
-				"type" : "iLaX"
-			}
-, 			{
-				"name" : "fluid.bufmfcc~.mxo",
-				"type" : "iLaX"
-			}
-, 			{
-				"name" : "fluid.bufstats~.mxo",
-				"type" : "iLaX"
-			}
-, 			{
-				"name" : "fluid.flucomaorg.maxpat",
-				"bootpath" : "~/dev/flucoma/max/help",
-				"patcherrelativepath" : ".",
-				"type" : "JSON",
-				"implicit" : 1
-			}
-, 			{
-				"name" : "fluid.learn.maxpat",
-				"bootpath" : "~/dev/flucoma/max/help",
-				"patcherrelativepath" : ".",
-				"type" : "JSON",
-				"implicit" : 1
-			}
-, 			{
-				"name" : "fluid.libmanipulation.mxo",
-				"type" : "iLaX"
-			}
-, 			{
-				"name" : "helpdetails.js",
-				"bootpath" : "C74:/help/resources",
-				"type" : "TEXT",
-				"implicit" : 1
-			}
- ],
 		"autosave" : 0
 	}
 

--- a/help/fluid.normalize~.maxhelp
+++ b/help/fluid.normalize~.maxhelp
@@ -57,7 +57,7 @@
 						}
 ,
 						"classnamespace" : "box",
-						"rect" : [ 34.0, 113.0, 934.0, 721.0 ],
+						"rect" : [ 0.0, 26.0, 934.0, 721.0 ],
 						"bglocked" : 0,
 						"openinpresentation" : 0,
 						"default_fontsize" : 13.0,
@@ -88,22 +88,13 @@
 						"assistshowspatchername" : 0,
 						"boxes" : [ 							{
 								"box" : 								{
-									"args" : [ "normalize" ],
-									"bgmode" : 0,
-									"border" : 0,
-									"clickthrough" : 0,
-									"enablehscroll" : 0,
-									"enablevscroll" : 0,
-									"id" : "obj-3",
-									"lockeddragscroll" : 0,
-									"lockedsize" : 0,
-									"maxclass" : "bpatcher",
-									"name" : "fluid.learn.maxpat",
-									"numinlets" : 0,
-									"numoutlets" : 0,
-									"offset" : [ 0.0, 0.0 ],
-									"patching_rect" : [ 540.0, 10.0, 240.0, 110.0 ],
-									"viewvisibility" : 1
+									"id" : "obj-8",
+									"maxclass" : "newobj",
+									"numinlets" : 2,
+									"numoutlets" : 2,
+									"outlettype" : [ "", "" ],
+									"patching_rect" : [ 300.0, 447.5, 187.0, 23.0 ],
+									"text" : "substitute transformpoint buffer"
 								}
 
 							}
@@ -119,7 +110,7 @@
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
 									"parameter_enable" : 0,
-									"patching_rect" : [ 10.0, 10.0, 525.0, 115.0 ]
+									"patching_rect" : [ 10.0, 10.0, 350.0, 50.0 ]
 								}
 
 							}
@@ -132,7 +123,7 @@
 									"numoutlets" : 2,
 									"outlettype" : [ "", "bang" ],
 									"parameter_enable" : 0,
-									"patching_rect" : [ 296.0, 249.0, 50.0, 23.0 ]
+									"patching_rect" : [ 346.0, 256.5, 50.0, 23.0 ]
 								}
 
 							}
@@ -143,7 +134,7 @@
 									"maxclass" : "comment",
 									"numinlets" : 1,
 									"numoutlets" : 0,
-									"patching_rect" : [ 390.0, 573.5, 210.0, 36.0 ],
+									"patching_rect" : [ 440.0, 551.0, 210.0, 36.0 ],
 									"text" : "The result of transforming the single point is output to a buffer.",
 									"textcolor" : [ 0.501960784313725, 0.501960784313725, 0.501960784313725, 1.0 ]
 								}
@@ -162,7 +153,7 @@
 									"numoutlets" : 3,
 									"outlettype" : [ "", "", "int" ],
 									"parameter_enable" : 0,
-									"patching_rect" : [ 823.0, 356.5, 20.0, 20.0 ],
+									"patching_rect" : [ 873.0, 364.0, 20.0, 20.0 ],
 									"rounded" : 60.0,
 									"text" : "4",
 									"textcolor" : [ 0.34902, 0.34902, 0.34902, 1.0 ]
@@ -182,7 +173,7 @@
 									"numoutlets" : 3,
 									"outlettype" : [ "", "", "int" ],
 									"parameter_enable" : 0,
-									"patching_rect" : [ 550.0, 251.5, 20.0, 20.0 ],
+									"patching_rect" : [ 600.0, 259.0, 20.0, 20.0 ],
 									"rounded" : 60.0,
 									"text" : "3",
 									"textcolor" : [ 0.34902, 0.34902, 0.34902, 1.0 ]
@@ -197,7 +188,7 @@
 									"maxclass" : "comment",
 									"numinlets" : 1,
 									"numoutlets" : 0,
-									"patching_rect" : [ 550.0, 338.0, 271.0, 54.0 ],
+									"patching_rect" : [ 600.0, 345.5, 271.0, 54.0 ],
 									"text" : "Transform the help.pointsrc buffer to be normalized based on the range of the help.transformpoint dataset."
 								}
 
@@ -209,7 +200,7 @@
 									"maxclass" : "comment",
 									"numinlets" : 1,
 									"numoutlets" : 0,
-									"patching_rect" : [ 348.0, 249.0, 201.0, 25.0 ],
+									"patching_rect" : [ 398.0, 256.5, 201.0, 25.0 ],
 									"text" : "Store a single value in a buffer"
 								}
 
@@ -220,9 +211,9 @@
 									"id" : "obj-54",
 									"maxclass" : "newobj",
 									"numinlets" : 1,
-									"numoutlets" : 3,
-									"outlettype" : [ "bang", "float", "" ],
-									"patching_rect" : [ 10.0, 480.0, 201.0, 23.0 ],
+									"numoutlets" : 2,
+									"outlettype" : [ "", "" ],
+									"patching_rect" : [ 60.0, 480.0, 201.0, 23.0 ],
 									"text" : "fluid.dataset~ help.transformpoint"
 								}
 
@@ -280,7 +271,7 @@
 													"numinlets" : 2,
 													"numoutlets" : 1,
 													"outlettype" : [ "" ],
-													"patching_rect" : [ 192.0, 388.0, 41.0, 22.0 ],
+													"patching_rect" : [ 196.0, 388.0, 41.0, 22.0 ],
 													"text" : "dump"
 												}
 
@@ -292,7 +283,7 @@
 													"numinlets" : 3,
 													"numoutlets" : 3,
 													"outlettype" : [ "", "", "" ],
-													"patching_rect" : [ 192.0, 353.0, 133.75, 22.0 ],
+													"patching_rect" : [ 196.0, 353.0, 133.75, 22.0 ],
 													"text" : "route load dump"
 												}
 
@@ -304,7 +295,7 @@
 													"numinlets" : 2,
 													"numoutlets" : 1,
 													"outlettype" : [ "" ],
-													"patching_rect" : [ 68.0, 188.0, 117.0, 22.0 ],
+													"patching_rect" : [ 72.0, 188.0, 117.0, 22.0 ],
 													"text" : "sprintf entry-%i: %i"
 												}
 
@@ -328,7 +319,7 @@
 													"numinlets" : 2,
 													"numoutlets" : 1,
 													"outlettype" : [ "dictionary" ],
-													"patching_rect" : [ 25.0, 253.0, 130.0, 22.0 ],
+													"patching_rect" : [ 29.0, 253.0, 130.0, 22.0 ],
 													"text" : "dict.pack data: cols:1"
 												}
 
@@ -340,7 +331,7 @@
 													"numinlets" : 1,
 													"numoutlets" : 1,
 													"outlettype" : [ "dictionary" ],
-													"patching_rect" : [ 25.0, 223.0, 66.0, 22.0 ],
+													"patching_rect" : [ 29.0, 223.0, 66.0, 22.0 ],
 													"text" : "dict.group"
 												}
 
@@ -351,8 +342,8 @@
 													"id" : "obj-54",
 													"maxclass" : "newobj",
 													"numinlets" : 1,
-													"numoutlets" : 3,
-													"outlettype" : [ "bang", "float", "" ],
+													"numoutlets" : 2,
+													"outlettype" : [ "", "" ],
 													"patching_rect" : [ 112.5, 88.0, 186.0, 22.0 ],
 													"text" : "fluid.dataset~ help.transformpoint"
 												}
@@ -377,7 +368,7 @@
 													"numinlets" : 1,
 													"numoutlets" : 1,
 													"outlettype" : [ "" ],
-													"patching_rect" : [ 25.0, 288.0, 84.0, 22.0 ],
+													"patching_rect" : [ 29.0, 288.0, 84.0, 22.0 ],
 													"text" : "prepend load"
 												}
 
@@ -388,9 +379,9 @@
 													"id" : "obj-1",
 													"maxclass" : "newobj",
 													"numinlets" : 1,
-													"numoutlets" : 3,
-													"outlettype" : [ "bang", "float", "" ],
-													"patching_rect" : [ 25.0, 320.0, 186.0, 22.0 ],
+													"numoutlets" : 2,
+													"outlettype" : [ "", "" ],
+													"patching_rect" : [ 29.0, 320.0, 186.0, 22.0 ],
 													"text" : "fluid.dataset~ help.transformpoint"
 												}
 
@@ -416,7 +407,7 @@
 													"maxclass" : "outlet",
 													"numinlets" : 1,
 													"numoutlets" : 0,
-													"patching_rect" : [ 249.375, 388.0, 30.0, 30.0 ]
+													"patching_rect" : [ 253.375, 388.0, 30.0, 30.0 ]
 												}
 
 											}
@@ -424,7 +415,7 @@
 										"lines" : [ 											{
 												"patchline" : 												{
 													"destination" : [ "obj-104", 0 ],
-													"source" : [ "obj-1", 2 ]
+													"source" : [ "obj-1", 1 ]
 												}
 
 											}
@@ -452,7 +443,7 @@
 , 											{
 												"patchline" : 												{
 													"destination" : [ "obj-1", 0 ],
-													"midpoints" : [ 201.5, 411.0, 17.75, 411.0, 17.75, 315.0, 34.5, 315.0 ],
+													"midpoints" : [ 205.5, 411.0, 21.75, 411.0, 21.75, 315.0, 38.5, 315.0 ],
 													"source" : [ "obj-107", 0 ]
 												}
 
@@ -525,7 +516,7 @@
  ]
 									}
 ,
-									"patching_rect" : [ 10.0, 220.0, 157.0, 23.0 ],
+									"patching_rect" : [ 60.0, 180.0, 157.0, 23.0 ],
 									"saved_object_attributes" : 									{
 										"description" : "",
 										"digest" : "",
@@ -545,7 +536,7 @@
 									"numinlets" : 1,
 									"numoutlets" : 1,
 									"outlettype" : [ "list" ],
-									"patching_rect" : [ 296.0, 290.0, 234.0, 23.0 ],
+									"patching_rect" : [ 346.0, 297.5, 234.0, 23.0 ],
 									"text" : "fluid.list2buf @destination help.pointsrc"
 								}
 
@@ -557,8 +548,8 @@
 									"numinlets" : 2,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 250.0, 580.0, 132.0, 23.0 ],
-									"text" : "0.065556"
+									"patching_rect" : [ 300.0, 557.5, 132.0, 23.0 ],
+									"text" : "0.095556"
 								}
 
 							}
@@ -569,7 +560,7 @@
 									"numinlets" : 2,
 									"numoutlets" : 1,
 									"outlettype" : [ "list" ],
-									"patching_rect" : [ 250.0, 530.0, 210.0, 23.0 ],
+									"patching_rect" : [ 300.0, 487.5, 210.0, 23.0 ],
 									"text" : "fluid.buf2list @source help.pointdst"
 								}
 
@@ -581,7 +572,7 @@
 									"numinlets" : 2,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 250.0, 182.5, 134.0, 23.0 ],
+									"patching_rect" : [ 300.0, 190.0, 134.0, 23.0 ],
 									"text" : "fit help.transformpoint"
 								}
 
@@ -593,7 +584,7 @@
 									"numinlets" : 1,
 									"numoutlets" : 2,
 									"outlettype" : [ "float", "bang" ],
-									"patching_rect" : [ 605.0, 580.0, 126.0, 23.0 ],
+									"patching_rect" : [ 651.0, 557.5, 126.0, 23.0 ],
 									"text" : "buffer~ help.pointdst"
 								}
 
@@ -606,7 +597,7 @@
 									"numinlets" : 1,
 									"numoutlets" : 2,
 									"outlettype" : [ "float", "bang" ],
-									"patching_rect" : [ 535.0, 290.0, 192.0, 23.0 ],
+									"patching_rect" : [ 585.0, 297.5, 192.0, 23.0 ],
 									"text" : "buffer~ help.pointsrc @samps 1"
 								}
 
@@ -618,7 +609,7 @@
 									"numinlets" : 2,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 296.0, 353.5, 246.0, 23.0 ],
+									"patching_rect" : [ 346.0, 361.0, 246.0, 23.0 ],
 									"text" : "transformpoint help.pointsrc help.pointdst"
 								}
 
@@ -630,7 +621,7 @@
 									"maxclass" : "comment",
 									"numinlets" : 1,
 									"numoutlets" : 0,
-									"patching_rect" : [ 385.0, 182.5, 271.0, 25.0 ],
+									"patching_rect" : [ 435.0, 190.0, 271.0, 25.0 ],
 									"text" : "Fit a datasaet to learn minima and maxima"
 								}
 
@@ -648,7 +639,7 @@
 									"numoutlets" : 3,
 									"outlettype" : [ "", "", "int" ],
 									"parameter_enable" : 0,
-									"patching_rect" : [ 204.0, 182.5, 20.0, 20.0 ],
+									"patching_rect" : [ 254.0, 142.5, 20.0, 20.0 ],
 									"rounded" : 60.0,
 									"text" : "1",
 									"textcolor" : [ 0.34902, 0.34902, 0.34902, 1.0 ]
@@ -662,7 +653,7 @@
 									"maxclass" : "comment",
 									"numinlets" : 1,
 									"numoutlets" : 0,
-									"patching_rect" : [ 34.0, 180.0, 168.0, 25.0 ],
+									"patching_rect" : [ 84.0, 140.0, 168.0, 25.0 ],
 									"text" : "Create a dummy dataset"
 								}
 
@@ -673,7 +664,7 @@
 									"maxclass" : "dict.view",
 									"numinlets" : 1,
 									"numoutlets" : 0,
-									"patching_rect" : [ 10.0, 260.0, 214.0, 210.0 ],
+									"patching_rect" : [ 60.0, 220.0, 130.0, 250.0 ],
 									"stripecolor" : [ 1.0, 0.43921568627451, 0.662745098039216, 1.0 ]
 								}
 
@@ -686,7 +677,7 @@
 									"numoutlets" : 1,
 									"outlettype" : [ "bang" ],
 									"parameter_enable" : 0,
-									"patching_rect" : [ 10.0, 180.0, 24.0, 24.0 ]
+									"patching_rect" : [ 60.0, 140.0, 24.0, 24.0 ]
 								}
 
 							}
@@ -696,7 +687,7 @@
 									"maxclass" : "comment",
 									"numinlets" : 1,
 									"numoutlets" : 0,
-									"patching_rect" : [ 10.0, 140.0, 705.0, 21.0 ],
+									"patching_rect" : [ 10.0, 62.0, 705.0, 21.0 ],
 									"text" : "We can also transform singular points based on the minima and maxima of a fluid.dataset~ that has been learned before.",
 									"textcolor" : [ 0.501960784313725, 0.501960784313725, 0.501960784313725, 1.0 ]
 								}
@@ -715,7 +706,7 @@
 									"numoutlets" : 3,
 									"outlettype" : [ "", "", "int" ],
 									"parameter_enable" : 0,
-									"patching_rect" : [ 658.0, 182.5, 20.0, 20.0 ],
+									"patching_rect" : [ 708.0, 190.0, 20.0, 20.0 ],
 									"rounded" : 60.0,
 									"text" : "2",
 									"textcolor" : [ 0.34902, 0.34902, 0.34902, 1.0 ]
@@ -724,24 +715,12 @@
 							}
 , 							{
 								"box" : 								{
-									"id" : "obj-38",
-									"maxclass" : "newobj",
-									"numinlets" : 2,
-									"numoutlets" : 2,
-									"outlettype" : [ "", "" ],
-									"patching_rect" : [ 250.0, 486.5, 125.0, 23.0 ],
-									"text" : "route transformpoint"
-								}
-
-							}
-, 							{
-								"box" : 								{
 									"id" : "obj-31",
 									"maxclass" : "newobj",
 									"numinlets" : 1,
-									"numoutlets" : 3,
-									"outlettype" : [ "bang", "float", "" ],
-									"patching_rect" : [ 250.0, 420.0, 208.0, 23.0 ],
+									"numoutlets" : 2,
+									"outlettype" : [ "", "" ],
+									"patching_rect" : [ 300.0, 407.5, 208.0, 23.0 ],
 									"text" : "fluid.normalize~ @min 0. @max 1."
 								}
 
@@ -750,7 +729,7 @@
 						"lines" : [ 							{
 								"patchline" : 								{
 									"destination" : [ "obj-31", 0 ],
-									"midpoints" : [ 259.5, 207.0, 259.5, 207.0 ],
+									"midpoints" : [ 309.5, 214.5, 309.5, 214.5 ],
 									"source" : [ "obj-12", 0 ]
 								}
 
@@ -758,16 +737,22 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-15", 1 ],
-									"midpoints" : [ 259.5, 567.0, 372.5, 567.0 ],
+									"midpoints" : [ 309.5, 544.5, 422.5, 544.5 ],
 									"source" : [ "obj-13", 0 ]
 								}
 
 							}
 , 							{
 								"patchline" : 								{
-									"destination" : [ "obj-38", 0 ],
-									"midpoints" : [ 448.5, 471.0, 259.5, 471.0 ],
-									"source" : [ "obj-31", 2 ]
+									"destination" : [ "obj-5", 0 ],
+									"source" : [ "obj-22", 0 ]
+								}
+
+							}
+, 							{
+								"patchline" : 								{
+									"destination" : [ "obj-8", 0 ],
+									"source" : [ "obj-31", 0 ]
 								}
 
 							}
@@ -780,15 +765,8 @@
 							}
 , 							{
 								"patchline" : 								{
-									"destination" : [ "obj-13", 0 ],
-									"source" : [ "obj-38", 0 ]
-								}
-
-							}
-, 							{
-								"patchline" : 								{
 									"destination" : [ "obj-31", 0 ],
-									"midpoints" : [ 305.5, 405.0, 259.5, 405.0 ],
+									"midpoints" : [ 355.5, 395.25, 309.5, 395.25 ],
 									"source" : [ "obj-5", 0 ]
 								}
 
@@ -804,6 +782,13 @@
 								"patchline" : 								{
 									"destination" : [ "obj-57", 0 ],
 									"source" : [ "obj-6", 0 ]
+								}
+
+							}
+, 							{
+								"patchline" : 								{
+									"destination" : [ "obj-13", 0 ],
+									"source" : [ "obj-8", 0 ]
 								}
 
 							}
@@ -832,13 +817,13 @@
 								"name" : "max6message",
 								"default" : 								{
 									"bgfillcolor" : 									{
-										"type" : "gradient",
+										"angle" : 270.0,
+										"autogradient" : 0,
+										"color" : [ 0.290196, 0.309804, 0.301961, 1.0 ],
 										"color1" : [ 0.866667, 0.866667, 0.866667, 1.0 ],
 										"color2" : [ 0.788235, 0.788235, 0.788235, 1.0 ],
-										"color" : [ 0.290196, 0.309804, 0.301961, 1.0 ],
-										"angle" : 270.0,
 										"proportion" : 0.39,
-										"autogradient" : 0
+										"type" : "gradient"
 									}
 ,
 									"textcolor_inverse" : [ 0.0, 0.0, 0.0, 1.0 ]
@@ -921,27 +906,6 @@
 						"assistshowspatchername" : 0,
 						"boxes" : [ 							{
 								"box" : 								{
-									"args" : [ "normalize" ],
-									"bgmode" : 0,
-									"border" : 0,
-									"clickthrough" : 0,
-									"enablehscroll" : 0,
-									"enablevscroll" : 0,
-									"id" : "obj-3",
-									"lockeddragscroll" : 0,
-									"lockedsize" : 0,
-									"maxclass" : "bpatcher",
-									"name" : "fluid.learn.maxpat",
-									"numinlets" : 0,
-									"numoutlets" : 0,
-									"offset" : [ 0.0, 0.0 ],
-									"patching_rect" : [ 540.0, 10.0, 240.0, 110.0 ],
-									"viewvisibility" : 1
-								}
-
-							}
-, 							{
-								"box" : 								{
 									"border" : 0,
 									"filename" : "helpdetails.js",
 									"id" : "obj-2",
@@ -952,7 +916,7 @@
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
 									"parameter_enable" : 0,
-									"patching_rect" : [ 10.0, 10.0, 525.0, 115.0 ]
+									"patching_rect" : [ 10.0, 10.0, 340.0, 50.0 ]
 								}
 
 							}
@@ -963,7 +927,7 @@
 									"maxclass" : "comment",
 									"numinlets" : 1,
 									"numoutlets" : 0,
-									"patching_rect" : [ 725.0, 244.5, 182.0, 25.0 ],
+									"patching_rect" : [ 712.0, 162.5, 182.0, 25.0 ],
 									"text" : "Exexcute the normalisation"
 								}
 
@@ -981,7 +945,7 @@
 									"numoutlets" : 3,
 									"outlettype" : [ "", "", "int" ],
 									"parameter_enable" : 0,
-									"patching_rect" : [ 364.0, 244.5, 20.0, 20.0 ],
+									"patching_rect" : [ 370.0, 162.5, 20.0, 20.0 ],
 									"rounded" : 60.0,
 									"text" : "1",
 									"textcolor" : [ 0.34902, 0.34902, 0.34902, 1.0 ]
@@ -995,7 +959,7 @@
 									"maxclass" : "comment",
 									"numinlets" : 1,
 									"numoutlets" : 0,
-									"patching_rect" : [ 44.0, 242.0, 318.0, 25.0 ],
+									"patching_rect" : [ 50.0, 160.0, 318.0, 25.0 ],
 									"text" : "Compute some pitch and pitch confidence analysis"
 								}
 
@@ -1006,7 +970,7 @@
 									"maxclass" : "dict.view",
 									"numinlets" : 1,
 									"numoutlets" : 0,
-									"patching_rect" : [ 425.0, 490.0, 214.0, 210.0 ],
+									"patching_rect" : [ 412.0, 408.0, 138.0, 252.0 ],
 									"stripecolor" : [ 0.254901960784314, 0.905882352941176, 0.450980392156863, 1.0 ]
 								}
 
@@ -1017,7 +981,7 @@
 									"maxclass" : "dict.view",
 									"numinlets" : 1,
 									"numoutlets" : 0,
-									"patching_rect" : [ 166.0, 490.0, 214.0, 210.0 ],
+									"patching_rect" : [ 172.0, 408.0, 138.0, 252.0 ],
 									"stripecolor" : [ 0.423529411764706, 0.513725490196078, 1.0, 1.0 ]
 								}
 
@@ -1029,7 +993,7 @@
 									"numinlets" : 2,
 									"numoutlets" : 2,
 									"outlettype" : [ "", "" ],
-									"patching_rect" : [ 166.0, 450.0, 74.0, 23.0 ],
+									"patching_rect" : [ 172.0, 368.0, 74.0, 23.0 ],
 									"text" : "route dump"
 								}
 
@@ -1041,7 +1005,7 @@
 									"numinlets" : 2,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 20.0, 345.0, 220.0, 23.0 ],
+									"patching_rect" : [ 26.0, 263.0, 220.0, 23.0 ],
 									"text" : "setpoint $1 help.pitch.stats.mean.flat"
 								}
 
@@ -1052,9 +1016,9 @@
 									"id" : "obj-8",
 									"maxclass" : "newobj",
 									"numinlets" : 1,
-									"numoutlets" : 3,
-									"outlettype" : [ "bang", "float", "" ],
-									"patching_rect" : [ 20.0, 400.0, 165.0, 23.0 ],
+									"numoutlets" : 2,
+									"outlettype" : [ "", "" ],
+									"patching_rect" : [ 26.0, 318.0, 165.0, 23.0 ],
 									"text" : "fluid.dataset~ help.analysis"
 								}
 
@@ -1067,7 +1031,7 @@
 									"numoutlets" : 1,
 									"outlettype" : [ "bang" ],
 									"parameter_enable" : 0,
-									"patching_rect" : [ 20.0, 242.0, 24.0, 24.0 ]
+									"patching_rect" : [ 26.0, 160.0, 24.0, 24.0 ]
 								}
 
 							}
@@ -1119,6 +1083,18 @@
 										"assistshowspatchername" : 0,
 										"boxes" : [ 											{
 												"box" : 												{
+													"id" : "obj-12",
+													"maxclass" : "newobj",
+													"numinlets" : 1,
+													"numoutlets" : 1,
+													"outlettype" : [ "bang" ],
+													"patching_rect" : [ 96.00000011920929, 500.0, 22.0, 22.0 ],
+													"text" : "t b"
+												}
+
+											}
+, 											{
+												"box" : 												{
 													"color" : [ 0.298039215686275, 0.407843137254902, 0.870588235294118, 1.0 ],
 													"id" : "obj-9",
 													"maxclass" : "newobj",
@@ -1149,7 +1125,7 @@
 													"numinlets" : 2,
 													"numoutlets" : 1,
 													"outlettype" : [ "" ],
-													"patching_rect" : [ 52.00000011920929, 508.199999928474426, 39.0, 22.0 ],
+													"patching_rect" : [ 52.00000011920929, 538.199999928474426, 39.0, 22.0 ],
 													"text" : "dump"
 												}
 
@@ -1160,8 +1136,8 @@
 													"id" : "obj-19",
 													"maxclass" : "newobj",
 													"numinlets" : 1,
-													"numoutlets" : 3,
-													"outlettype" : [ "bang", "float", "" ],
+													"numoutlets" : 2,
+													"outlettype" : [ "", "" ],
 													"patching_rect" : [ 96.00000011920929, 328.199999928474426, 267.0, 22.0 ],
 													"text" : "fluid.bufpitch~ @source src @features help.pitch"
 												}
@@ -1275,7 +1251,7 @@
 													"numinlets" : 2,
 													"numoutlets" : 1,
 													"outlettype" : [ "int" ],
-													"patching_rect" : [ 96.00000011920929, 508.199999928474426, 703.5, 22.0 ],
+													"patching_rect" : [ 96.00000011920929, 538.199999928474426, 703.5, 22.0 ],
 													"text" : "i"
 												}
 
@@ -1286,8 +1262,8 @@
 													"id" : "obj-49",
 													"maxclass" : "newobj",
 													"numinlets" : 1,
-													"numoutlets" : 3,
-													"outlettype" : [ "bang", "float", "" ],
+													"numoutlets" : 2,
+													"outlettype" : [ "", "" ],
 													"patching_rect" : [ 96.00000011920929, 463.199999928474426, 468.0, 22.0 ],
 													"text" : "fluid.bufflatten~ @source help.pitch.stats.mean @destination help.pitch.stats.mean.flat"
 												}
@@ -1312,8 +1288,8 @@
 													"id" : "obj-41",
 													"maxclass" : "newobj",
 													"numinlets" : 1,
-													"numoutlets" : 3,
-													"outlettype" : [ "bang", "float", "" ],
+													"numoutlets" : 2,
+													"outlettype" : [ "", "" ],
 													"patching_rect" : [ 96.00000011920929, 418.199999928474426, 477.0, 22.0 ],
 													"text" : "fluid.bufselect~ @source help.pitch.stats @destination help.pitch.stats.mean @indices 0"
 												}
@@ -1324,9 +1300,9 @@
 													"color" : [ 1.0, 0.709803921568627, 0.196078431372549, 1.0 ],
 													"id" : "obj-40",
 													"maxclass" : "newobj",
-													"numinlets" : 1,
-													"numoutlets" : 3,
-													"outlettype" : [ "bang", "float", "" ],
+													"numinlets" : 2,
+													"numoutlets" : 2,
+													"outlettype" : [ "", "" ],
 													"patching_rect" : [ 96.00000011920929, 373.199999928474426, 313.0, 22.0 ],
 													"text" : "fluid.bufstats~ @source help.pitch @stats help.pitch.stats"
 												}
@@ -1517,8 +1493,15 @@
 											}
 , 											{
 												"patchline" : 												{
+													"destination" : [ "obj-6", 0 ],
+													"source" : [ "obj-12", 0 ]
+												}
+
+											}
+, 											{
+												"patchline" : 												{
 													"destination" : [ "obj-15", 0 ],
-													"midpoints" : [ 61.50000011920929, 531.0, 61.5, 531.0 ],
+													"midpoints" : [ 61.50000011920929, 561.0, 61.5, 561.0 ],
 													"source" : [ "obj-14", 0 ]
 												}
 
@@ -1554,6 +1537,7 @@
 , 											{
 												"patchline" : 												{
 													"destination" : [ "obj-14", 0 ],
+													"midpoints" : [ 61.50000011920929, 72.0, 61.50000011920929, 72.0 ],
 													"source" : [ "obj-31", 1 ]
 												}
 
@@ -1618,7 +1602,7 @@
 											}
 , 											{
 												"patchline" : 												{
-													"destination" : [ "obj-6", 0 ],
+													"destination" : [ "obj-12", 0 ],
 													"source" : [ "obj-49", 0 ]
 												}
 
@@ -1663,13 +1647,13 @@
 												"name" : "max6message",
 												"default" : 												{
 													"bgfillcolor" : 													{
-														"type" : "gradient",
+														"angle" : 270.0,
+														"autogradient" : 0,
+														"color" : [ 0.290196, 0.309804, 0.301961, 1.0 ],
 														"color1" : [ 0.866667, 0.866667, 0.866667, 1.0 ],
 														"color2" : [ 0.788235, 0.788235, 0.788235, 1.0 ],
-														"color" : [ 0.290196, 0.309804, 0.301961, 1.0 ],
-														"angle" : 270.0,
 														"proportion" : 0.39,
-														"autogradient" : 0
+														"type" : "gradient"
 													}
 ,
 													"textcolor_inverse" : [ 0.0, 0.0, 0.0, 1.0 ]
@@ -1690,7 +1674,7 @@
  ]
 									}
 ,
-									"patching_rect" : [ 20.0, 290.0, 97.0, 23.0 ],
+									"patching_rect" : [ 26.0, 208.0, 97.0, 23.0 ],
 									"saved_object_attributes" : 									{
 										"description" : "",
 										"digest" : "",
@@ -1709,7 +1693,7 @@
 									"maxclass" : "comment",
 									"numinlets" : 1,
 									"numoutlets" : 0,
-									"patching_rect" : [ 10.0, 140.0, 700.0, 79.0 ],
+									"patching_rect" : [ 10.0, 60.0, 700.0, 79.0 ],
 									"text" : "When fluid.normalize~ learns the minima and maxima of a fluid.dataset~ it does so per-column. In this example, pitch and pitch confidence data make up the source dataset with pitch being in the range of the minimum and maximum frequency of the analysis and confidence ranging between 0 and 1. Even though these two separate bits of information occupy different ranges, by normalising each column individual descriptor values for each point are transformed to be in the same range (0 to 1 by default).",
 									"textcolor" : [ 0.501960784313725, 0.501960784313725, 0.501960784313725, 1.0 ]
 								}
@@ -1728,7 +1712,7 @@
 									"numoutlets" : 3,
 									"outlettype" : [ "", "", "int" ],
 									"parameter_enable" : 0,
-									"patching_rect" : [ 909.0, 247.0, 20.0, 20.0 ],
+									"patching_rect" : [ 896.0, 165.0, 20.0, 20.0 ],
 									"rounded" : 60.0,
 									"text" : "2",
 									"textcolor" : [ 0.34902, 0.34902, 0.34902, 1.0 ]
@@ -1742,7 +1726,7 @@
 									"numinlets" : 2,
 									"numoutlets" : 2,
 									"outlettype" : [ "", "" ],
-									"patching_rect" : [ 638.0, 450.0, 74.0, 23.0 ],
+									"patching_rect" : [ 625.0, 368.0, 74.0, 23.0 ],
 									"text" : "route dump"
 								}
 
@@ -1754,7 +1738,7 @@
 									"numinlets" : 2,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 425.0, 380.0, 41.0, 23.0 ],
+									"patching_rect" : [ 412.0, 298.0, 41.0, 23.0 ],
 									"text" : "dump"
 								}
 
@@ -1766,7 +1750,7 @@
 									"numinlets" : 2,
 									"numoutlets" : 2,
 									"outlettype" : [ "", "" ],
-									"patching_rect" : [ 425.0, 345.0, 107.0, 23.0 ],
+									"patching_rect" : [ 412.0, 263.0, 107.0, 23.0 ],
 									"text" : "route fittransform"
 								}
 
@@ -1777,9 +1761,9 @@
 									"id" : "obj-34",
 									"maxclass" : "newobj",
 									"numinlets" : 1,
-									"numoutlets" : 3,
-									"outlettype" : [ "bang", "float", "" ],
-									"patching_rect" : [ 425.0, 415.0, 232.0, 23.0 ],
+									"numoutlets" : 2,
+									"outlettype" : [ "", "" ],
+									"patching_rect" : [ 412.0, 333.0, 232.0, 23.0 ],
 									"text" : "fluid.dataset~ help.analysis.normalized"
 								}
 
@@ -1791,7 +1775,7 @@
 									"numinlets" : 2,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 425.0, 244.5, 298.0, 23.0 ],
+									"patching_rect" : [ 412.0, 162.5, 298.0, 23.0 ],
 									"text" : "fittransform help.analysis help.analysis.normalized"
 								}
 
@@ -1801,9 +1785,9 @@
 									"id" : "obj-31",
 									"maxclass" : "newobj",
 									"numinlets" : 1,
-									"numoutlets" : 3,
-									"outlettype" : [ "bang", "float", "" ],
-									"patching_rect" : [ 425.0, 290.0, 208.0, 23.0 ],
+									"numoutlets" : 2,
+									"outlettype" : [ "", "" ],
+									"patching_rect" : [ 412.0, 208.0, 208.0, 23.0 ],
 									"text" : "fluid.normalize~ @min 0. @max 1."
 								}
 
@@ -1812,7 +1796,7 @@
 						"lines" : [ 							{
 								"patchline" : 								{
 									"destination" : [ "obj-8", 0 ],
-									"midpoints" : [ 29.5, 371.0, 29.5, 371.0 ],
+									"midpoints" : [ 35.5, 289.0, 35.5, 289.0 ],
 									"source" : [ "obj-11", 0 ]
 								}
 
@@ -1820,7 +1804,7 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-18", 0 ],
-									"midpoints" : [ 175.5, 476.0, 175.5, 476.0 ],
+									"midpoints" : [ 181.5, 394.0, 181.5, 394.0 ],
 									"source" : [ "obj-17", 0 ]
 								}
 
@@ -1828,8 +1812,7 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-38", 0 ],
-									"midpoints" : [ 623.5, 332.0, 434.5, 332.0 ],
-									"source" : [ "obj-31", 2 ]
+									"source" : [ "obj-31", 0 ]
 								}
 
 							}
@@ -1843,7 +1826,7 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-44", 0 ],
-									"source" : [ "obj-34", 2 ]
+									"source" : [ "obj-34", 1 ]
 								}
 
 							}
@@ -1864,7 +1847,7 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-21", 0 ],
-									"midpoints" : [ 647.5, 476.0, 434.5, 476.0 ],
+									"midpoints" : [ 634.5, 394.0, 421.5, 394.0 ],
 									"source" : [ "obj-44", 0 ]
 								}
 
@@ -1879,7 +1862,7 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-17", 0 ],
-									"source" : [ "obj-8", 2 ]
+									"source" : [ "obj-8", 1 ]
 								}
 
 							}
@@ -1893,7 +1876,7 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-8", 0 ],
-									"midpoints" : [ 107.5, 332.0, 5.0, 332.0, 5.0, 386.0, 29.5, 386.0 ],
+									"midpoints" : [ 113.5, 250.0, 11.0, 250.0, 11.0, 304.0, 35.5, 304.0 ],
 									"source" : [ "obj-95", 1 ]
 								}
 
@@ -1923,13 +1906,13 @@
 								"name" : "max6message",
 								"default" : 								{
 									"bgfillcolor" : 									{
-										"type" : "gradient",
+										"angle" : 270.0,
+										"autogradient" : 0,
+										"color" : [ 0.290196, 0.309804, 0.301961, 1.0 ],
 										"color1" : [ 0.866667, 0.866667, 0.866667, 1.0 ],
 										"color2" : [ 0.788235, 0.788235, 0.788235, 1.0 ],
-										"color" : [ 0.290196, 0.309804, 0.301961, 1.0 ],
-										"angle" : 270.0,
 										"proportion" : 0.39,
-										"autogradient" : 0
+										"type" : "gradient"
 									}
 ,
 									"textcolor_inverse" : [ 0.0, 0.0, 0.0, 1.0 ]
@@ -1981,7 +1964,7 @@
 						}
 ,
 						"classnamespace" : "box",
-						"rect" : [ 0.0, 26.0, 934.0, 721.0 ],
+						"rect" : [ 34.0, 113.0, 934.0, 721.0 ],
 						"bglocked" : 0,
 						"openinpresentation" : 0,
 						"default_fontsize" : 13.0,
@@ -2026,7 +2009,7 @@
 									"numinlets" : 0,
 									"numoutlets" : 0,
 									"offset" : [ 0.0, 0.0 ],
-									"patching_rect" : [ 540.0, 10.0, 240.0, 110.0 ],
+									"patching_rect" : [ 552.0, 12.5, 240.0, 110.0 ],
 									"viewvisibility" : 1
 								}
 
@@ -2179,8 +2162,8 @@
 													"id" : "obj-54",
 													"maxclass" : "newobj",
 													"numinlets" : 1,
-													"numoutlets" : 3,
-													"outlettype" : [ "bang", "float", "" ],
+													"numoutlets" : 2,
+													"outlettype" : [ "", "" ],
 													"patching_rect" : [ 112.5, 88.0, 129.0, 22.0 ],
 													"text" : "fluid.dataset~ help.raw"
 												}
@@ -2205,7 +2188,7 @@
 													"numinlets" : 1,
 													"numoutlets" : 1,
 													"outlettype" : [ "" ],
-													"patching_rect" : [ 25.0, 288.0, 84.0, 22.0 ],
+													"patching_rect" : [ 25.0, 284.0, 84.0, 22.0 ],
 													"text" : "prepend load"
 												}
 
@@ -2216,8 +2199,8 @@
 													"id" : "obj-1",
 													"maxclass" : "newobj",
 													"numinlets" : 1,
-													"numoutlets" : 3,
-													"outlettype" : [ "bang", "float", "" ],
+													"numoutlets" : 2,
+													"outlettype" : [ "", "" ],
 													"patching_rect" : [ 25.0, 320.0, 129.0, 22.0 ],
 													"text" : "fluid.dataset~ help.raw"
 												}
@@ -2252,7 +2235,7 @@
 										"lines" : [ 											{
 												"patchline" : 												{
 													"destination" : [ "obj-104", 0 ],
-													"source" : [ "obj-1", 2 ]
+													"source" : [ "obj-1", 1 ]
 												}
 
 											}
@@ -2344,6 +2327,7 @@
 , 											{
 												"patchline" : 												{
 													"destination" : [ "obj-103", 0 ],
+													"midpoints" : [ 46.5, 118.5, 78.0, 118.5 ],
 													"source" : [ "obj-74", 2 ]
 												}
 
@@ -2365,7 +2349,7 @@
  ]
 									}
 ,
-									"patching_rect" : [ 10.0, 180.0, 157.0, 23.0 ],
+									"patching_rect" : [ 80.0, 180.0, 157.0, 23.0 ],
 									"saved_object_attributes" : 									{
 										"description" : "",
 										"digest" : "",
@@ -2390,7 +2374,7 @@
 									"numoutlets" : 3,
 									"outlettype" : [ "", "", "int" ],
 									"parameter_enable" : 0,
-									"patching_rect" : [ 515.0, 223.0, 20.0, 20.0 ],
+									"patching_rect" : [ 750.0, 221.5, 20.0, 20.0 ],
 									"rounded" : 60.0,
 									"text" : "2",
 									"textcolor" : [ 0.34902, 0.34902, 0.34902, 1.0 ]
@@ -2405,7 +2389,7 @@
 									"maxclass" : "comment",
 									"numinlets" : 1,
 									"numoutlets" : 0,
-									"patching_rect" : [ 279.0, 204.5, 233.0, 54.0 ],
+									"patching_rect" : [ 515.0, 204.5, 233.0, 54.0 ],
 									"text" : "Normalise \"help.raw\" to a new fluid.dataset~ called \"help.normalized\""
 								}
 
@@ -2417,7 +2401,7 @@
 									"numinlets" : 2,
 									"numoutlets" : 2,
 									"outlettype" : [ "", "" ],
-									"patching_rect" : [ 407.0, 400.0, 74.0, 23.0 ],
+									"patching_rect" : [ 454.0, 395.0, 74.0, 23.0 ],
 									"text" : "route dump"
 								}
 
@@ -2428,7 +2412,7 @@
 									"maxclass" : "dict.view",
 									"numinlets" : 1,
 									"numoutlets" : 0,
-									"patching_rect" : [ 175.0, 445.0, 133.625, 225.0 ],
+									"patching_rect" : [ 454.0, 425.0, 133.625, 225.0 ],
 									"stripecolor" : [ 1.0, 0.345098039215686, 0.298039215686275, 1.0 ]
 								}
 
@@ -2440,7 +2424,7 @@
 									"numinlets" : 2,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 244.0, 330.0, 41.0, 23.0 ],
+									"patching_rect" : [ 291.0, 330.0, 41.0, 23.0 ],
 									"text" : "dump"
 								}
 
@@ -2452,7 +2436,7 @@
 									"numinlets" : 2,
 									"numoutlets" : 2,
 									"outlettype" : [ "", "" ],
-									"patching_rect" : [ 244.0, 295.0, 107.0, 23.0 ],
+									"patching_rect" : [ 291.0, 295.0, 107.0, 23.0 ],
 									"text" : "route fittransform"
 								}
 
@@ -2470,7 +2454,7 @@
 									"numoutlets" : 3,
 									"outlettype" : [ "", "", "int" ],
 									"parameter_enable" : 0,
-									"patching_rect" : [ 445.0, 142.5, 20.0, 20.0 ],
+									"patching_rect" : [ 515.0, 142.5, 20.0, 20.0 ],
 									"rounded" : 60.0,
 									"text" : "1",
 									"textcolor" : [ 0.34902, 0.34902, 0.34902, 1.0 ]
@@ -2484,7 +2468,7 @@
 									"maxclass" : "comment",
 									"numinlets" : 1,
 									"numoutlets" : 0,
-									"patching_rect" : [ 36.0, 140.0, 407.0, 25.0 ],
+									"patching_rect" : [ 106.0, 140.0, 407.0, 25.0 ],
 									"text" : "Generate random data to be stored in the fluid.dataset~ \"help.raw\""
 								}
 
@@ -2495,7 +2479,7 @@
 									"maxclass" : "dict.view",
 									"numinlets" : 1,
 									"numoutlets" : 0,
-									"patching_rect" : [ 10.0, 445.0, 133.625, 225.0 ],
+									"patching_rect" : [ 80.0, 220.0, 133.625, 225.0 ],
 									"stripecolor" : [ 0.0, 0.854901960784314, 0.282352941176471, 0.5 ]
 								}
 
@@ -2508,7 +2492,7 @@
 									"numoutlets" : 1,
 									"outlettype" : [ "bang" ],
 									"parameter_enable" : 0,
-									"patching_rect" : [ 10.0, 140.0, 24.0, 24.0 ]
+									"patching_rect" : [ 80.0, 140.0, 24.0, 24.0 ]
 								}
 
 							}
@@ -2518,9 +2502,9 @@
 									"id" : "obj-34",
 									"maxclass" : "newobj",
 									"numinlets" : 1,
-									"numoutlets" : 3,
-									"outlettype" : [ "bang", "float", "" ],
-									"patching_rect" : [ 244.0, 365.0, 182.0, 23.0 ],
+									"numoutlets" : 2,
+									"outlettype" : [ "", "" ],
+									"patching_rect" : [ 291.0, 365.0, 182.0, 23.0 ],
 									"text" : "fluid.dataset~ help.normalized"
 								}
 
@@ -2532,7 +2516,7 @@
 									"numinlets" : 2,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 55.0, 220.0, 222.0, 23.0 ],
+									"patching_rect" : [ 291.0, 220.0, 222.0, 23.0 ],
 									"text" : "fittransform help.raw help.normalized"
 								}
 
@@ -2542,9 +2526,9 @@
 									"id" : "obj-31",
 									"maxclass" : "newobj",
 									"numinlets" : 1,
-									"numoutlets" : 3,
-									"outlettype" : [ "bang", "float", "" ],
-									"patching_rect" : [ 55.0, 260.0, 208.0, 23.0 ],
+									"numoutlets" : 2,
+									"outlettype" : [ "", "" ],
+									"patching_rect" : [ 291.0, 260.0, 208.0, 23.0 ],
 									"text" : "fluid.normalize~ @min 0. @max 1."
 								}
 
@@ -2561,7 +2545,7 @@
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
 									"parameter_enable" : 0,
-									"patching_rect" : [ 10.0, 10.0, 525.0, 115.0 ]
+									"patching_rect" : [ 10.0, 10.0, 540.0, 115.0 ]
 								}
 
 							}
@@ -2569,7 +2553,7 @@
 						"lines" : [ 							{
 								"patchline" : 								{
 									"destination" : [ "obj-38", 0 ],
-									"source" : [ "obj-31", 2 ]
+									"source" : [ "obj-31", 0 ]
 								}
 
 							}
@@ -2583,7 +2567,7 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-44", 0 ],
-									"source" : [ "obj-34", 2 ]
+									"source" : [ "obj-34", 1 ]
 								}
 
 							}
@@ -2604,7 +2588,6 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-41", 0 ],
-									"midpoints" : [ 416.5, 432.0, 184.5, 432.0 ],
 									"source" : [ "obj-44", 0 ]
 								}
 
@@ -2619,7 +2602,7 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-108", 0 ],
-									"midpoints" : [ 19.5, 206.0, 19.5, 206.0 ],
+									"midpoints" : [ 89.5, 206.0, 89.5, 206.0 ],
 									"source" : [ "obj-57", 0 ]
 								}
 
@@ -2649,13 +2632,13 @@
 								"name" : "max6message",
 								"default" : 								{
 									"bgfillcolor" : 									{
-										"type" : "gradient",
+										"angle" : 270.0,
+										"autogradient" : 0,
+										"color" : [ 0.290196, 0.309804, 0.301961, 1.0 ],
 										"color1" : [ 0.866667, 0.866667, 0.866667, 1.0 ],
 										"color2" : [ 0.788235, 0.788235, 0.788235, 1.0 ],
-										"color" : [ 0.290196, 0.309804, 0.301961, 1.0 ],
-										"angle" : 270.0,
 										"proportion" : 0.39,
-										"autogradient" : 0
+										"type" : "gradient"
 									}
 ,
 									"textcolor_inverse" : [ 0.0, 0.0, 0.0, 1.0 ]
@@ -2771,61 +2754,6 @@
 			}
  ],
 		"lines" : [  ],
-		"dependency_cache" : [ 			{
-				"name" : "fluid.buf2list.mxo",
-				"type" : "iLaX"
-			}
-, 			{
-				"name" : "fluid.bufflatten~.mxo",
-				"type" : "iLaX"
-			}
-, 			{
-				"name" : "fluid.bufpitch~.mxo",
-				"type" : "iLaX"
-			}
-, 			{
-				"name" : "fluid.bufselect~.mxo",
-				"type" : "iLaX"
-			}
-, 			{
-				"name" : "fluid.bufstats~.mxo",
-				"type" : "iLaX"
-			}
-, 			{
-				"name" : "fluid.flucomaorg.maxpat",
-				"bootpath" : "~/dev/flucoma/max/help",
-				"patcherrelativepath" : ".",
-				"type" : "JSON",
-				"implicit" : 1
-			}
-, 			{
-				"name" : "fluid.learn.maxpat",
-				"bootpath" : "~/dev/flucoma/max/help",
-				"patcherrelativepath" : ".",
-				"type" : "JSON",
-				"implicit" : 1
-			}
-, 			{
-				"name" : "fluid.libmanipulation.mxo",
-				"type" : "iLaX"
-			}
-, 			{
-				"name" : "fluid.list2buf.mxo",
-				"type" : "iLaX"
-			}
-, 			{
-				"name" : "helpdetails.js",
-				"bootpath" : "C74:/help/resources",
-				"type" : "TEXT",
-				"implicit" : 1
-			}
-, 			{
-				"name" : "helpname.js",
-				"bootpath" : "C74:/help/resources",
-				"type" : "TEXT",
-				"implicit" : 1
-			}
- ],
 		"autosave" : 0
 	}
 

--- a/help/fluid.plotter.maxhelp
+++ b/help/fluid.plotter.maxhelp
@@ -10,7 +10,7 @@
 		}
 ,
 		"classnamespace" : "box",
-		"rect" : [ 35.0, 88.0, 995.0, 777.0 ],
+		"rect" : [ 35.0, 88.0, 956.0, 779.0 ],
 		"bglocked" : 0,
 		"openinpresentation" : 0,
 		"default_fontsize" : 12.0,
@@ -57,14 +57,14 @@
 						}
 ,
 						"classnamespace" : "box",
-						"rect" : [ 35.0, 114.0, 995.0, 751.0 ],
+						"rect" : [ 35.0, 114.0, 956.0, 753.0 ],
 						"bglocked" : 0,
 						"openinpresentation" : 0,
 						"default_fontsize" : 12.0,
 						"default_fontface" : 0,
 						"default_fontname" : "Arial",
 						"gridonopen" : 2,
-						"gridsize" : [ 5.0, 5.0 ],
+						"gridsize" : [ 10.0, 10.0 ],
 						"gridsnaponopen" : 2,
 						"objectsnaponopen" : 1,
 						"statusbarvisible" : 2,
@@ -88,44 +88,76 @@
 						"assistshowspatchername" : 0,
 						"boxes" : [ 							{
 								"box" : 								{
+									"fontsize" : 13.0,
+									"id" : "obj-2",
+									"linecount" : 4,
+									"maxclass" : "comment",
+									"numinlets" : 1,
+									"numoutlets" : 0,
+									"patching_rect" : [ 460.0, 215.0, 279.0, 65.0 ],
+									"presentation_linecount" : 4,
+									"text" : "The range of the generated data sits between -2.5 and 2.5 but the view of the data is set to be between -5 and 5 on both axes to have some whitespace around the edges.",
+									"textcolor" : [ 0.501960784313725, 0.501960784313725, 0.501960784313725, 1.0 ]
+								}
+
+							}
+, 							{
+								"box" : 								{
+									"id" : "obj-1",
+									"maxclass" : "comment",
+									"numinlets" : 1,
+									"numoutlets" : 0,
+									"patching_rect" : [ 10.0, 67.0, 415.0, 20.0 ],
+									"presentation_linecount" : 2,
+									"text" : "fluid.plotter has a zoom feature allowing you to zone in on subsets of the plot",
+									"textcolor" : [ 0.501960784313725, 0.501960784313725, 0.501960784313725, 1.0 ]
+								}
+
+							}
+, 							{
+								"box" : 								{
+									"fontsize" : 13.0,
 									"id" : "obj-13",
 									"linecount" : 2,
 									"maxclass" : "message",
 									"numinlets" : 2,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 381.0, 615.0, 90.0, 35.0 ],
-									"text" : "0.223602 0.950311"
+									"patching_rect" : [ 431.5, 665.0, 97.0, 38.0 ],
+									"text" : "-3.78882 3.198758"
 								}
 
 							}
 , 							{
 								"box" : 								{
+									"fontsize" : 13.0,
 									"id" : "obj-11",
 									"linecount" : 2,
 									"maxclass" : "message",
 									"numinlets" : 2,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 265.0, 610.0, 90.0, 35.0 ],
-									"text" : "0.263975 0.903727"
+									"patching_rect" : [ 307.0, 665.0, 96.0, 38.0 ],
+									"text" : "-2.857143 2.981366"
 								}
 
 							}
 , 							{
 								"box" : 								{
+									"fontsize" : 13.0,
 									"id" : "obj-8",
 									"maxclass" : "newobj",
 									"numinlets" : 3,
 									"numoutlets" : 3,
 									"outlettype" : [ "", "", "" ],
-									"patching_rect" : [ 336.0, 580.0, 251.0, 22.0 ],
+									"patching_rect" : [ 384.0, 630.0, 270.0, 23.0 ],
 									"text" : "route zoomxrange zoomyrange"
 								}
 
 							}
 , 							{
 								"box" : 								{
+									"fontsize" : 13.0,
 									"id" : "obj-88",
 									"maxclass" : "newobj",
 									"numinlets" : 1,
@@ -142,7 +174,7 @@
 										}
 ,
 										"classnamespace" : "box",
-										"rect" : [ 59.0, 106.0, 558.0, 502.0 ],
+										"rect" : [ 59.0, 106.0, 430.0, 328.0 ],
 										"bglocked" : 0,
 										"openinpresentation" : 0,
 										"default_fontsize" : 12.0,
@@ -177,7 +209,7 @@
 													"numinlets" : 2,
 													"numoutlets" : 1,
 													"outlettype" : [ "" ],
-													"patching_rect" : [ 126.0, 306.0, 144.0, 22.0 ],
+													"patching_rect" : [ 126.0, 226.0, 144.0, 22.0 ],
 													"text" : "pointcolor $1 $2 $3 0.3 1."
 												}
 
@@ -189,7 +221,7 @@
 													"numinlets" : 2,
 													"numoutlets" : 1,
 													"outlettype" : [ "" ],
-													"patching_rect" : [ 21.0, 306.0, 101.0, 22.0 ],
+													"patching_rect" : [ 21.0, 226.0, 101.0, 22.0 ],
 													"text" : "setpoint $1 $2 $3"
 												}
 
@@ -201,7 +233,7 @@
 													"numinlets" : 1,
 													"numoutlets" : 3,
 													"outlettype" : [ "int", "bang", "bang" ],
-													"patching_rect" : [ 21.0, 116.0, 96.0, 22.0 ],
+													"patching_rect" : [ 21.0, 60.0, 96.0, 22.0 ],
 													"text" : "t i b b"
 												}
 
@@ -213,7 +245,7 @@
 													"numinlets" : 3,
 													"numoutlets" : 1,
 													"outlettype" : [ "" ],
-													"patching_rect" : [ 21.0, 227.0, 96.0, 22.0 ],
+													"patching_rect" : [ 21.0, 171.0, 96.0, 22.0 ],
 													"text" : "join 3"
 												}
 
@@ -225,7 +257,7 @@
 													"numinlets" : 1,
 													"numoutlets" : 1,
 													"outlettype" : [ "" ],
-													"patching_rect" : [ 229.5, 169.0, 168.0, 22.0 ],
+													"patching_rect" : [ 229.5, 113.0, 168.0, 22.0 ],
 													"text" : "expr random(-250\\, 250) / 100."
 												}
 
@@ -237,7 +269,7 @@
 													"numinlets" : 1,
 													"numoutlets" : 1,
 													"outlettype" : [ "" ],
-													"patching_rect" : [ 59.5, 169.0, 168.0, 22.0 ],
+													"patching_rect" : [ 59.5, 113.0, 168.0, 22.0 ],
 													"text" : "expr random(-250\\, 250) / 100."
 												}
 
@@ -263,7 +295,7 @@
 													"maxclass" : "outlet",
 													"numinlets" : 1,
 													"numoutlets" : 0,
-													"patching_rect" : [ 21.0, 358.0, 30.0, 30.0 ]
+													"patching_rect" : [ 21.0, 271.0, 30.0, 30.0 ]
 												}
 
 											}
@@ -271,6 +303,7 @@
 										"lines" : [ 											{
 												"patchline" : 												{
 													"destination" : [ "obj-87", 0 ],
+													"midpoints" : [ 30.5, 249.0, 30.5, 249.0 ],
 													"source" : [ "obj-1", 0 ]
 												}
 
@@ -285,7 +318,7 @@
 , 											{
 												"patchline" : 												{
 													"destination" : [ "obj-13", 2 ],
-													"midpoints" : [ 239.0, 213.0, 107.5, 213.0 ],
+													"midpoints" : [ 239.0, 157.0, 107.5, 157.0 ],
 													"source" : [ "obj-12", 0 ]
 												}
 
@@ -293,6 +326,7 @@
 , 											{
 												"patchline" : 												{
 													"destination" : [ "obj-1", 0 ],
+													"midpoints" : [ 30.5, 195.0, 30.5, 195.0 ],
 													"order" : 1,
 													"source" : [ "obj-13", 0 ]
 												}
@@ -301,6 +335,7 @@
 , 											{
 												"patchline" : 												{
 													"destination" : [ "obj-93", 0 ],
+													"midpoints" : [ 30.5, 213.0, 135.5, 213.0 ],
 													"order" : 0,
 													"source" : [ "obj-13", 0 ]
 												}
@@ -316,7 +351,7 @@
 , 											{
 												"patchline" : 												{
 													"destination" : [ "obj-12", 0 ],
-													"midpoints" : [ 107.5, 156.0, 239.0, 156.0 ],
+													"midpoints" : [ 107.5, 100.0, 239.0, 100.0 ],
 													"source" : [ "obj-57", 2 ]
 												}
 
@@ -324,7 +359,7 @@
 , 											{
 												"patchline" : 												{
 													"destination" : [ "obj-13", 0 ],
-													"midpoints" : [ 30.5, 141.0, 30.5, 141.0 ],
+													"midpoints" : [ 30.5, 85.0, 30.5, 85.0 ],
 													"source" : [ "obj-57", 0 ]
 												}
 
@@ -332,7 +367,6 @@
 , 											{
 												"patchline" : 												{
 													"destination" : [ "obj-57", 0 ],
-													"midpoints" : [ 30.5, 50.0, 30.5, 50.0 ],
 													"source" : [ "obj-86", 0 ]
 												}
 
@@ -340,6 +374,7 @@
 , 											{
 												"patchline" : 												{
 													"destination" : [ "obj-87", 0 ],
+													"midpoints" : [ 135.5, 258.0, 30.5, 258.0 ],
 													"source" : [ "obj-93", 0 ]
 												}
 
@@ -369,13 +404,13 @@
 												"name" : "max6message",
 												"default" : 												{
 													"bgfillcolor" : 													{
-														"type" : "gradient",
+														"angle" : 270.0,
+														"autogradient" : 0,
+														"color" : [ 0.290196, 0.309804, 0.301961, 1.0 ],
 														"color1" : [ 0.866667, 0.866667, 0.866667, 1.0 ],
 														"color2" : [ 0.788235, 0.788235, 0.788235, 1.0 ],
-														"color" : [ 0.290196, 0.309804, 0.301961, 1.0 ],
-														"angle" : 270.0,
 														"proportion" : 0.39,
-														"autogradient" : 0
+														"type" : "gradient"
 													}
 ,
 													"textcolor_inverse" : [ 0.0, 0.0, 0.0, 1.0 ]
@@ -396,7 +431,7 @@
  ]
 									}
 ,
-									"patching_rect" : [ 33.0, 205.0, 148.0, 22.0 ],
+									"patching_rect" : [ 81.0, 240.0, 159.0, 23.0 ],
 									"saved_object_attributes" : 									{
 										"description" : "",
 										"digest" : "",
@@ -410,36 +445,39 @@
 							}
 , 							{
 								"box" : 								{
+									"fontsize" : 13.0,
 									"id" : "obj-80",
 									"maxclass" : "newobj",
 									"numinlets" : 1,
-									"numoutlets" : 2,
-									"outlettype" : [ "bang", "clear" ],
-									"patching_rect" : [ 5.0, 135.0, 95.0, 22.0 ],
-									"text" : "t b clear"
+									"numoutlets" : 3,
+									"outlettype" : [ "bang", "clear", "bang" ],
+									"patching_rect" : [ 50.0, 150.0, 66.0, 23.0 ],
+									"text" : "t b clear b"
 								}
 
 							}
 , 							{
 								"box" : 								{
+									"fontsize" : 13.0,
 									"id" : "obj-19",
 									"maxclass" : "newobj",
 									"numinlets" : 2,
 									"numoutlets" : 3,
 									"outlettype" : [ "bang", "bang", "int" ],
-									"patching_rect" : [ 5.0, 169.0, 47.0, 22.0 ],
+									"patching_rect" : [ 50.0, 200.0, 50.0, 23.0 ],
 									"text" : "uzi 200"
 								}
 
 							}
 , 							{
 								"box" : 								{
+									"fontsize" : 13.0,
 									"id" : "obj-9",
 									"linecount" : 2,
 									"maxclass" : "comment",
 									"numinlets" : 1,
 									"numoutlets" : 0,
-									"patching_rect" : [ 591.0, 574.5, 251.0, 33.0 ],
+									"patching_rect" : [ 660.0, 623.5, 258.0, 36.0 ],
 									"text" : "The selected range is output from the right in response to drag + modifier events.",
 									"textcolor" : [ 0.501960784313725, 0.501960784313725, 0.501960784313725, 1.0 ]
 								}
@@ -447,59 +485,28 @@
 							}
 , 							{
 								"box" : 								{
+									"fontsize" : 13.0,
 									"id" : "obj-7",
 									"linecount" : 11,
 									"maxclass" : "comment",
 									"numinlets" : 1,
 									"numoutlets" : 0,
-									"patching_rect" : [ 361.0, 310.0, 255.0, 154.0 ],
-									"text" : "You can interactively control the range of the x and y areas using different keyboard modifiers while clicking and dragging.\n\nIf you (hold option / alt / winkey + drag) a box will be drawn over the canvas, showing which area of the plot you will \"zoom\" in on in.\n\nIf you (control + drag) it resets the x and y ranges to the last stored values received from a message (such as xrange [-3 3]).",
+									"patching_rect" : [ 409.0, 360.0, 275.0, 166.0 ],
+									"text" : "You can interactively control the range of the x and y areas using different keyboard modifiers while clicking and dragging.\n\nIf you (hold option / alt / winkey + drag) a box will be drawn over the canvas, showing which area of the plot you will \"zoom\" in on in.\n\nIf you (control + drag) it resets the x and y ranges to the last stored values received from a message (such as range [-5 5]).",
 									"textcolor" : [ 0.501960784313725, 0.501960784313725, 0.501960784313725, 1.0 ]
 								}
 
 							}
 , 							{
 								"box" : 								{
+									"fontsize" : 13.0,
 									"id" : "obj-5",
 									"maxclass" : "message",
 									"numinlets" : 2,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 336.0, 205.0, 63.0, 22.0 ],
+									"patching_rect" : [ 384.0, 236.0, 68.0, 23.0 ],
 									"text" : "range -5 5"
-								}
-
-							}
-, 							{
-								"box" : 								{
-									"bgcolor" : [ 1.0, 0.788235, 0.470588, 1.0 ],
-									"fontname" : "Arial Bold",
-									"hint" : "",
-									"id" : "obj-71",
-									"ignoreclick" : 1,
-									"legacytextcolor" : 1,
-									"maxclass" : "textbutton",
-									"numinlets" : 1,
-									"numoutlets" : 3,
-									"outlettype" : [ "", "", "int" ],
-									"parameter_enable" : 0,
-									"patching_rect" : [ 401.0, 205.0, 20.0, 20.0 ],
-									"rounded" : 60.0,
-									"text" : "2",
-									"textcolor" : [ 0.34902, 0.34902, 0.34902, 1.0 ]
-								}
-
-							}
-, 							{
-								"box" : 								{
-									"bubble" : 1,
-									"id" : "obj-72",
-									"linecount" : 4,
-									"maxclass" : "comment",
-									"numinlets" : 1,
-									"numoutlets" : 0,
-									"patching_rect" : [ 425.0, 183.0, 200.0, 64.0 ],
-									"text" : "Let's set the range to something that will capture the range of the dataset. It won't be perfect though!"
 								}
 
 							}
@@ -512,7 +519,7 @@
 									"numoutlets" : 2,
 									"outlettype" : [ "", "" ],
 									"parameter_enable" : 0,
-									"patching_rect" : [ 33.0, 240.0, 322.0, 322.0 ]
+									"patching_rect" : [ 81.0, 290.0, 322.0, 322.0 ]
 								}
 
 							}
@@ -520,6 +527,7 @@
 								"box" : 								{
 									"bgcolor" : [ 1.0, 0.788235, 0.470588, 1.0 ],
 									"fontname" : "Arial Bold",
+									"fontsize" : 13.0,
 									"hint" : "",
 									"id" : "obj-42",
 									"ignoreclick" : 1,
@@ -529,7 +537,7 @@
 									"numoutlets" : 3,
 									"outlettype" : [ "", "", "int" ],
 									"parameter_enable" : 0,
-									"patching_rect" : [ 35.0, 97.0, 20.0, 20.0 ],
+									"patching_rect" : [ 80.0, 112.0, 20.0, 20.0 ],
 									"rounded" : 60.0,
 									"text" : "1",
 									"textcolor" : [ 0.34902, 0.34902, 0.34902, 1.0 ]
@@ -539,11 +547,12 @@
 , 							{
 								"box" : 								{
 									"bubble" : 1,
+									"fontsize" : 13.0,
 									"id" : "obj-37",
 									"maxclass" : "comment",
 									"numinlets" : 1,
 									"numoutlets" : 0,
-									"patching_rect" : [ 57.0, 97.0, 337.0, 24.0 ],
+									"patching_rect" : [ 110.0, 107.0, 363.0, 25.0 ],
 									"text" : "Generate some random points with the advanced interface"
 								}
 
@@ -556,19 +565,7 @@
 									"numoutlets" : 1,
 									"outlettype" : [ "bang" ],
 									"parameter_enable" : 0,
-									"patching_rect" : [ 5.0, 95.0, 24.0, 24.0 ]
-								}
-
-							}
-, 							{
-								"box" : 								{
-									"fontsize" : 13.0,
-									"id" : "obj-6",
-									"maxclass" : "comment",
-									"numinlets" : 1,
-									"numoutlets" : 0,
-									"patching_rect" : [ 5.0, 61.0, 280.0, 21.0 ],
-									"text" : "An abstraction for plotting fluid.dataset~ data."
+									"patching_rect" : [ 50.0, 110.0, 24.0, 24.0 ]
 								}
 
 							}
@@ -584,7 +581,7 @@
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
 									"parameter_enable" : 0,
-									"patching_rect" : [ 5.0, 5.0, 334.0, 55.0 ]
+									"patching_rect" : [ 10.0, 10.0, 334.0, 55.0 ]
 								}
 
 							}
@@ -640,7 +637,24 @@
 							}
 , 							{
 								"patchline" : 								{
+									"destination" : [ "obj-5", 0 ],
+									"midpoints" : [ 106.5, 186.0, 393.5, 186.0 ],
+									"source" : [ "obj-80", 2 ]
+								}
+
+							}
+, 							{
+								"patchline" : 								{
 									"destination" : [ "obj-58", 0 ],
+									"midpoints" : [ 83.0, 186.0, 35.0, 186.0, 35.0, 276.0, 90.5, 276.0 ],
+									"source" : [ "obj-80", 1 ]
+								}
+
+							}
+, 							{
+								"patchline" : 								{
+									"destination" : [ "obj-58", 0 ],
+									"midpoints" : [ 90.5, 264.0, 90.5, 264.0 ],
 									"source" : [ "obj-88", 0 ]
 								}
 
@@ -670,13 +684,13 @@
 								"name" : "max6message",
 								"default" : 								{
 									"bgfillcolor" : 									{
-										"type" : "gradient",
+										"angle" : 270.0,
+										"autogradient" : 0,
+										"color" : [ 0.290196, 0.309804, 0.301961, 1.0 ],
 										"color1" : [ 0.866667, 0.866667, 0.866667, 1.0 ],
 										"color2" : [ 0.788235, 0.788235, 0.788235, 1.0 ],
-										"color" : [ 0.290196, 0.309804, 0.301961, 1.0 ],
-										"angle" : 270.0,
 										"proportion" : 0.39,
-										"autogradient" : 0
+										"type" : "gradient"
 									}
 ,
 									"textcolor_inverse" : [ 0.0, 0.0, 0.0, 1.0 ]
@@ -726,14 +740,14 @@
 						}
 ,
 						"classnamespace" : "box",
-						"rect" : [ 0.0, 26.0, 995.0, 751.0 ],
+						"rect" : [ 0.0, 26.0, 956.0, 753.0 ],
 						"bglocked" : 0,
 						"openinpresentation" : 0,
 						"default_fontsize" : 12.0,
 						"default_fontface" : 0,
 						"default_fontname" : "Arial",
 						"gridonopen" : 2,
-						"gridsize" : [ 5.0, 5.0 ],
+						"gridsize" : [ 10.0, 10.0 ],
 						"gridsnaponopen" : 2,
 						"objectsnaponopen" : 1,
 						"statusbarvisible" : 2,
@@ -757,8 +771,22 @@
 						"assistshowspatchername" : 0,
 						"boxes" : [ 							{
 								"box" : 								{
+									"fontsize" : 13.0,
+									"id" : "obj-6",
+									"maxclass" : "comment",
+									"numinlets" : 1,
+									"numoutlets" : 0,
+									"patching_rect" : [ 10.0, 67.0, 474.0, 21.0 ],
+									"text" : "Drawing through the \"advanced\" interface lets you be more draw at a lower level.",
+									"textcolor" : [ 0.501960784313725, 0.501960784313725, 0.501960784313725, 1.0 ]
+								}
+
+							}
+, 							{
+								"box" : 								{
 									"bgcolor" : [ 1.0, 0.788235, 0.470588, 1.0 ],
 									"fontname" : "Arial Bold",
+									"fontsize" : 13.0,
 									"hint" : "",
 									"id" : "obj-2",
 									"ignoreclick" : 1,
@@ -768,7 +796,7 @@
 									"numoutlets" : 3,
 									"outlettype" : [ "", "", "int" ],
 									"parameter_enable" : 0,
-									"patching_rect" : [ 35.0, 125.0, 20.0, 20.0 ],
+									"patching_rect" : [ 80.0, 135.0, 20.0, 20.0 ],
 									"rounded" : 60.0,
 									"text" : "1",
 									"textcolor" : [ 0.34902, 0.34902, 0.34902, 1.0 ]
@@ -777,30 +805,34 @@
 							}
 , 							{
 								"box" : 								{
+									"fontsize" : 13.0,
 									"id" : "obj-20",
 									"maxclass" : "message",
 									"numinlets" : 2,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 372.0, 400.0, 89.0, 22.0 ],
+									"patching_rect" : [ 451.0, 399.0, 96.0, 23.0 ],
 									"text" : "pointsize $1 $2"
 								}
 
 							}
 , 							{
 								"box" : 								{
+									"fontsize" : 13.0,
 									"id" : "obj-18",
-									"linecount" : 4,
+									"linecount" : 5,
 									"maxclass" : "comment",
 									"numinlets" : 1,
 									"numoutlets" : 0,
-									"patching_rect" : [ 385.0, 279.0, 153.0, 60.0 ],
-									"text" : "Set the size of each point.\nFormat is:\n<identifer>\n<size>"
+									"patching_rect" : [ 471.5, 276.0, 113.0, 79.0 ],
+									"text" : "Set the size of each point.\nFormat is:\n<identifer>\n<size>",
+									"textcolor" : [ 0.501960784313725, 0.501960784313725, 0.501960784313725, 1.0 ]
 								}
 
 							}
 , 							{
 								"box" : 								{
+									"fontsize" : 13.0,
 									"id" : "obj-17",
 									"maxclass" : "newobj",
 									"numinlets" : 1,
@@ -957,7 +989,7 @@
  ]
 									}
 ,
-									"patching_rect" : [ 372.0, 365.0, 143.0, 22.0 ],
+									"patching_rect" : [ 451.0, 364.0, 154.0, 23.0 ],
 									"saved_object_attributes" : 									{
 										"description" : "",
 										"digest" : "",
@@ -971,30 +1003,35 @@
 							}
 , 							{
 								"box" : 								{
+									"fontsize" : 13.0,
 									"id" : "obj-44",
 									"linecount" : 4,
 									"maxclass" : "comment",
 									"numinlets" : 1,
 									"numoutlets" : 0,
-									"patching_rect" : [ 215.0, 279.0, 153.0, 60.0 ],
-									"text" : "Set the pointcolor of each point. Format is:\n<identifier>\n<r><g><b><a>"
+									"patching_rect" : [ 297.0, 283.0, 138.0, 65.0 ],
+									"text" : "Set the pointcolor of each point. Format is:\n<identifier>\n<r><g><b><a>",
+									"textcolor" : [ 0.501960784313725, 0.501960784313725, 0.501960784313725, 1.0 ]
 								}
 
 							}
 , 							{
 								"box" : 								{
+									"fontsize" : 13.0,
 									"id" : "obj-43",
 									"linecount" : 5,
 									"maxclass" : "comment",
 									"numinlets" : 1,
 									"numoutlets" : 0,
-									"patching_rect" : [ 40.0, 279.0, 153.0, 74.0 ],
-									"text" : "You don't need a fluid.dataset~ necessarily. Using the setpoint message you can create a plot point by point."
+									"patching_rect" : [ 97.0, 283.0, 161.0, 79.0 ],
+									"text" : "You don't need a fluid.dataset~ necessarily. Using the setpoint message you can create a plot point by point.",
+									"textcolor" : [ 0.501960784313725, 0.501960784313725, 0.501960784313725, 1.0 ]
 								}
 
 							}
 , 							{
 								"box" : 								{
+									"fontsize" : 13.0,
 									"id" : "obj-35",
 									"maxclass" : "newobj",
 									"numinlets" : 0,
@@ -1316,7 +1353,7 @@
  ]
 									}
 ,
-									"patching_rect" : [ 649.0, 244.0, 45.0, 22.0 ],
+									"patching_rect" : [ 674.0, 248.0, 48.0, 23.0 ],
 									"saved_object_attributes" : 									{
 										"description" : "",
 										"digest" : "",
@@ -1335,7 +1372,7 @@
 									"numinlets" : 1,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 540.0, 400.0, 29.0, 22.0 ],
+									"patching_rect" : [ 630.0, 399.0, 29.0, 22.0 ],
 									"text" : "thru"
 								}
 
@@ -1343,11 +1380,12 @@
 , 							{
 								"box" : 								{
 									"bubble" : 1,
+									"fontsize" : 13.0,
 									"id" : "obj-105",
 									"maxclass" : "comment",
 									"numinlets" : 1,
 									"numoutlets" : 0,
-									"patching_rect" : [ 60.0, 125.0, 198.0, 24.0 ],
+									"patching_rect" : [ 102.0, 133.0, 213.0, 25.0 ],
 									"text" : "generate a random set of points."
 								}
 
@@ -1360,59 +1398,68 @@
 									"numoutlets" : 1,
 									"outlettype" : [ "bang" ],
 									"parameter_enable" : 0,
-									"patching_rect" : [ 5.0, 123.0, 24.0, 24.0 ]
+									"patching_rect" : [ 50.0, 133.0, 24.0, 24.0 ]
 								}
 
 							}
 , 							{
 								"box" : 								{
+									"fontsize" : 13.0,
 									"id" : "obj-101",
 									"maxclass" : "newobj",
 									"numinlets" : 1,
 									"numoutlets" : 1,
 									"outlettype" : [ "bang" ],
-									"patching_rect" : [ 5.0, 90.0, 58.0, 22.0 ],
+									"patching_rect" : [ 50.0, 100.0, 62.0, 23.0 ],
 									"text" : "loadbang"
 								}
 
 							}
 , 							{
 								"box" : 								{
+									"fontsize" : 13.0,
 									"id" : "obj-100",
 									"linecount" : 2,
 									"maxclass" : "comment",
 									"numinlets" : 1,
 									"numoutlets" : 0,
-									"patching_rect" : [ 703.0, 153.5, 184.0, 33.0 ],
-									"text" : "Change the overall point size scale"
+									"patching_rect" : [ 728.0, 157.5, 131.0, 36.0 ],
+									"text" : "Change the overall point size scale",
+									"textcolor" : [ 0.501960784313725, 0.501960784313725, 0.501960784313725, 1.0 ]
 								}
 
 							}
 , 							{
 								"box" : 								{
+									"fontsize" : 13.0,
 									"id" : "obj-99",
 									"linecount" : 2,
 									"maxclass" : "comment",
 									"numinlets" : 1,
 									"numoutlets" : 0,
-									"patching_rect" : [ 735.0, 94.0, 184.0, 33.0 ],
-									"text" : "Change the shape of the points as they're drawn."
+									"patching_rect" : [ 760.0, 98.0, 160.0, 36.0 ],
+									"text" : "Change the shape of the points as they're drawn.",
+									"textcolor" : [ 0.501960784313725, 0.501960784313725, 0.501960784313725, 1.0 ]
 								}
 
 							}
 , 							{
 								"box" : 								{
+									"fontsize" : 13.0,
 									"id" : "obj-97",
+									"linecount" : 2,
 									"maxclass" : "comment",
 									"numinlets" : 1,
 									"numoutlets" : 0,
-									"patching_rect" : [ 780.0, 304.0, 184.0, 20.0 ],
-									"text" : "Change the background colour"
+									"patching_rect" : [ 805.0, 308.0, 124.0, 36.0 ],
+									"text" : "Change the background colour",
+									"textcolor" : [ 0.501960784313725, 0.501960784313725, 0.501960784313725, 1.0 ]
 								}
 
 							}
 , 							{
 								"box" : 								{
+									"fontsize" : 13.0,
 									"id" : "obj-95",
 									"maxclass" : "newobj",
 									"numinlets" : 1,
@@ -1616,7 +1663,7 @@
  ]
 									}
 ,
-									"patching_rect" : [ 199.5, 365.0, 148.0, 22.0 ],
+									"patching_rect" : [ 266.0, 364.0, 159.0, 23.0 ],
 									"saved_object_attributes" : 									{
 										"description" : "",
 										"digest" : "",
@@ -1630,30 +1677,33 @@
 							}
 , 							{
 								"box" : 								{
+									"fontsize" : 13.0,
 									"id" : "obj-93",
 									"maxclass" : "message",
 									"numinlets" : 2,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 199.5, 400.0, 141.0, 22.0 ],
+									"patching_rect" : [ 266.0, 399.0, 152.0, 23.0 ],
 									"text" : "pointcolor $1 $2 $3 $4 1."
 								}
 
 							}
 , 							{
 								"box" : 								{
+									"fontsize" : 13.0,
 									"id" : "obj-89",
 									"maxclass" : "newobj",
 									"numinlets" : 1,
 									"numoutlets" : 3,
 									"outlettype" : [ "int", "int", "int" ],
-									"patching_rect" : [ 27.0, 246.0, 364.0, 22.0 ],
+									"patching_rect" : [ 81.0, 245.0, 389.0, 23.0 ],
 									"text" : "t i i i"
 								}
 
 							}
 , 							{
 								"box" : 								{
+									"fontsize" : 13.0,
 									"id" : "obj-88",
 									"maxclass" : "newobj",
 									"numinlets" : 1,
@@ -1852,7 +1902,7 @@
  ]
 									}
 ,
-									"patching_rect" : [ 27.0, 365.0, 148.0, 22.0 ],
+									"patching_rect" : [ 81.0, 364.0, 159.0, 23.0 ],
 									"saved_object_attributes" : 									{
 										"description" : "",
 										"digest" : "",
@@ -1866,42 +1916,46 @@
 							}
 , 							{
 								"box" : 								{
+									"fontsize" : 13.0,
 									"id" : "obj-80",
 									"maxclass" : "newobj",
 									"numinlets" : 1,
 									"numoutlets" : 2,
 									"outlettype" : [ "bang", "clear" ],
-									"patching_rect" : [ 5.0, 161.0, 95.0, 22.0 ],
+									"patching_rect" : [ 50.0, 171.0, 103.0, 23.0 ],
 									"text" : "t b clear"
 								}
 
 							}
 , 							{
 								"box" : 								{
+									"fontsize" : 13.0,
 									"id" : "obj-51",
 									"maxclass" : "message",
 									"numinlets" : 2,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 649.0, 117.0, 73.0, 22.0 ],
+									"patching_rect" : [ 674.0, 121.0, 78.0, 23.0 ],
 									"text" : "shape circle"
 								}
 
 							}
 , 							{
 								"box" : 								{
+									"fontsize" : 13.0,
 									"id" : "obj-50",
 									"maxclass" : "message",
 									"numinlets" : 2,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 649.0, 80.0, 81.0, 22.0 ],
+									"patching_rect" : [ 674.0, 84.0, 87.0, 23.0 ],
 									"text" : "shape square"
 								}
 
 							}
 , 							{
 								"box" : 								{
+									"fontsize" : 13.0,
 									"format" : 6,
 									"id" : "obj-48",
 									"maxclass" : "flonum",
@@ -1909,30 +1963,32 @@
 									"numoutlets" : 2,
 									"outlettype" : [ "", "bang" ],
 									"parameter_enable" : 0,
-									"patching_rect" : [ 649.0, 159.0, 50.0, 22.0 ]
+									"patching_rect" : [ 674.0, 163.0, 50.0, 23.0 ]
 								}
 
 							}
 , 							{
 								"box" : 								{
+									"fontsize" : 13.0,
 									"id" : "obj-46",
 									"maxclass" : "message",
 									"numinlets" : 2,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 649.0, 195.0, 101.0, 22.0 ],
+									"patching_rect" : [ 674.0, 199.0, 108.0, 23.0 ],
 									"text" : "pointsizescale $1"
 								}
 
 							}
 , 							{
 								"box" : 								{
+									"fontsize" : 13.0,
 									"id" : "obj-31",
 									"maxclass" : "newobj",
 									"numinlets" : 1,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 649.0, 358.0, 95.0, 22.0 ],
+									"patching_rect" : [ 674.0, 362.0, 102.0, 23.0 ],
 									"text" : "prepend bgcolor"
 								}
 
@@ -1945,31 +2001,33 @@
 									"numoutlets" : 2,
 									"outlettype" : [ "", "float" ],
 									"parameter_enable" : 0,
-									"patching_rect" : [ 649.0, 279.0, 125.0, 70.0 ],
-									"saturation" : 0.611764705882353
+									"patching_rect" : [ 674.0, 283.0, 125.0, 70.0 ],
+									"saturation" : 0.137254901960784
 								}
 
 							}
 , 							{
 								"box" : 								{
+									"fontsize" : 13.0,
 									"id" : "obj-19",
 									"maxclass" : "newobj",
 									"numinlets" : 2,
 									"numoutlets" : 3,
 									"outlettype" : [ "bang", "bang", "int" ],
-									"patching_rect" : [ 5.0, 195.0, 41.0, 22.0 ],
-									"text" : "uzi 20"
+									"patching_rect" : [ 50.0, 205.0, 50.0, 23.0 ],
+									"text" : "uzi 200"
 								}
 
 							}
 , 							{
 								"box" : 								{
+									"fontsize" : 13.0,
 									"id" : "obj-7",
 									"maxclass" : "message",
 									"numinlets" : 2,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 27.0, 400.0, 101.0, 22.0 ],
+									"patching_rect" : [ 81.0, 399.0, 108.0, 23.0 ],
 									"text" : "setpoint $1 $2 $3"
 								}
 
@@ -1983,19 +2041,7 @@
 									"numoutlets" : 2,
 									"outlettype" : [ "", "" ],
 									"parameter_enable" : 0,
-									"patching_rect" : [ 5.0, 460.0, 281.0, 281.0 ]
-								}
-
-							}
-, 							{
-								"box" : 								{
-									"fontsize" : 13.0,
-									"id" : "obj-6",
-									"maxclass" : "comment",
-									"numinlets" : 1,
-									"numoutlets" : 0,
-									"patching_rect" : [ 5.0, 61.0, 239.0, 21.0 ],
-									"text" : "An abstraction for plotting fluid.dataset~"
+									"patching_rect" : [ 50.0, 455.0, 281.0, 281.0 ]
 								}
 
 							}
@@ -2011,7 +2057,7 @@
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
 									"parameter_enable" : 0,
-									"patching_rect" : [ 5.0, 5.0, 334.0, 55.0 ]
+									"patching_rect" : [ 10.0, 10.0, 334.0, 55.0 ]
 								}
 
 							}
@@ -2027,7 +2073,7 @@
 									"mode" : 0,
 									"numinlets" : 1,
 									"numoutlets" : 0,
-									"patching_rect" : [ 640.0, 70.0, 330.0, 325.0 ],
+									"patching_rect" : [ 665.0, 74.0, 285.0, 325.0 ],
 									"proportion" : 0.5
 								}
 
@@ -2057,7 +2103,6 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-89", 0 ],
-									"midpoints" : [ 36.5, 226.0, 36.5, 226.0 ],
 									"source" : [ "obj-19", 2 ]
 								}
 
@@ -2065,7 +2110,7 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-1", 0 ],
-									"midpoints" : [ 381.5, 447.0, 14.5, 447.0 ],
+									"midpoints" : [ 460.5, 440.0, 59.5, 440.0 ],
 									"source" : [ "obj-20", 0 ]
 								}
 
@@ -2080,7 +2125,7 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-4", 0 ],
-									"midpoints" : [ 658.5, 381.0, 549.5, 381.0 ],
+									"midpoints" : [ 683.5, 380.0, 639.5, 380.0 ],
 									"source" : [ "obj-31", 0 ]
 								}
 
@@ -2095,7 +2140,7 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-1", 0 ],
-									"midpoints" : [ 549.5, 447.0, 14.5, 447.0 ],
+									"midpoints" : [ 639.5, 440.0, 59.5, 440.0 ],
 									"source" : [ "obj-4", 0 ]
 								}
 
@@ -2103,7 +2148,7 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-4", 0 ],
-									"midpoints" : [ 658.5, 231.0, 549.5, 231.0 ],
+									"midpoints" : [ 683.5, 230.0, 639.5, 230.0 ],
 									"source" : [ "obj-46", 0 ]
 								}
 
@@ -2118,7 +2163,7 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-4", 0 ],
-									"midpoints" : [ 658.5, 105.0, 549.5, 105.0 ],
+									"midpoints" : [ 683.5, 104.0, 639.5, 104.0 ],
 									"source" : [ "obj-50", 0 ]
 								}
 
@@ -2126,7 +2171,7 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-4", 0 ],
-									"midpoints" : [ 658.5, 141.0, 549.5, 141.0 ],
+									"midpoints" : [ 683.5, 140.0, 639.5, 140.0 ],
 									"source" : [ "obj-51", 0 ]
 								}
 
@@ -2134,7 +2179,7 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-1", 0 ],
-									"midpoints" : [ 36.5, 447.0, 14.5, 447.0 ],
+									"midpoints" : [ 90.5, 440.0, 59.5, 440.0 ],
 									"source" : [ "obj-7", 0 ]
 								}
 
@@ -2142,7 +2187,7 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-1", 0 ],
-									"midpoints" : [ 90.5, 231.0, 14.5, 231.0 ],
+									"midpoints" : [ 143.5, 235.0, 61.0, 235.0, 61.0, 449.0, 59.5, 449.0 ],
 									"source" : [ "obj-80", 1 ]
 								}
 
@@ -2157,7 +2202,7 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-7", 0 ],
-									"midpoints" : [ 36.5, 390.0, 36.5, 390.0 ],
+									"midpoints" : [ 90.5, 389.0, 90.5, 389.0 ],
 									"source" : [ "obj-88", 0 ]
 								}
 
@@ -2172,7 +2217,7 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-88", 0 ],
-									"midpoints" : [ 36.5, 270.0, 36.5, 270.0 ],
+									"midpoints" : [ 90.5, 269.0, 90.5, 269.0 ],
 									"source" : [ "obj-89", 0 ]
 								}
 
@@ -2187,7 +2232,7 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-1", 0 ],
-									"midpoints" : [ 209.0, 447.0, 14.5, 447.0 ],
+									"midpoints" : [ 275.5, 440.0, 59.5, 440.0 ],
 									"source" : [ "obj-93", 0 ]
 								}
 
@@ -2224,13 +2269,13 @@
 								"name" : "max6message",
 								"default" : 								{
 									"bgfillcolor" : 									{
-										"type" : "gradient",
+										"angle" : 270.0,
+										"autogradient" : 0,
+										"color" : [ 0.290196, 0.309804, 0.301961, 1.0 ],
 										"color1" : [ 0.866667, 0.866667, 0.866667, 1.0 ],
 										"color2" : [ 0.788235, 0.788235, 0.788235, 1.0 ],
-										"color" : [ 0.290196, 0.309804, 0.301961, 1.0 ],
-										"angle" : 270.0,
 										"proportion" : 0.39,
-										"autogradient" : 0
+										"type" : "gradient"
 									}
 ,
 									"textcolor_inverse" : [ 0.0, 0.0, 0.0, 1.0 ]
@@ -2281,14 +2326,14 @@
 						}
 ,
 						"classnamespace" : "box",
-						"rect" : [ 0.0, 26.0, 995.0, 751.0 ],
+						"rect" : [ 0.0, 26.0, 956.0, 753.0 ],
 						"bglocked" : 0,
 						"openinpresentation" : 0,
 						"default_fontsize" : 12.0,
 						"default_fontface" : 0,
 						"default_fontname" : "Arial",
 						"gridonopen" : 2,
-						"gridsize" : [ 5.0, 5.0 ],
+						"gridsize" : [ 10.0, 10.0 ],
 						"gridsnaponopen" : 2,
 						"objectsnaponopen" : 1,
 						"statusbarvisible" : 2,
@@ -2312,93 +2357,78 @@
 						"assistshowspatchername" : 0,
 						"boxes" : [ 							{
 								"box" : 								{
+									"fontsize" : 13.0,
 									"id" : "obj-4",
 									"maxclass" : "newobj",
 									"numinlets" : 2,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 354.25, 327.5, 41.0, 22.0 ],
+									"patching_rect" : [ 370.5, 292.5, 44.0, 23.0 ],
 									"text" : "pak f f"
 								}
 
 							}
 , 							{
 								"box" : 								{
+									"fontsize" : 13.0,
 									"id" : "obj-1",
 									"maxclass" : "newobj",
 									"numinlets" : 2,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 180.25, 327.5, 41.0, 22.0 ],
+									"patching_rect" : [ 235.25, 292.5, 44.0, 23.0 ],
 									"text" : "pak f f"
 								}
 
 							}
 , 							{
 								"box" : 								{
-									"bgcolor" : [ 1.0, 0.015686274509804, 0.015686274509804, 1.0 ],
-									"fontname" : "Arial Bold",
-									"fontsize" : 40.0,
-									"hint" : "",
-									"id" : "obj-57",
-									"ignoreclick" : 1,
-									"legacytextcolor" : 1,
-									"maxclass" : "textbutton",
-									"numinlets" : 1,
-									"numoutlets" : 3,
-									"outlettype" : [ "", "", "int" ],
-									"parameter_enable" : 0,
-									"patching_rect" : [ 350.0, 145.0, 68.0, 44.0 ],
-									"rounded" : 60.0,
-									"text" : "!!!",
-									"textcolor" : [ 1.0, 0.968627450980392, 0.0, 1.0 ]
-								}
-
-							}
-, 							{
-								"box" : 								{
+									"fontsize" : 13.0,
 									"id" : "obj-28",
 									"maxclass" : "message",
 									"numinlets" : 2,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 409.25, 238.902831999999989, 29.5, 22.0 ],
+									"patching_rect" : [ 425.5, 203.902831999999989, 31.0, 23.0 ],
 									"text" : "600"
 								}
 
 							}
 , 							{
 								"box" : 								{
+									"fontsize" : 13.0,
 									"id" : "obj-26",
 									"maxclass" : "message",
 									"numinlets" : 2,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 354.25, 238.902831999999989, 29.5, 22.0 ],
+									"patching_rect" : [ 370.5, 203.902831999999989, 31.0, 23.0 ],
 									"text" : "40"
 								}
 
 							}
 , 							{
 								"box" : 								{
+									"fontsize" : 13.0,
 									"id" : "obj-25",
 									"maxclass" : "message",
 									"numinlets" : 2,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 270.5, 238.902831999999989, 42.0, 22.0 ],
+									"patching_rect" : [ 300.0, 203.902831999999989, 45.0, 23.0 ],
 									"text" : "10000"
 								}
 
 							}
 , 							{
 								"box" : 								{
+									"fontsize" : 13.0,
 									"id" : "obj-24",
 									"maxclass" : "message",
 									"numinlets" : 2,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 180.25, 238.902831999999989, 29.5, 22.0 ],
+									"patching_rect" : [ 235.25, 203.902831999999989, 32.0, 23.0 ],
 									"text" : "0"
 								}
 
@@ -2407,6 +2437,7 @@
 								"box" : 								{
 									"bgcolor" : [ 1.0, 0.788235, 0.470588, 1.0 ],
 									"fontname" : "Arial Bold",
+									"fontsize" : 13.0,
 									"hint" : "",
 									"id" : "obj-11",
 									"ignoreclick" : 1,
@@ -2416,7 +2447,7 @@
 									"numoutlets" : 3,
 									"outlettype" : [ "", "", "int" ],
 									"parameter_enable" : 0,
-									"patching_rect" : [ 442.5, 238.902831999999989, 20.0, 20.0 ],
+									"patching_rect" : [ 458.75, 203.902831999999989, 20.0, 20.0 ],
 									"rounded" : 60.0,
 									"text" : "3",
 									"textcolor" : [ 0.34902, 0.34902, 0.34902, 1.0 ]
@@ -2426,12 +2457,13 @@
 , 							{
 								"box" : 								{
 									"bubble" : 1,
+									"fontsize" : 13.0,
 									"id" : "obj-13",
-									"linecount" : 3,
+									"linecount" : 4,
 									"maxclass" : "comment",
 									"numinlets" : 1,
 									"numoutlets" : 0,
-									"patching_rect" : [ 465.0, 223.402831999999989, 448.0, 51.0 ],
+									"patching_rect" : [ 490.25, 179.402831999999989, 375.0, 69.0 ],
 									"text" : "Click these messages to start adjusting the range to the minimum and maximum of the original data. You will see that the data is now visible in the space. Wiggle the number boxes to see how it affects the display of points."
 								}
 
@@ -2440,6 +2472,7 @@
 								"box" : 								{
 									"bgcolor" : [ 1.0, 0.788235, 0.470588, 1.0 ],
 									"fontname" : "Arial Bold",
+									"fontsize" : 13.0,
 									"hint" : "",
 									"id" : "obj-7",
 									"ignoreclick" : 1,
@@ -2449,7 +2482,7 @@
 									"numoutlets" : 3,
 									"outlettype" : [ "", "", "int" ],
 									"parameter_enable" : 0,
-									"patching_rect" : [ 420.0, 157.0, 20.0, 20.0 ],
+									"patching_rect" : [ 389.25, 532.5, 20.0, 20.0 ],
 									"rounded" : 60.0,
 									"text" : "2",
 									"textcolor" : [ 0.34902, 0.34902, 0.34902, 1.0 ]
@@ -2458,31 +2491,35 @@
 							}
 , 							{
 								"box" : 								{
-									"bubble" : 1,
+									"fontsize" : 13.0,
 									"id" : "obj-8",
-									"linecount" : 3,
+									"linecount" : 2,
 									"maxclass" : "comment",
 									"numinlets" : 1,
 									"numoutlets" : 0,
-									"patching_rect" : [ 447.0, 141.5, 315.0, 51.0 ],
-									"text" : "You'll notice that there is nothing in the plotter. By default it is displaying the 0 to 1 range in both dimensions."
+									"patching_rect" : [ 411.25, 524.5, 339.0, 36.0 ],
+									"text" : "You'll notice that there is nothing in the plotter. By default it is displaying the 0 to 1 range in both dimensions.",
+									"textcolor" : [ 0.501960784313725, 0.501960784313725, 0.501960784313725, 1.0 ]
 								}
 
 							}
 , 							{
 								"box" : 								{
+									"fontsize" : 13.0,
 									"id" : "obj-2",
 									"linecount" : 2,
 									"maxclass" : "comment",
 									"numinlets" : 1,
 									"numoutlets" : 0,
-									"patching_rect" : [ 5.0, 84.0, 680.0, 33.0 ],
-									"text" : "By default, the range of the fluid.plotter is between 0 and 1 for both the X and Y axis. You can modify the displayed range of the plotter with two messages, xrange and yrange. Each message accepts two values, the minimum and maximum for each."
+									"patching_rect" : [ 10.0, 67.0, 736.0, 36.0 ],
+									"text" : "By default, the range of the fluid.plotter is between 0 and 1 for both the X and Y axis. You can modify the displayed range of the plotter with two messages, xrange and yrange. Each message accepts two values, the minimum and maximum for each.",
+									"textcolor" : [ 0.501960784313725, 0.501960784313725, 0.501960784313725, 1.0 ]
 								}
 
 							}
 , 							{
 								"box" : 								{
+									"fontsize" : 13.0,
 									"format" : 6,
 									"id" : "obj-19",
 									"maxclass" : "flonum",
@@ -2490,12 +2527,13 @@
 									"numoutlets" : 2,
 									"outlettype" : [ "", "bang" ],
 									"parameter_enable" : 0,
-									"patching_rect" : [ 409.25, 280.0, 53.5, 22.0 ]
+									"patching_rect" : [ 425.5, 245.0, 54.0, 23.0 ]
 								}
 
 							}
 , 							{
 								"box" : 								{
+									"fontsize" : 13.0,
 									"format" : 6,
 									"id" : "obj-20",
 									"maxclass" : "flonum",
@@ -2503,36 +2541,39 @@
 									"numoutlets" : 2,
 									"outlettype" : [ "", "bang" ],
 									"parameter_enable" : 0,
-									"patching_rect" : [ 354.25, 280.0, 50.0, 22.0 ]
+									"patching_rect" : [ 370.5, 245.0, 50.0, 23.0 ]
 								}
 
 							}
 , 							{
 								"box" : 								{
+									"fontsize" : 13.0,
 									"id" : "obj-18",
 									"maxclass" : "message",
 									"numinlets" : 2,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 353.75, 367.305664031249989, 79.0, 22.0 ],
+									"patching_rect" : [ 370.0, 332.305664031249989, 84.0, 23.0 ],
 									"text" : "yrange $1 $2"
 								}
 
 							}
 , 							{
 								"box" : 								{
+									"fontsize" : 13.0,
 									"id" : "obj-17",
 									"maxclass" : "message",
 									"numinlets" : 2,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 180.25, 367.305664031249989, 79.0, 22.0 ],
+									"patching_rect" : [ 235.25, 332.305664031249989, 84.0, 23.0 ],
 									"text" : "xrange $1 $2"
 								}
 
 							}
 , 							{
 								"box" : 								{
+									"fontsize" : 13.0,
 									"format" : 6,
 									"id" : "obj-12",
 									"maxclass" : "flonum",
@@ -2540,12 +2581,13 @@
 									"numoutlets" : 2,
 									"outlettype" : [ "", "bang" ],
 									"parameter_enable" : 0,
-									"patching_rect" : [ 270.5, 280.0, 79.5, 22.0 ]
+									"patching_rect" : [ 300.0, 245.0, 59.5, 23.0 ]
 								}
 
 							}
 , 							{
 								"box" : 								{
+									"fontsize" : 13.0,
 									"format" : 6,
 									"id" : "obj-9",
 									"maxclass" : "flonum",
@@ -2553,7 +2595,7 @@
 									"numoutlets" : 2,
 									"outlettype" : [ "", "bang" ],
 									"parameter_enable" : 0,
-									"patching_rect" : [ 180.25, 280.0, 79.5, 22.0 ]
+									"patching_rect" : [ 235.25, 245.0, 54.75, 23.0 ]
 								}
 
 							}
@@ -2561,6 +2603,7 @@
 								"box" : 								{
 									"bgcolor" : [ 1.0, 0.788235, 0.470588, 1.0 ],
 									"fontname" : "Arial Bold",
+									"fontsize" : 13.0,
 									"hint" : "",
 									"id" : "obj-50",
 									"ignoreclick" : 1,
@@ -2570,7 +2613,7 @@
 									"numoutlets" : 3,
 									"outlettype" : [ "", "", "int" ],
 									"parameter_enable" : 0,
-									"patching_rect" : [ 30.0, 157.0, 20.0, 20.0 ],
+									"patching_rect" : [ 85.0, 147.0, 20.0, 20.0 ],
 									"rounded" : 60.0,
 									"text" : "1",
 									"textcolor" : [ 0.34902, 0.34902, 0.34902, 1.0 ]
@@ -2580,12 +2623,13 @@
 , 							{
 								"box" : 								{
 									"bubble" : 1,
+									"fontsize" : 13.0,
 									"id" : "obj-48",
 									"linecount" : 4,
 									"maxclass" : "comment",
 									"numinlets" : 1,
 									"numoutlets" : 0,
-									"patching_rect" : [ 56.25, 135.0, 289.0, 64.0 ],
+									"patching_rect" : [ 111.25, 125.0, 298.0, 69.0 ],
 									"text" : "Generate random data between a range that is not normal. In this case the horizontal values range between 0 and 10000, and the vertical values range between 40 and 600."
 								}
 
@@ -2599,7 +2643,7 @@
 									"numoutlets" : 2,
 									"outlettype" : [ "", "" ],
 									"parameter_enable" : 0,
-									"patching_rect" : [ 5.0, 415.0, 325.0, 325.0 ]
+									"patching_rect" : [ 60.0, 380.0, 325.0, 325.0 ]
 								}
 
 							}
@@ -2611,12 +2655,13 @@
 									"numoutlets" : 1,
 									"outlettype" : [ "bang" ],
 									"parameter_enable" : 0,
-									"patching_rect" : [ 5.0, 155.0, 24.0, 24.0 ]
+									"patching_rect" : [ 60.0, 145.0, 24.0, 24.0 ]
 								}
 
 							}
 , 							{
 								"box" : 								{
+									"fontsize" : 13.0,
 									"id" : "obj-5",
 									"maxclass" : "newobj",
 									"numinlets" : 1,
@@ -2690,8 +2735,8 @@
 													"id" : "obj-63",
 													"maxclass" : "newobj",
 													"numinlets" : 1,
-													"numoutlets" : 3,
-													"outlettype" : [ "bang", "float", "" ],
+													"numoutlets" : 2,
+													"outlettype" : [ "", "" ],
 													"patching_rect" : [ 49.5, 425.90283203125, 132.0, 22.0 ],
 													"text" : "fluid.dataset~ plotting.3"
 												}
@@ -2702,8 +2747,8 @@
 													"id" : "obj-17",
 													"maxclass" : "newobj",
 													"numinlets" : 1,
-													"numoutlets" : 3,
-													"outlettype" : [ "bang", "float", "" ],
+													"numoutlets" : 2,
+													"outlettype" : [ "", "" ],
 													"patching_rect" : [ 49.5, 349.90283203125, 132.0, 22.0 ],
 													"text" : "fluid.dataset~ plotting.3"
 												}
@@ -2810,8 +2855,8 @@
 													"id" : "obj-54",
 													"maxclass" : "newobj",
 													"numinlets" : 1,
-													"numoutlets" : 3,
-													"outlettype" : [ "bang", "float", "" ],
+													"numoutlets" : 2,
+													"outlettype" : [ "", "" ],
 													"patching_rect" : [ 134.5, 93.90283203125, 132.0, 22.0 ],
 													"text" : "fluid.dataset~ plotting.3"
 												}
@@ -2892,14 +2937,6 @@
 											}
 , 											{
 												"patchline" : 												{
-													"destination" : [ "obj-68", 0 ],
-													"midpoints" : [ 172.0, 386.0, 59.0, 386.0 ],
-													"source" : [ "obj-17", 2 ]
-												}
-
-											}
-, 											{
-												"patchline" : 												{
 													"destination" : [ "obj-52", 0 ],
 													"source" : [ "obj-2", 0 ]
 												}
@@ -2963,13 +3000,6 @@
 											}
 , 											{
 												"patchline" : 												{
-													"destination" : [ "obj-62", 0 ],
-													"source" : [ "obj-63", 2 ]
-												}
-
-											}
-, 											{
-												"patchline" : 												{
 													"destination" : [ "obj-63", 0 ],
 													"source" : [ "obj-68", 0 ]
 												}
@@ -3006,7 +3036,7 @@
  ]
 									}
 ,
-									"patching_rect" : [ 5.0, 280.0, 145.0, 22.0 ],
+									"patching_rect" : [ 60.0, 245.0, 156.0, 23.0 ],
 									"saved_object_attributes" : 									{
 										"description" : "",
 										"digest" : "",
@@ -3015,18 +3045,6 @@
 									}
 ,
 									"text" : "p \"generate random data\""
-								}
-
-							}
-, 							{
-								"box" : 								{
-									"fontsize" : 13.0,
-									"id" : "obj-6",
-									"maxclass" : "comment",
-									"numinlets" : 1,
-									"numoutlets" : 0,
-									"patching_rect" : [ 5.0, 61.0, 239.0, 21.0 ],
-									"text" : "An abstraction for plotting fluid.dataset~"
 								}
 
 							}
@@ -3042,7 +3060,7 @@
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
 									"parameter_enable" : 0,
-									"patching_rect" : [ 5.0, 5.0, 334.0, 55.0 ]
+									"patching_rect" : [ 10.0, 10.0, 334.0, 55.0 ]
 								}
 
 							}
@@ -3057,6 +3075,7 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-5", 0 ],
+									"midpoints" : [ 69.5, 171.0, 69.5, 171.0 ],
 									"source" : [ "obj-10", 0 ]
 								}
 
@@ -3064,7 +3083,7 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-1", 1 ],
-									"midpoints" : [ 280.0, 313.5, 211.75, 313.5 ],
+									"midpoints" : [ 309.5, 278.5, 269.75, 278.5 ],
 									"source" : [ "obj-12", 0 ]
 								}
 
@@ -3072,7 +3091,7 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-36", 0 ],
-									"midpoints" : [ 189.75, 402.0, 14.5, 402.0 ],
+									"midpoints" : [ 244.75, 367.0, 69.5, 367.0 ],
 									"source" : [ "obj-17", 0 ]
 								}
 
@@ -3080,7 +3099,7 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-36", 0 ],
-									"midpoints" : [ 363.25, 402.0, 14.5, 402.0 ],
+									"midpoints" : [ 379.5, 367.0, 69.5, 367.0 ],
 									"source" : [ "obj-18", 0 ]
 								}
 
@@ -3088,7 +3107,7 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-4", 1 ],
-									"midpoints" : [ 418.75, 313.5, 385.75, 313.5 ],
+									"midpoints" : [ 435.0, 278.5, 405.0, 278.5 ],
 									"source" : [ "obj-19", 0 ]
 								}
 
@@ -3096,7 +3115,7 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-4", 0 ],
-									"midpoints" : [ 363.75, 304.5, 363.75, 304.5 ],
+									"midpoints" : [ 380.0, 269.5, 380.0, 269.5 ],
 									"source" : [ "obj-20", 0 ]
 								}
 
@@ -3139,7 +3158,7 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-36", 0 ],
-									"midpoints" : [ 14.5, 282.0, 14.5, 282.0 ],
+									"midpoints" : [ 69.5, 270.0, 69.5, 270.0 ],
 									"source" : [ "obj-5", 0 ]
 								}
 
@@ -3147,7 +3166,7 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-1", 0 ],
-									"midpoints" : [ 189.75, 304.5, 189.75, 304.5 ],
+									"midpoints" : [ 244.75, 269.5, 244.75, 269.5 ],
 									"source" : [ "obj-9", 0 ]
 								}
 
@@ -3177,13 +3196,13 @@
 								"name" : "max6message",
 								"default" : 								{
 									"bgfillcolor" : 									{
-										"type" : "gradient",
+										"angle" : 270.0,
+										"autogradient" : 0,
+										"color" : [ 0.290196, 0.309804, 0.301961, 1.0 ],
 										"color1" : [ 0.866667, 0.866667, 0.866667, 1.0 ],
 										"color2" : [ 0.788235, 0.788235, 0.788235, 1.0 ],
-										"color" : [ 0.290196, 0.309804, 0.301961, 1.0 ],
-										"angle" : 270.0,
 										"proportion" : 0.39,
-										"autogradient" : 0
+										"type" : "gradient"
 									}
 ,
 									"textcolor_inverse" : [ 0.0, 0.0, 0.0, 1.0 ]
@@ -3233,14 +3252,14 @@
 						}
 ,
 						"classnamespace" : "box",
-						"rect" : [ 0.0, 26.0, 995.0, 751.0 ],
+						"rect" : [ 0.0, 26.0, 956.0, 753.0 ],
 						"bglocked" : 0,
 						"openinpresentation" : 0,
 						"default_fontsize" : 12.0,
 						"default_fontface" : 0,
 						"default_fontname" : "Arial",
 						"gridonopen" : 2,
-						"gridsize" : [ 5.0, 5.0 ],
+						"gridsize" : [ 10.0, 10.0 ],
 						"gridsnaponopen" : 2,
 						"objectsnaponopen" : 1,
 						"statusbarvisible" : 2,
@@ -3270,7 +3289,7 @@
 									"maxclass" : "live.line",
 									"numinlets" : 1,
 									"numoutlets" : 0,
-									"patching_rect" : [ 41.5, 328.0, 12.5, 61.0 ]
+									"patching_rect" : [ 163.0, 341.0, 12.5, 61.0 ]
 								}
 
 							}
@@ -3278,6 +3297,7 @@
 								"box" : 								{
 									"bgcolor" : [ 1.0, 0.788235, 0.470588, 1.0 ],
 									"fontname" : "Arial Bold",
+									"fontsize" : 13.0,
 									"hint" : "",
 									"id" : "obj-64",
 									"ignoreclick" : 1,
@@ -3287,7 +3307,7 @@
 									"numoutlets" : 3,
 									"outlettype" : [ "", "", "int" ],
 									"parameter_enable" : 0,
-									"patching_rect" : [ 689.0, 191.5, 20.0, 20.0 ],
+									"patching_rect" : [ 772.0, 248.5, 20.0, 20.0 ],
 									"rounded" : 60.0,
 									"text" : "7",
 									"textcolor" : [ 0.34902, 0.34902, 0.34902, 1.0 ]
@@ -3297,12 +3317,14 @@
 , 							{
 								"box" : 								{
 									"bubble" : 1,
+									"bubbleside" : 0,
+									"fontsize" : 13.0,
 									"id" : "obj-65",
 									"maxclass" : "comment",
 									"numinlets" : 1,
 									"numoutlets" : 0,
-									"patching_rect" : [ 715.0, 191.5, 213.0, 24.0 ],
-									"text" : "You can higlight multiple identifiers."
+									"patching_rect" : [ 598.0, 228.5, 172.0, 40.0 ],
+									"text" : "Highlight multiple identifiers."
 								}
 
 							}
@@ -3319,7 +3341,7 @@
 									"numoutlets" : 3,
 									"outlettype" : [ "", "", "int" ],
 									"parameter_enable" : 0,
-									"patching_rect" : [ 38.0, 306.0, 20.0, 20.0 ],
+									"patching_rect" : [ 159.5, 319.0, 20.0, 20.0 ],
 									"rounded" : 60.0,
 									"text" : "6",
 									"textcolor" : [ 0.34902, 0.34902, 0.34902, 1.0 ]
@@ -3333,84 +3355,48 @@
 									"maxclass" : "comment",
 									"numinlets" : 1,
 									"numoutlets" : 0,
-									"patching_rect" : [ 24.0, 391.0, 106.0, 100.0 ],
-									"text" : "The highlight message dictates which \"identifiers\" will be emphasised visually in the plotter."
+									"patching_rect" : [ 100.0, 404.0, 106.0, 100.0 ],
+									"text" : "The highlight message dictates which \"identifiers\" will be emphasised visually in the plotter.",
+									"textcolor" : [ 0.501960784313725, 0.501960784313725, 0.501960784313725, 1.0 ]
 								}
 
 							}
 , 							{
 								"box" : 								{
-									"bgcolor" : [ 1.0, 0.788235, 0.470588, 1.0 ],
-									"fontname" : "Arial Bold",
-									"hint" : "",
-									"id" : "obj-60",
-									"ignoreclick" : 1,
-									"legacytextcolor" : 1,
-									"maxclass" : "textbutton",
-									"numinlets" : 1,
-									"numoutlets" : 3,
-									"outlettype" : [ "", "", "int" ],
-									"parameter_enable" : 0,
-									"patching_rect" : [ 252.5, 648.0, 20.0, 20.0 ],
-									"rounded" : 60.0,
-									"text" : "5",
-									"textcolor" : [ 0.34902, 0.34902, 0.34902, 1.0 ]
-								}
-
-							}
-, 							{
-								"box" : 								{
-									"bubble" : 1,
+									"fontsize" : 13.0,
 									"id" : "obj-61",
 									"maxclass" : "comment",
 									"numinlets" : 1,
 									"numoutlets" : 0,
-									"patching_rect" : [ 274.5, 646.0, 346.0, 24.0 ],
-									"text" : "Query for the nearest point in the original data to the mouse."
+									"patching_rect" : [ 305.0, 658.0, 355.0, 21.0 ],
+									"text" : "Query for the nearest point in the original data to the mouse.",
+									"textcolor" : [ 0.501960784313725, 0.501960784313725, 0.501960784313725, 1.0 ]
 								}
 
 							}
 , 							{
 								"box" : 								{
+									"fontsize" : 13.0,
 									"id" : "obj-57",
 									"maxclass" : "newobj",
 									"numinlets" : 2,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 177.5, 690.0, 73.0, 22.0 ],
+									"patching_rect" : [ 222.5, 700.0, 79.0, 23.0 ],
 									"text" : "speedlim 20"
 								}
 
 							}
 , 							{
 								"box" : 								{
-									"bgcolor" : [ 1.0, 0.788235, 0.470588, 1.0 ],
-									"fontname" : "Arial Bold",
-									"hint" : "",
-									"id" : "obj-56",
-									"ignoreclick" : 1,
-									"legacytextcolor" : 1,
-									"maxclass" : "textbutton",
-									"numinlets" : 1,
-									"numoutlets" : 3,
-									"outlettype" : [ "", "", "int" ],
-									"parameter_enable" : 0,
-									"patching_rect" : [ 252.5, 606.0, 20.0, 20.0 ],
-									"rounded" : 60.0,
-									"text" : "4",
-									"textcolor" : [ 0.34902, 0.34902, 0.34902, 1.0 ]
-								}
-
-							}
-, 							{
-								"box" : 								{
-									"bubble" : 1,
+									"fontsize" : 13.0,
 									"id" : "obj-55",
 									"maxclass" : "comment",
 									"numinlets" : 1,
 									"numoutlets" : 0,
-									"patching_rect" : [ 274.5, 604.0, 262.0, 24.0 ],
-									"text" : "Store the coordinates in a temporary buffer."
+									"patching_rect" : [ 305.0, 616.0, 258.0, 21.0 ],
+									"text" : "Store the coordinates in a temporary buffer.",
+									"textcolor" : [ 0.501960784313725, 0.501960784313725, 0.501960784313725, 1.0 ]
 								}
 
 							}
@@ -3418,6 +3404,7 @@
 								"box" : 								{
 									"bgcolor" : [ 1.0, 0.788235, 0.470588, 1.0 ],
 									"fontname" : "Arial Bold",
+									"fontsize" : 13.0,
 									"hint" : "",
 									"id" : "obj-53",
 									"ignoreclick" : 1,
@@ -3427,7 +3414,7 @@
 									"numoutlets" : 3,
 									"outlettype" : [ "", "", "int" ],
 									"parameter_enable" : 0,
-									"patching_rect" : [ 350.0, 565.0, 20.0, 20.0 ],
+									"patching_rect" : [ 395.0, 575.0, 20.0, 20.0 ],
 									"rounded" : 60.0,
 									"text" : "3",
 									"textcolor" : [ 0.34902, 0.34902, 0.34902, 1.0 ]
@@ -3437,12 +3424,13 @@
 , 							{
 								"box" : 								{
 									"bubble" : 1,
+									"fontsize" : 13.0,
 									"id" : "obj-54",
 									"linecount" : 2,
 									"maxclass" : "comment",
 									"numinlets" : 1,
 									"numoutlets" : 0,
-									"patching_rect" : [ 372.0, 556.5, 429.0, 37.0 ],
+									"patching_rect" : [ 417.0, 566.5, 457.0, 40.0 ],
 									"text" : "These are the coordinates of your mouse inside the two-dimensional space according to the ranges which have been set by xrange and yrange."
 								}
 
@@ -3451,6 +3439,7 @@
 								"box" : 								{
 									"bgcolor" : [ 1.0, 0.788235, 0.470588, 1.0 ],
 									"fontname" : "Arial Bold",
+									"fontsize" : 13.0,
 									"hint" : "",
 									"id" : "obj-52",
 									"ignoreclick" : 1,
@@ -3460,7 +3449,7 @@
 									"numoutlets" : 3,
 									"outlettype" : [ "", "", "int" ],
 									"parameter_enable" : 0,
-									"patching_rect" : [ 443.5, 398.0, 20.0, 20.0 ],
+									"patching_rect" : [ 488.5, 408.0, 20.0, 20.0 ],
 									"rounded" : 60.0,
 									"text" : "2",
 									"textcolor" : [ 0.34902, 0.34902, 0.34902, 1.0 ]
@@ -3470,11 +3459,12 @@
 , 							{
 								"box" : 								{
 									"bubble" : 1,
+									"fontsize" : 13.0,
 									"id" : "obj-51",
 									"maxclass" : "comment",
 									"numinlets" : 1,
 									"numoutlets" : 0,
-									"patching_rect" : [ 465.5, 398.0, 257.0, 24.0 ],
+									"patching_rect" : [ 510.5, 408.0, 277.0, 25.0 ],
 									"text" : "Move your mouse around the fluid.plotter."
 								}
 
@@ -3483,6 +3473,7 @@
 								"box" : 								{
 									"bgcolor" : [ 1.0, 0.788235, 0.470588, 1.0 ],
 									"fontname" : "Arial Bold",
+									"fontsize" : 13.0,
 									"hint" : "",
 									"id" : "obj-50",
 									"ignoreclick" : 1,
@@ -3492,7 +3483,7 @@
 									"numoutlets" : 3,
 									"outlettype" : [ "", "", "int" ],
 									"parameter_enable" : 0,
-									"patching_rect" : [ 30.0, 102.0, 20.0, 20.0 ],
+									"patching_rect" : [ 75.0, 112.0, 20.0, 20.0 ],
 									"rounded" : 60.0,
 									"text" : "1",
 									"textcolor" : [ 0.34902, 0.34902, 0.34902, 1.0 ]
@@ -3502,36 +3493,38 @@
 , 							{
 								"box" : 								{
 									"bubble" : 1,
+									"fontsize" : 13.0,
 									"id" : "obj-48",
-									"linecount" : 2,
 									"maxclass" : "comment",
 									"numinlets" : 1,
 									"numoutlets" : 0,
-									"patching_rect" : [ 52.0, 95.5, 350.0, 37.0 ],
+									"patching_rect" : [ 97.0, 110.0, 580.0, 25.0 ],
 									"text" : "Generate random data and cluster it. Also fit a fluid.kdtree~ so we can query for the closest data."
 								}
 
 							}
 , 							{
 								"box" : 								{
+									"fontsize" : 13.0,
 									"id" : "obj-40",
 									"maxclass" : "newobj",
 									"numinlets" : 1,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 60.0, 306.0, 101.0, 22.0 ],
+									"patching_rect" : [ 50.0, 319.0, 108.0, 23.0 ],
 									"text" : "prepend highlight"
 								}
 
 							}
 , 							{
 								"box" : 								{
+									"fontsize" : 13.0,
 									"id" : "obj-37",
 									"maxclass" : "newobj",
 									"numinlets" : 2,
 									"numoutlets" : 2,
 									"outlettype" : [ "", "" ],
-									"patching_rect" : [ 60.0, 262.0, 85.0, 22.0 ],
+									"patching_rect" : [ 50.0, 275.0, 92.0, 23.0 ],
 									"text" : "route knearest"
 								}
 
@@ -3545,84 +3538,91 @@
 									"numoutlets" : 2,
 									"outlettype" : [ "", "" ],
 									"parameter_enable" : 0,
-									"patching_rect" : [ 177.5, 276.0, 264.0, 264.0 ]
+									"patching_rect" : [ 222.5, 286.0, 264.0, 264.0 ]
 								}
 
 							}
 , 							{
 								"box" : 								{
+									"fontsize" : 13.0,
 									"id" : "obj-33",
 									"maxclass" : "message",
 									"numinlets" : 2,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 510.0, 191.5, 175.0, 22.0 ],
+									"patching_rect" : [ 555.0, 201.5, 189.0, 23.0 ],
 									"text" : "highlight entry-1 entry-4 entry-9"
 								}
 
 							}
 , 							{
 								"box" : 								{
+									"fontsize" : 13.0,
 									"id" : "obj-31",
 									"maxclass" : "message",
 									"numinlets" : 2,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 5.0, 191.5, 70.0, 22.0 ],
+									"patching_rect" : [ 50.0, 201.5, 75.0, 23.0 ],
 									"text" : "fit plotting.2"
 								}
 
 							}
 , 							{
 								"box" : 								{
+									"fontsize" : 13.0,
 									"id" : "obj-27",
 									"maxclass" : "message",
 									"numinlets" : 2,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 177.5, 648.0, 71.0, 22.0 ],
+									"patching_rect" : [ 222.5, 658.0, 76.0, 23.0 ],
 									"text" : "knearest $2"
 								}
 
 							}
 , 							{
 								"box" : 								{
+									"fontsize" : 13.0,
 									"id" : "obj-22",
 									"maxclass" : "newobj",
 									"numinlets" : 1,
 									"numoutlets" : 1,
 									"outlettype" : [ "list" ],
-									"patching_rect" : [ 177.5, 606.0, 72.0, 22.0 ],
+									"patching_rect" : [ 222.5, 616.0, 77.0, 23.0 ],
 									"text" : "fluid.list2buf"
 								}
 
 							}
 , 							{
 								"box" : 								{
+									"fontsize" : 13.0,
 									"id" : "obj-21",
 									"maxclass" : "message",
 									"numinlets" : 2,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 177.5, 564.0, 170.0, 22.0 ],
-									"text" : "0.541667 0.829545"
+									"patching_rect" : [ 222.5, 574.0, 161.5, 23.0 ],
+									"text" : "0.723485 0.291667"
 								}
 
 							}
 , 							{
 								"box" : 								{
+									"fontsize" : 13.0,
 									"id" : "obj-16",
 									"maxclass" : "newobj",
 									"numinlets" : 1,
-									"numoutlets" : 3,
-									"outlettype" : [ "bang", "float", "" ],
-									"patching_rect" : [ 5.0, 227.0, 74.0, 22.0 ],
+									"numoutlets" : 2,
+									"outlettype" : [ "", "" ],
+									"patching_rect" : [ 50.0, 237.0, 80.0, 23.0 ],
 									"text" : "fluid.kdtree~"
 								}
 
 							}
 , 							{
 								"box" : 								{
+									"fontsize" : 13.0,
 									"id" : "obj-15",
 									"maxclass" : "newobj",
 									"numinlets" : 1,
@@ -3674,7 +3674,7 @@
 													"numinlets" : 2,
 													"numoutlets" : 2,
 													"outlettype" : [ "", "" ],
-													"patching_rect" : [ 206.0, 254.0, 69.0, 22.0 ],
+													"patching_rect" : [ 142.0, 238.0, 69.0, 22.0 ],
 													"text" : "route dump"
 												}
 
@@ -3686,7 +3686,7 @@
 													"numinlets" : 2,
 													"numoutlets" : 1,
 													"outlettype" : [ "" ],
-													"patching_rect" : [ 78.0, 183.5, 39.0, 22.0 ],
+													"patching_rect" : [ 14.0, 167.5, 39.0, 22.0 ],
 													"text" : "dump"
 												}
 
@@ -3696,9 +3696,9 @@
 													"id" : "obj-81",
 													"maxclass" : "newobj",
 													"numinlets" : 1,
-													"numoutlets" : 3,
-													"outlettype" : [ "bang", "float", "" ],
-													"patching_rect" : [ 78.0, 220.0, 147.0, 22.0 ],
+													"numoutlets" : 2,
+													"outlettype" : [ "", "" ],
+													"patching_rect" : [ 14.0, 204.0, 147.0, 22.0 ],
 													"text" : "fluid.labelset~ clustering.2"
 												}
 
@@ -3710,7 +3710,7 @@
 													"numinlets" : 2,
 													"numoutlets" : 2,
 													"outlettype" : [ "", "" ],
-													"patching_rect" : [ 78.0, 149.5, 85.0, 22.0 ],
+													"patching_rect" : [ 14.0, 133.5, 85.0, 22.0 ],
 													"text" : "route fitpredict"
 												}
 
@@ -3732,8 +3732,8 @@
 													"id" : "obj-76",
 													"maxclass" : "newobj",
 													"numinlets" : 1,
-													"numoutlets" : 3,
-													"outlettype" : [ "bang", "float", "" ],
+													"numoutlets" : 2,
+													"outlettype" : [ "", "" ],
 													"patching_rect" : [ 14.0, 103.0, 173.0, 22.0 ],
 													"text" : "fluid.kmeans~ @numclusters 4"
 												}
@@ -3760,7 +3760,7 @@
 													"maxclass" : "outlet",
 													"numinlets" : 1,
 													"numoutlets" : 0,
-													"patching_rect" : [ 206.0, 287.0, 30.0, 30.0 ]
+													"patching_rect" : [ 142.0, 271.0, 30.0, 30.0 ]
 												}
 
 											}
@@ -3775,8 +3775,7 @@
 , 											{
 												"patchline" : 												{
 													"destination" : [ "obj-80", 0 ],
-													"midpoints" : [ 177.5, 143.5, 87.5, 143.5 ],
-													"source" : [ "obj-76", 2 ]
+													"source" : [ "obj-76", 0 ]
 												}
 
 											}
@@ -3797,7 +3796,7 @@
 , 											{
 												"patchline" : 												{
 													"destination" : [ "obj-84", 0 ],
-													"source" : [ "obj-81", 2 ]
+													"source" : [ "obj-81", 1 ]
 												}
 
 											}
@@ -3818,7 +3817,7 @@
  ]
 									}
 ,
-									"patching_rect" : [ 177.5, 191.5, 133.0, 22.0 ],
+									"patching_rect" : [ 222.5, 201.5, 143.0, 23.0 ],
 									"saved_object_attributes" : 									{
 										"description" : "",
 										"digest" : "",
@@ -3838,24 +3837,26 @@
 									"numoutlets" : 1,
 									"outlettype" : [ "bang" ],
 									"parameter_enable" : 0,
-									"patching_rect" : [ 5.0, 100.0, 24.0, 24.0 ]
+									"patching_rect" : [ 50.0, 110.0, 24.0, 24.0 ]
 								}
 
 							}
 , 							{
 								"box" : 								{
+									"fontsize" : 13.0,
 									"id" : "obj-8",
 									"maxclass" : "newobj",
 									"numinlets" : 1,
 									"numoutlets" : 3,
 									"outlettype" : [ "bang", "bang", "bang" ],
-									"patching_rect" : [ 5.0, 138.597168000000011, 364.0, 22.0 ],
+									"patching_rect" : [ 50.0, 148.597168000000011, 364.0, 23.0 ],
 									"text" : "t b b b"
 								}
 
 							}
 , 							{
 								"box" : 								{
+									"fontsize" : 13.0,
 									"id" : "obj-5",
 									"maxclass" : "newobj",
 									"numinlets" : 1,
@@ -3907,7 +3908,7 @@
 													"numinlets" : 2,
 													"numoutlets" : 1,
 													"outlettype" : [ "" ],
-													"patching_rect" : [ 53.0, 390.40283203125, 39.0, 22.0 ],
+													"patching_rect" : [ 166.0, 382.40283203125, 39.0, 22.0 ],
 													"text" : "dump"
 												}
 
@@ -3919,7 +3920,7 @@
 													"numinlets" : 2,
 													"numoutlets" : 2,
 													"outlettype" : [ "", "" ],
-													"patching_rect" : [ 166.0, 458.90283203125, 69.0, 22.0 ],
+													"patching_rect" : [ 279.0, 450.90283203125, 69.0, 22.0 ],
 													"text" : "route dump"
 												}
 
@@ -3929,9 +3930,9 @@
 													"id" : "obj-63",
 													"maxclass" : "newobj",
 													"numinlets" : 1,
-													"numoutlets" : 3,
-													"outlettype" : [ "bang", "float", "" ],
-													"patching_rect" : [ 53.0, 424.90283203125, 132.0, 22.0 ],
+													"numoutlets" : 2,
+													"outlettype" : [ "", "" ],
+													"patching_rect" : [ 166.0, 416.90283203125, 132.0, 22.0 ],
 													"text" : "fluid.dataset~ plotting.2"
 												}
 
@@ -3941,8 +3942,8 @@
 													"id" : "obj-17",
 													"maxclass" : "newobj",
 													"numinlets" : 1,
-													"numoutlets" : 3,
-													"outlettype" : [ "bang", "float", "" ],
+													"numoutlets" : 2,
+													"outlettype" : [ "", "" ],
 													"patching_rect" : [ 53.0, 348.90283203125, 132.0, 22.0 ],
 													"text" : "fluid.dataset~ plotting.2"
 												}
@@ -4049,8 +4050,8 @@
 													"id" : "obj-54",
 													"maxclass" : "newobj",
 													"numinlets" : 1,
-													"numoutlets" : 3,
-													"outlettype" : [ "bang", "float", "" ],
+													"numoutlets" : 2,
+													"outlettype" : [ "", "" ],
 													"patching_rect" : [ 138.5, 94.90283203125, 132.0, 22.0 ],
 													"text" : "fluid.dataset~ plotting.2"
 												}
@@ -4101,7 +4102,7 @@
 													"maxclass" : "outlet",
 													"numinlets" : 1,
 													"numoutlets" : 0,
-													"patching_rect" : [ 166.0, 491.805664031249989, 30.0, 30.0 ]
+													"patching_rect" : [ 279.0, 483.805664031249989, 30.0, 30.0 ]
 												}
 
 											}
@@ -4132,8 +4133,7 @@
 , 											{
 												"patchline" : 												{
 													"destination" : [ "obj-68", 0 ],
-													"midpoints" : [ 175.5, 385.0, 62.5, 385.0 ],
-													"source" : [ "obj-17", 2 ]
+													"source" : [ "obj-17", 1 ]
 												}
 
 											}
@@ -4203,7 +4203,7 @@
 , 											{
 												"patchline" : 												{
 													"destination" : [ "obj-62", 0 ],
-													"source" : [ "obj-63", 2 ]
+													"source" : [ "obj-63", 1 ]
 												}
 
 											}
@@ -4245,7 +4245,7 @@
  ]
 									}
 ,
-									"patching_rect" : [ 350.0, 191.5, 145.0, 22.0 ],
+									"patching_rect" : [ 395.0, 201.5, 156.0, 23.0 ],
 									"saved_object_attributes" : 									{
 										"description" : "",
 										"digest" : "",
@@ -4264,8 +4264,9 @@
 									"maxclass" : "comment",
 									"numinlets" : 1,
 									"numoutlets" : 0,
-									"patching_rect" : [ 5.0, 61.0, 239.0, 21.0 ],
-									"text" : "An abstraction for plotting fluid.dataset~"
+									"patching_rect" : [ 10.0, 66.0, 239.0, 21.0 ],
+									"text" : "An abstraction for plotting fluid.dataset~",
+									"textcolor" : [ 0.501960784313725, 0.501960784313725, 0.501960784313725, 1.0 ]
 								}
 
 							}
@@ -4281,7 +4282,7 @@
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
 									"parameter_enable" : 0,
-									"patching_rect" : [ 5.0, 5.0, 334.0, 55.0 ]
+									"patching_rect" : [ 10.0, 10.0, 334.0, 55.0 ]
 								}
 
 							}
@@ -4296,7 +4297,7 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-36", 1 ],
-									"midpoints" : [ 187.0, 262.0, 432.0, 262.0 ],
+									"midpoints" : [ 232.0, 272.0, 477.0, 272.0 ],
 									"source" : [ "obj-15", 0 ]
 								}
 
@@ -4304,7 +4305,7 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-37", 0 ],
-									"source" : [ "obj-16", 2 ]
+									"source" : [ "obj-16", 0 ]
 								}
 
 							}
@@ -4325,7 +4326,7 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-57", 0 ],
-									"midpoints" : [ 187.0, 685.0, 187.0, 685.0 ],
+									"midpoints" : [ 232.0, 695.0, 232.0, 695.0 ],
 									"source" : [ "obj-27", 0 ]
 								}
 
@@ -4340,7 +4341,7 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-36", 0 ],
-									"midpoints" : [ 519.5, 262.0, 187.0, 262.0 ],
+									"midpoints" : [ 564.5, 272.0, 232.0, 272.0 ],
 									"source" : [ "obj-33", 0 ]
 								}
 
@@ -4348,7 +4349,7 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-21", 1 ],
-									"midpoints" : [ 187.0, 550.0, 338.0, 550.0 ],
+									"midpoints" : [ 232.0, 560.0, 374.5, 560.0 ],
 									"order" : 0,
 									"source" : [ "obj-36", 0 ]
 								}
@@ -4372,7 +4373,7 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-36", 0 ],
-									"midpoints" : [ 69.5, 340.0, 170.0, 340.0, 170.0, 265.0, 187.0, 265.0 ],
+									"midpoints" : [ 59.5, 350.0, 215.0, 350.0, 215.0, 275.0, 232.0, 275.0 ],
 									"source" : [ "obj-40", 0 ]
 								}
 
@@ -4380,7 +4381,7 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-36", 0 ],
-									"midpoints" : [ 359.5, 262.0, 187.0, 262.0 ],
+									"midpoints" : [ 404.5, 272.0, 232.0, 272.0 ],
 									"source" : [ "obj-5", 0 ]
 								}
 
@@ -4388,7 +4389,7 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-16", 0 ],
-									"midpoints" : [ 187.0, 714.0, 0.0, 714.0, 0.0, 222.0, 14.5, 222.0 ],
+									"midpoints" : [ 232.0, 724.0, 45.0, 724.0, 45.0, 232.0, 59.5, 232.0 ],
 									"source" : [ "obj-57", 0 ]
 								}
 
@@ -4439,13 +4440,13 @@
 								"name" : "max6message",
 								"default" : 								{
 									"bgfillcolor" : 									{
-										"type" : "gradient",
+										"angle" : 270.0,
+										"autogradient" : 0,
+										"color" : [ 0.290196, 0.309804, 0.301961, 1.0 ],
 										"color1" : [ 0.866667, 0.866667, 0.866667, 1.0 ],
 										"color2" : [ 0.788235, 0.788235, 0.788235, 1.0 ],
-										"color" : [ 0.290196, 0.309804, 0.301961, 1.0 ],
-										"angle" : 270.0,
 										"proportion" : 0.39,
-										"autogradient" : 0
+										"type" : "gradient"
 									}
 ,
 									"textcolor_inverse" : [ 0.0, 0.0, 0.0, 1.0 ]
@@ -4495,14 +4496,14 @@
 						}
 ,
 						"classnamespace" : "box",
-						"rect" : [ 0.0, 26.0, 995.0, 751.0 ],
+						"rect" : [ 0.0, 26.0, 956.0, 753.0 ],
 						"bglocked" : 0,
 						"openinpresentation" : 0,
 						"default_fontsize" : 12.0,
 						"default_fontface" : 0,
 						"default_fontname" : "Arial",
 						"gridonopen" : 2,
-						"gridsize" : [ 5.0, 5.0 ],
+						"gridsize" : [ 10.0, 10.0 ],
 						"gridsnaponopen" : 2,
 						"objectsnaponopen" : 1,
 						"statusbarvisible" : 2,
@@ -4526,34 +4527,48 @@
 						"assistshowspatchername" : 0,
 						"boxes" : [ 							{
 								"box" : 								{
-									"bgcolor" : [ 1.0, 0.788235, 0.470588, 1.0 ],
-									"fontname" : "Arial Bold",
-									"hint" : "",
-									"id" : "obj-23",
-									"ignoreclick" : 1,
-									"legacytextcolor" : 1,
-									"maxclass" : "textbutton",
-									"numinlets" : 1,
-									"numoutlets" : 3,
-									"outlettype" : [ "", "", "int" ],
-									"parameter_enable" : 0,
-									"patching_rect" : [ 674.0, 292.5, 20.0, 20.0 ],
-									"rounded" : 60.0,
-									"text" : "4",
-									"textcolor" : [ 0.34902, 0.34902, 0.34902, 1.0 ]
+									"id" : "obj-11",
+									"maxclass" : "message",
+									"numinlets" : 2,
+									"numoutlets" : 1,
+									"outlettype" : [ "" ],
+									"patching_rect" : [ 30.0, 170.0, 49.0, 22.0 ],
+									"text" : "read $1"
 								}
 
 							}
 , 							{
 								"box" : 								{
-									"bubble" : 1,
+									"bgmode" : 0,
+									"border" : 0,
+									"clickthrough" : 0,
+									"enablehscroll" : 0,
+									"enablevscroll" : 0,
+									"id" : "obj-1",
+									"lockeddragscroll" : 0,
+									"lockedsize" : 0,
+									"maxclass" : "bpatcher",
+									"name" : "fluid.dataloader.maxpat",
+									"numinlets" : 0,
+									"numoutlets" : 1,
+									"offset" : [ 0.0, 0.0 ],
+									"outlettype" : [ "" ],
+									"patching_rect" : [ 30.0, 100.0, 175.0, 63.363631999999996 ],
+									"viewvisibility" : 1
+								}
+
+							}
+, 							{
+								"box" : 								{
+									"fontsize" : 13.0,
 									"id" : "obj-24",
 									"linecount" : 11,
 									"maxclass" : "comment",
 									"numinlets" : 1,
 									"numoutlets" : 0,
-									"patching_rect" : [ 696.0, 223.5, 166.0, 158.0 ],
-									"text" : "Dump the clustering from fluid.kmeans~ and send the output dictionary to the second inlet of the fluid.plotter.\n\nEach unique label in the fluid.labelset~ will be randomly assigned to a colour inside the fluid.plotter."
+									"patching_rect" : [ 711.0, 210.5, 172.0, 166.0 ],
+									"text" : "Dump the clustering from fluid.kmeans~ and send the output dictionary to the second inlet of the fluid.plotter.\n\nEach unique label in the fluid.labelset~ will be randomly assigned to a colour inside the fluid.plotter.",
+									"textcolor" : [ 0.501960784313725, 0.501960784313725, 0.501960784313725, 1.0 ]
 								}
 
 							}
@@ -4561,6 +4576,7 @@
 								"box" : 								{
 									"bgcolor" : [ 1.0, 0.788235, 0.470588, 1.0 ],
 									"fontname" : "Arial Bold",
+									"fontsize" : 13.0,
 									"hint" : "",
 									"id" : "obj-21",
 									"ignoreclick" : 1,
@@ -4570,7 +4586,7 @@
 									"numoutlets" : 3,
 									"outlettype" : [ "", "", "int" ],
 									"parameter_enable" : 0,
-									"patching_rect" : [ 608.0, 108.5, 20.0, 20.0 ],
+									"patching_rect" : [ 863.0, 102.5, 20.0, 20.0 ],
 									"rounded" : 60.0,
 									"text" : "4",
 									"textcolor" : [ 0.34902, 0.34902, 0.34902, 1.0 ]
@@ -4580,118 +4596,105 @@
 , 							{
 								"box" : 								{
 									"bubble" : 1,
+									"fontsize" : 13.0,
 									"id" : "obj-22",
-									"linecount" : 3,
 									"maxclass" : "comment",
 									"numinlets" : 1,
 									"numoutlets" : 0,
-									"patching_rect" : [ 630.0, 95.0, 166.0, 51.0 ],
-									"text" : "Cluster the original data stored in the dataset named \"plotting\""
+									"patching_rect" : [ 740.0, 100.0, 117.0, 25.0 ],
+									"text" : "Cluster the data"
 								}
 
 							}
 , 							{
 								"box" : 								{
+									"fontsize" : 13.0,
 									"id" : "obj-84",
 									"maxclass" : "newobj",
 									"numinlets" : 2,
 									"numoutlets" : 2,
 									"outlettype" : [ "", "" ],
-									"patching_rect" : [ 603.0, 292.5, 69.0, 22.0 ],
+									"patching_rect" : [ 629.0, 300.0, 74.0, 23.0 ],
 									"text" : "route dump"
 								}
 
 							}
 , 							{
 								"box" : 								{
+									"fontsize" : 13.0,
 									"id" : "obj-83",
 									"maxclass" : "message",
 									"numinlets" : 2,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 485.0, 221.0, 39.0, 22.0 ],
+									"patching_rect" : [ 500.0, 220.0, 41.0, 23.0 ],
 									"text" : "dump"
 								}
 
 							}
 , 							{
 								"box" : 								{
+									"fontsize" : 13.0,
 									"id" : "obj-81",
 									"maxclass" : "newobj",
 									"numinlets" : 1,
-									"numoutlets" : 3,
-									"outlettype" : [ "bang", "float", "" ],
-									"patching_rect" : [ 485.0, 257.5, 137.0, 22.0 ],
+									"numoutlets" : 2,
+									"outlettype" : [ "", "" ],
+									"patching_rect" : [ 500.0, 260.0, 148.0, 23.0 ],
 									"text" : "fluid.labelset~ clustering"
 								}
 
 							}
 , 							{
 								"box" : 								{
+									"fontsize" : 13.0,
 									"id" : "obj-80",
 									"maxclass" : "newobj",
 									"numinlets" : 2,
 									"numoutlets" : 2,
 									"outlettype" : [ "", "" ],
-									"patching_rect" : [ 485.0, 187.0, 85.0, 22.0 ],
+									"patching_rect" : [ 500.0, 180.0, 91.0, 23.0 ],
 									"text" : "route fitpredict"
 								}
 
 							}
 , 							{
 								"box" : 								{
+									"fontsize" : 13.0,
 									"id" : "obj-78",
 									"maxclass" : "message",
 									"numinlets" : 2,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 421.0, 108.5, 183.0, 22.0 ],
-									"text" : "clear, fitpredict plotting clustering"
+									"patching_rect" : [ 500.0, 100.0, 236.0, 23.0 ],
+									"text" : "clear, fitpredict help.plotting.1 clustering"
 								}
 
 							}
 , 							{
 								"box" : 								{
+									"fontsize" : 13.0,
 									"id" : "obj-76",
 									"maxclass" : "newobj",
 									"numinlets" : 1,
-									"numoutlets" : 3,
-									"outlettype" : [ "bang", "float", "" ],
-									"patching_rect" : [ 421.0, 140.5, 173.0, 22.0 ],
+									"numoutlets" : 2,
+									"outlettype" : [ "", "" ],
+									"patching_rect" : [ 500.0, 140.0, 187.0, 23.0 ],
 									"text" : "fluid.kmeans~ @numclusters 4"
 								}
 
 							}
 , 							{
 								"box" : 								{
-									"bgcolor" : [ 1.0, 0.788235, 0.470588, 1.0 ],
-									"fontname" : "Arial Bold",
-									"hint" : "",
-									"id" : "obj-71",
-									"ignoreclick" : 1,
-									"legacytextcolor" : 1,
-									"maxclass" : "textbutton",
-									"numinlets" : 1,
-									"numoutlets" : 3,
-									"outlettype" : [ "", "", "int" ],
-									"parameter_enable" : 0,
-									"patching_rect" : [ 180.0, 293.0, 20.0, 20.0 ],
-									"rounded" : 60.0,
-									"text" : "3",
-									"textcolor" : [ 0.34902, 0.34902, 0.34902, 1.0 ]
-								}
-
-							}
-, 							{
-								"box" : 								{
-									"bubble" : 1,
+									"fontsize" : 13.0,
 									"id" : "obj-72",
-									"linecount" : 6,
+									"linecount" : 7,
 									"maxclass" : "comment",
 									"numinlets" : 1,
 									"numoutlets" : 0,
-									"patching_rect" : [ 202.0, 257.5, 265.0, 91.0 ],
-									"text" : "A temporary dict is output when you dump from a fluid.dataset~. The randomly assigned name for this dictionary can be sent to the plotter's first inlet and it will draw the points. The fluid.dataset~ must be only two dimensions."
+									"patching_rect" : [ 263.0, 278.0, 213.0, 108.0 ],
+									"text" : "A temporary dict is output when you dump from a fluid.dataset~. The randomly assigned name for this dictionary can be sent to the plotter's first inlet and it will draw the points. The fluid.dataset~ must be only two dimensions.",
+									"textcolor" : [ 0.501960784313725, 0.501960784313725, 0.501960784313725, 1.0 ]
 								}
 
 							}
@@ -4699,6 +4702,7 @@
 								"box" : 								{
 									"bgcolor" : [ 1.0, 0.788235, 0.470588, 1.0 ],
 									"fontname" : "Arial Bold",
+									"fontsize" : 13.0,
 									"hint" : "",
 									"id" : "obj-69",
 									"ignoreclick" : 1,
@@ -4708,7 +4712,7 @@
 									"numoutlets" : 3,
 									"outlettype" : [ "", "", "int" ],
 									"parameter_enable" : 0,
-									"patching_rect" : [ 46.0, 212.5, 20.0, 20.0 ],
+									"patching_rect" : [ 235.0, 245.0, 20.0, 20.0 ],
 									"rounded" : 60.0,
 									"text" : "2",
 									"textcolor" : [ 0.34902, 0.34902, 0.34902, 1.0 ]
@@ -4718,371 +4722,26 @@
 , 							{
 								"box" : 								{
 									"bubble" : 1,
+									"fontsize" : 13.0,
 									"id" : "obj-70",
 									"maxclass" : "comment",
 									"numinlets" : 1,
 									"numoutlets" : 0,
-									"patching_rect" : [ 68.0, 212.5, 153.0, 24.0 ],
+									"patching_rect" : [ 70.0, 242.5, 163.0, 25.0 ],
 									"text" : "Dump the fluid.dataset~"
 								}
 
 							}
 , 							{
 								"box" : 								{
+									"fontsize" : 13.0,
 									"id" : "obj-68",
 									"maxclass" : "message",
 									"numinlets" : 2,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 5.0, 212.5, 39.0, 22.0 ],
+									"patching_rect" : [ 30.0, 242.5, 41.0, 23.0 ],
 									"text" : "dump"
-								}
-
-							}
-, 							{
-								"box" : 								{
-									"id" : "obj-66",
-									"maxclass" : "newobj",
-									"numinlets" : 1,
-									"numoutlets" : 1,
-									"outlettype" : [ "" ],
-									"patcher" : 									{
-										"fileversion" : 1,
-										"appversion" : 										{
-											"major" : 8,
-											"minor" : 3,
-											"revision" : 0,
-											"architecture" : "x64",
-											"modernui" : 1
-										}
-,
-										"classnamespace" : "box",
-										"rect" : [ 84.0, 131.0, 640.0, 480.0 ],
-										"bglocked" : 0,
-										"openinpresentation" : 0,
-										"default_fontsize" : 12.0,
-										"default_fontface" : 0,
-										"default_fontname" : "Arial",
-										"gridonopen" : 1,
-										"gridsize" : [ 15.0, 15.0 ],
-										"gridsnaponopen" : 1,
-										"objectsnaponopen" : 1,
-										"statusbarvisible" : 2,
-										"toolbarvisible" : 1,
-										"lefttoolbarpinned" : 0,
-										"toptoolbarpinned" : 0,
-										"righttoolbarpinned" : 0,
-										"bottomtoolbarpinned" : 0,
-										"toolbars_unpinned_last_save" : 0,
-										"tallnewobj" : 0,
-										"boxanimatetime" : 200,
-										"enablehscroll" : 1,
-										"enablevscroll" : 1,
-										"devicewidth" : 0.0,
-										"description" : "",
-										"digest" : "",
-										"tags" : "",
-										"style" : "",
-										"subpatcher_template" : "",
-										"assistshowspatchername" : 0,
-										"visible" : 1,
-										"boxes" : [ 											{
-												"box" : 												{
-													"id" : "obj-1",
-													"maxclass" : "newobj",
-													"numinlets" : 1,
-													"numoutlets" : 0,
-													"patching_rect" : [ 362.0, 267.0, 32.0, 22.0 ],
-													"text" : "print"
-												}
-
-											}
-, 											{
-												"box" : 												{
-													"id" : "obj-24",
-													"maxclass" : "newobj",
-													"numinlets" : 3,
-													"numoutlets" : 1,
-													"outlettype" : [ "" ],
-													"patching_rect" : [ 74.5, 245.0, 237.0, 22.0 ],
-													"text" : "sprintf %s %f %f"
-												}
-
-											}
-, 											{
-												"box" : 												{
-													"id" : "obj-23",
-													"maxclass" : "newobj",
-													"numinlets" : 1,
-													"numoutlets" : 1,
-													"outlettype" : [ "" ],
-													"patching_rect" : [ 366.75, 198.0, 181.0, 22.0 ],
-													"text" : "expr random(-1000\\, 1000) / 324."
-												}
-
-											}
-, 											{
-												"box" : 												{
-													"id" : "obj-22",
-													"maxclass" : "newobj",
-													"numinlets" : 1,
-													"numoutlets" : 1,
-													"outlettype" : [ "" ],
-													"patching_rect" : [ 183.75, 198.0, 181.0, 22.0 ],
-													"text" : "expr random(-1000\\, 1000) / 324."
-												}
-
-											}
-, 											{
-												"box" : 												{
-													"id" : "obj-21",
-													"maxclass" : "newobj",
-													"numinlets" : 1,
-													"numoutlets" : 1,
-													"outlettype" : [ "" ],
-													"patching_rect" : [ 74.5, 198.0, 92.0, 22.0 ],
-													"text" : "sprintf entry-%i:"
-												}
-
-											}
-, 											{
-												"box" : 												{
-													"id" : "obj-16",
-													"maxclass" : "newobj",
-													"numinlets" : 1,
-													"numoutlets" : 2,
-													"outlettype" : [ "int", "bang" ],
-													"patching_rect" : [ 74.5, 149.0, 128.25, 22.0 ],
-													"text" : "t i b"
-												}
-
-											}
-, 											{
-												"box" : 												{
-													"id" : "obj-74",
-													"maxclass" : "newobj",
-													"numinlets" : 2,
-													"numoutlets" : 3,
-													"outlettype" : [ "bang", "bang", "int" ],
-													"patching_rect" : [ 16.0, 111.0, 47.0, 22.0 ],
-													"text" : "uzi 100"
-												}
-
-											}
-, 											{
-												"box" : 												{
-													"id" : "obj-71",
-													"maxclass" : "newobj",
-													"numinlets" : 2,
-													"numoutlets" : 1,
-													"outlettype" : [ "dictionary" ],
-													"patching_rect" : [ 30.0, 323.0, 121.0, 22.0 ],
-													"text" : "dict.pack data: cols:2"
-												}
-
-											}
-, 											{
-												"box" : 												{
-													"id" : "obj-70",
-													"maxclass" : "newobj",
-													"numinlets" : 1,
-													"numoutlets" : 1,
-													"outlettype" : [ "dictionary" ],
-													"patching_rect" : [ 30.0, 289.0, 61.0, 22.0 ],
-													"text" : "dict.group"
-												}
-
-											}
-, 											{
-												"box" : 												{
-													"id" : "obj-54",
-													"maxclass" : "newobj",
-													"numinlets" : 1,
-													"numoutlets" : 3,
-													"outlettype" : [ "bang", "float", "" ],
-													"patching_rect" : [ 115.5, 111.0, 122.0, 22.0 ],
-													"text" : "fluid.dataset~ plotting"
-												}
-
-											}
-, 											{
-												"box" : 												{
-													"id" : "obj-52",
-													"maxclass" : "newobj",
-													"numinlets" : 1,
-													"numoutlets" : 2,
-													"outlettype" : [ "bang", "clear" ],
-													"patching_rect" : [ 16.0, 65.0, 118.5, 22.0 ],
-													"text" : "t b clear"
-												}
-
-											}
-, 											{
-												"box" : 												{
-													"id" : "obj-43",
-													"maxclass" : "newobj",
-													"numinlets" : 1,
-													"numoutlets" : 1,
-													"outlettype" : [ "" ],
-													"patching_rect" : [ 30.0, 354.0, 81.0, 22.0 ],
-													"text" : "prepend load"
-												}
-
-											}
-, 											{
-												"box" : 												{
-													"comment" : "",
-													"id" : "obj-64",
-													"index" : 1,
-													"maxclass" : "inlet",
-													"numinlets" : 0,
-													"numoutlets" : 1,
-													"outlettype" : [ "bang" ],
-													"patching_rect" : [ 16.0, 16.0, 30.0, 30.0 ]
-												}
-
-											}
-, 											{
-												"box" : 												{
-													"comment" : "",
-													"id" : "obj-65",
-													"index" : 1,
-													"maxclass" : "outlet",
-													"numinlets" : 1,
-													"numoutlets" : 0,
-													"patching_rect" : [ 30.0, 388.0, 30.0, 30.0 ]
-												}
-
-											}
- ],
-										"lines" : [ 											{
-												"patchline" : 												{
-													"destination" : [ "obj-21", 0 ],
-													"source" : [ "obj-16", 0 ]
-												}
-
-											}
-, 											{
-												"patchline" : 												{
-													"destination" : [ "obj-22", 0 ],
-													"order" : 1,
-													"source" : [ "obj-16", 1 ]
-												}
-
-											}
-, 											{
-												"patchline" : 												{
-													"destination" : [ "obj-23", 0 ],
-													"order" : 0,
-													"source" : [ "obj-16", 1 ]
-												}
-
-											}
-, 											{
-												"patchline" : 												{
-													"destination" : [ "obj-24", 0 ],
-													"source" : [ "obj-21", 0 ]
-												}
-
-											}
-, 											{
-												"patchline" : 												{
-													"destination" : [ "obj-24", 1 ],
-													"source" : [ "obj-22", 0 ]
-												}
-
-											}
-, 											{
-												"patchline" : 												{
-													"destination" : [ "obj-24", 2 ],
-													"source" : [ "obj-23", 0 ]
-												}
-
-											}
-, 											{
-												"patchline" : 												{
-													"destination" : [ "obj-1", 0 ],
-													"order" : 0,
-													"source" : [ "obj-24", 0 ]
-												}
-
-											}
-, 											{
-												"patchline" : 												{
-													"destination" : [ "obj-70", 0 ],
-													"order" : 1,
-													"source" : [ "obj-24", 0 ]
-												}
-
-											}
-, 											{
-												"patchline" : 												{
-													"destination" : [ "obj-65", 0 ],
-													"source" : [ "obj-43", 0 ]
-												}
-
-											}
-, 											{
-												"patchline" : 												{
-													"destination" : [ "obj-54", 0 ],
-													"source" : [ "obj-52", 1 ]
-												}
-
-											}
-, 											{
-												"patchline" : 												{
-													"destination" : [ "obj-74", 0 ],
-													"source" : [ "obj-52", 0 ]
-												}
-
-											}
-, 											{
-												"patchline" : 												{
-													"destination" : [ "obj-52", 0 ],
-													"source" : [ "obj-64", 0 ]
-												}
-
-											}
-, 											{
-												"patchline" : 												{
-													"destination" : [ "obj-71", 0 ],
-													"source" : [ "obj-70", 0 ]
-												}
-
-											}
-, 											{
-												"patchline" : 												{
-													"destination" : [ "obj-43", 0 ],
-													"source" : [ "obj-71", 0 ]
-												}
-
-											}
-, 											{
-												"patchline" : 												{
-													"destination" : [ "obj-16", 0 ],
-													"source" : [ "obj-74", 2 ]
-												}
-
-											}
-, 											{
-												"patchline" : 												{
-													"destination" : [ "obj-70", 0 ],
-													"source" : [ "obj-74", 1 ]
-												}
-
-											}
- ]
-									}
-,
-									"patching_rect" : [ 5.0, 135.0, 116.0, 22.0 ],
-									"saved_object_attributes" : 									{
-										"description" : "",
-										"digest" : "",
-										"globalpatchername" : "",
-										"tags" : ""
-									}
-,
-									"text" : "p \"add dummy data\""
 								}
 
 							}
@@ -5095,31 +4754,33 @@
 									"numoutlets" : 2,
 									"outlettype" : [ "", "" ],
 									"parameter_enable" : 0,
-									"patching_rect" : [ 108.0, 370.0, 322.0, 322.0 ]
+									"patching_rect" : [ 182.0, 398.0, 322.0, 322.0 ]
 								}
 
 							}
 , 							{
 								"box" : 								{
+									"fontsize" : 13.0,
 									"id" : "obj-62",
 									"maxclass" : "newobj",
 									"numinlets" : 2,
 									"numoutlets" : 2,
 									"outlettype" : [ "", "" ],
-									"patching_rect" : [ 108.0, 292.0, 69.0, 22.0 ],
+									"patching_rect" : [ 182.0, 320.0, 74.0, 23.0 ],
 									"text" : "route dump"
 								}
 
 							}
 , 							{
 								"box" : 								{
+									"fontsize" : 13.0,
 									"id" : "obj-63",
 									"maxclass" : "newobj",
 									"numinlets" : 1,
-									"numoutlets" : 3,
-									"outlettype" : [ "bang", "float", "" ],
-									"patching_rect" : [ 5.0, 253.0, 122.0, 22.0 ],
-									"text" : "fluid.dataset~ plotting"
+									"numoutlets" : 2,
+									"outlettype" : [ "", "" ],
+									"patching_rect" : [ 30.0, 283.0, 171.0, 23.0 ],
+									"text" : "fluid.dataset~ help.plotting.1"
 								}
 
 							}
@@ -5127,6 +4788,7 @@
 								"box" : 								{
 									"bgcolor" : [ 1.0, 0.788235, 0.470588, 1.0 ],
 									"fontname" : "Arial Bold",
+									"fontsize" : 13.0,
 									"hint" : "",
 									"id" : "obj-42",
 									"ignoreclick" : 1,
@@ -5136,7 +4798,7 @@
 									"numoutlets" : 3,
 									"outlettype" : [ "", "", "int" ],
 									"parameter_enable" : 0,
-									"patching_rect" : [ 35.0, 97.0, 20.0, 20.0 ],
+									"patching_rect" : [ 358.0, 123.181815999999998, 20.0, 20.0 ],
 									"rounded" : 60.0,
 									"text" : "1",
 									"textcolor" : [ 0.34902, 0.34902, 0.34902, 1.0 ]
@@ -5150,32 +4812,21 @@
 									"maxclass" : "comment",
 									"numinlets" : 1,
 									"numoutlets" : 0,
-									"patching_rect" : [ 57.0, 97.0, 321.0, 24.0 ],
-									"text" : "Generate random data to be stored in the fluid.dataset~"
+									"patching_rect" : [ 207.0, 119.681815999999998, 149.0, 24.0 ],
+									"text" : "Select a prefab dataset"
 								}
 
 							}
 , 							{
 								"box" : 								{
-									"id" : "obj-56",
-									"maxclass" : "button",
-									"numinlets" : 1,
-									"numoutlets" : 1,
-									"outlettype" : [ "bang" ],
-									"parameter_enable" : 0,
-									"patching_rect" : [ 5.0, 95.0, 24.0, 24.0 ]
-								}
-
-							}
-, 							{
-								"box" : 								{
+									"fontsize" : 13.0,
 									"id" : "obj-17",
 									"maxclass" : "newobj",
 									"numinlets" : 1,
-									"numoutlets" : 3,
-									"outlettype" : [ "bang", "float", "" ],
-									"patching_rect" : [ 5.0, 170.0, 122.0, 22.0 ],
-									"text" : "fluid.dataset~ plotting"
+									"numoutlets" : 2,
+									"outlettype" : [ "", "" ],
+									"patching_rect" : [ 30.0, 200.0, 171.0, 23.0 ],
+									"text" : "fluid.dataset~ help.plotting.1"
 								}
 
 							}
@@ -5186,8 +4837,9 @@
 									"maxclass" : "comment",
 									"numinlets" : 1,
 									"numoutlets" : 0,
-									"patching_rect" : [ 5.0, 61.0, 280.0, 21.0 ],
-									"text" : "An abstraction for plotting fluid.dataset~ data."
+									"patching_rect" : [ 10.0, 66.0, 280.0, 21.0 ],
+									"text" : "An abstraction for plotting fluid.dataset~ data.",
+									"textcolor" : [ 0.501960784313725, 0.501960784313725, 0.501960784313725, 1.0 ]
 								}
 
 							}
@@ -5203,23 +4855,30 @@
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
 									"parameter_enable" : 0,
-									"patching_rect" : [ 5.0, 5.0, 334.0, 55.0 ]
+									"patching_rect" : [ 10.0, 10.0, 334.0, 55.0 ]
 								}
 
 							}
  ],
 						"lines" : [ 							{
 								"patchline" : 								{
-									"destination" : [ "obj-68", 0 ],
-									"midpoints" : [ 117.5, 202.5, 14.5, 202.5 ],
-									"source" : [ "obj-17", 2 ]
+									"destination" : [ "obj-11", 0 ],
+									"source" : [ "obj-1", 0 ]
 								}
 
 							}
 , 							{
 								"patchline" : 								{
-									"destination" : [ "obj-66", 0 ],
-									"source" : [ "obj-56", 0 ]
+									"destination" : [ "obj-17", 0 ],
+									"source" : [ "obj-11", 0 ]
+								}
+
+							}
+, 							{
+								"patchline" : 								{
+									"destination" : [ "obj-68", 0 ],
+									"midpoints" : [ 191.5, 232.25, 39.5, 232.25 ],
+									"source" : [ "obj-17", 1 ]
 								}
 
 							}
@@ -5233,14 +4892,7 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-62", 0 ],
-									"source" : [ "obj-63", 2 ]
-								}
-
-							}
-, 							{
-								"patchline" : 								{
-									"destination" : [ "obj-17", 0 ],
-									"source" : [ "obj-66", 0 ]
+									"source" : [ "obj-63", 1 ]
 								}
 
 							}
@@ -5254,8 +4906,7 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-80", 0 ],
-									"midpoints" : [ 584.5, 181.0, 494.5, 181.0 ],
-									"source" : [ "obj-76", 2 ]
+									"source" : [ "obj-76", 0 ]
 								}
 
 							}
@@ -5276,7 +4927,7 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-84", 0 ],
-									"source" : [ "obj-81", 2 ]
+									"source" : [ "obj-81", 1 ]
 								}
 
 							}
@@ -5290,7 +4941,7 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-58", 1 ],
-									"midpoints" : [ 612.5, 366.0, 420.5, 366.0 ],
+									"midpoints" : [ 638.5, 371.0, 494.5, 371.0 ],
 									"source" : [ "obj-84", 0 ]
 								}
 
@@ -5320,13 +4971,13 @@
 								"name" : "max6message",
 								"default" : 								{
 									"bgfillcolor" : 									{
-										"type" : "gradient",
+										"angle" : 270.0,
+										"autogradient" : 0,
+										"color" : [ 0.290196, 0.309804, 0.301961, 1.0 ],
 										"color1" : [ 0.866667, 0.866667, 0.866667, 1.0 ],
 										"color2" : [ 0.788235, 0.788235, 0.788235, 1.0 ],
-										"color" : [ 0.290196, 0.309804, 0.301961, 1.0 ],
-										"angle" : 270.0,
 										"proportion" : 0.39,
-										"autogradient" : 0
+										"type" : "gradient"
 									}
 ,
 									"textcolor_inverse" : [ 0.0, 0.0, 0.0, 1.0 ]
@@ -5361,34 +5012,6 @@
 			}
  ],
 		"lines" : [  ],
-		"dependency_cache" : [ 			{
-				"name" : "fluid.libmanipulation.mxo",
-				"type" : "iLaX"
-			}
-, 			{
-				"name" : "fluid.list2buf.mxo",
-				"type" : "iLaX"
-			}
-, 			{
-				"name" : "fluid.plotter.js",
-				"bootpath" : "~/dev/flucoma/max/jsui",
-				"patcherrelativepath" : "../jsui",
-				"type" : "TEXT",
-				"implicit" : 1
-			}
-, 			{
-				"name" : "helpdetails.js",
-				"bootpath" : "C74:/help/resources",
-				"type" : "TEXT",
-				"implicit" : 1
-			}
-, 			{
-				"name" : "thru.maxpat",
-				"bootpath" : "C74:/patchers/m4l/Pluggo for Live resources/patches",
-				"type" : "JSON",
-				"implicit" : 1
-			}
- ],
 		"autosave" : 0,
 		"styles" : [ 			{
 				"name" : "max6box",
@@ -5414,13 +5037,13 @@
 				"name" : "max6message",
 				"default" : 				{
 					"bgfillcolor" : 					{
-						"type" : "gradient",
+						"angle" : 270.0,
+						"autogradient" : 0,
+						"color" : [ 0.290196, 0.309804, 0.301961, 1.0 ],
 						"color1" : [ 0.866667, 0.866667, 0.866667, 1.0 ],
 						"color2" : [ 0.788235, 0.788235, 0.788235, 1.0 ],
-						"color" : [ 0.290196, 0.309804, 0.301961, 1.0 ],
-						"angle" : 270.0,
 						"proportion" : 0.39,
-						"autogradient" : 0
+						"type" : "gradient"
 					}
 ,
 					"textcolor_inverse" : [ 0.0, 0.0, 0.0, 1.0 ]

--- a/help/fluid.umap~.maxhelp
+++ b/help/fluid.umap~.maxhelp
@@ -3,8 +3,8 @@
 		"fileversion" : 1,
 		"appversion" : 		{
 			"major" : 8,
-			"minor" : 2,
-			"revision" : 2,
+			"minor" : 3,
+			"revision" : 0,
 			"architecture" : "x64",
 			"modernui" : 1
 		}
@@ -50,8 +50,8 @@
 						"fileversion" : 1,
 						"appversion" : 						{
 							"major" : 8,
-							"minor" : 2,
-							"revision" : 2,
+							"minor" : 3,
+							"revision" : 0,
 							"architecture" : "x64",
 							"modernui" : 1
 						}
@@ -88,22 +88,14 @@
 						"assistshowspatchername" : 0,
 						"boxes" : [ 							{
 								"box" : 								{
-									"args" : [ "umap" ],
-									"bgmode" : 0,
-									"border" : 0,
-									"clickthrough" : 0,
-									"enablehscroll" : 0,
-									"enablevscroll" : 0,
-									"id" : "obj-8",
-									"lockeddragscroll" : 0,
-									"lockedsize" : 0,
-									"maxclass" : "bpatcher",
-									"name" : "fluid.learn.maxpat",
-									"numinlets" : 0,
+									"id" : "obj-3",
+									"maxclass" : "comment",
+									"numinlets" : 1,
 									"numoutlets" : 0,
-									"offset" : [ 0.0, 0.0 ],
-									"patching_rect" : [ 600.0, 10.0, 220.0, 110.0 ],
-									"viewvisibility" : 1
+									"patching_rect" : [ 10.0, 62.0, 614.0, 21.0 ],
+									"presentation_linecount" : 2,
+									"text" : "Adjusting the parameters to affect the \"embedding\" or \"projection\" of data into a lower dimensional space.",
+									"textcolor" : [ 0.501960784313725, 0.501960784313725, 0.501960784313725, 1.0 ]
 								}
 
 							}
@@ -119,7 +111,7 @@
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
 									"parameter_enable" : 0,
-									"patching_rect" : [ 10.0, 10.0, 580.0, 120.0 ]
+									"patching_rect" : [ 10.0, 10.0, 260.0, 50.0 ]
 								}
 
 							}
@@ -130,7 +122,7 @@
 									"maxclass" : "comment",
 									"numinlets" : 1,
 									"numoutlets" : 0,
-									"patching_rect" : [ 650.0, 167.0, 316.0, 486.0 ],
+									"patching_rect" : [ 660.0, 127.0, 320.0, 486.0 ],
 									"text" : "The UMAP algorithm can be nudged to favour the global or local structure of the original data. In essence, this is about whether or not you care about the overall shape of the data, or smaller clusters of points when it is reduced.\n\nThe numneighbours attribute dictates how many points from the original data are considered together when it is determining a transform for the data. These are related to the size of your data. For example, imagine that you have a dataset with 100 points and wanted the whole space to be considered as \"one thing\", setting numneighbours to 100 might be an interesting place to start.\n\nThe minimum distance attribute dictates how close points can be represented in the output dataset. Small values tending towards 0 let UMAP pack the points in tightly while larger values cause the data to be more spread out.\n\nMusically speaking, this decision making will be bound up in lots of different attentions, like what kind of sounds are being analysed and how those sounds will be used in conjunction with the UMAP representation. If you want tight perceptually meaningful clusters then lowering the number of neighbours (relative to your total dataset) and increasing the minimum distance could be a tool for creating more stark separations between points. Likewise, lowering the mindist and increasing the numneighbours might create a flatter and more spread out space for exploring more widely.",
 									"textcolor" : [ 0.501960784313725, 0.501960784313725, 0.501960784313725, 1.0 ]
 								}
@@ -149,7 +141,7 @@
 									"numoutlets" : 3,
 									"outlettype" : [ "", "", "int" ],
 									"parameter_enable" : 0,
-									"patching_rect" : [ 620.0, 191.5, 20.0, 20.0 ],
+									"patching_rect" : [ 630.0, 151.5, 20.0, 20.0 ],
 									"rounded" : 60.0,
 									"text" : "1",
 									"textcolor" : [ 0.34902, 0.34902, 0.34902, 1.0 ]
@@ -164,7 +156,8 @@
 									"numinlets" : 1,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 120.0, 220.0, 150.0, 23.0 ],
+									"parameter_enable" : 0,
+									"patching_rect" : [ 130.0, 180.0, 150.0, 23.0 ],
 									"text_width" : 82.0
 								}
 
@@ -177,20 +170,9 @@
 									"numinlets" : 1,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 70.0, 190.0, 200.0, 23.0 ],
+									"parameter_enable" : 0,
+									"patching_rect" : [ 80.0, 150.0, 200.0, 23.0 ],
 									"text_width" : 132.0
-								}
-
-							}
-, 							{
-								"box" : 								{
-									"id" : "obj-1",
-									"maxclass" : "newobj",
-									"numinlets" : 1,
-									"numoutlets" : 1,
-									"outlettype" : [ "" ],
-									"patching_rect" : [ 437.0, 277.0, 171.0, 23.0 ],
-									"text" : "loadmess pointsizescale 0.5"
 								}
 
 							}
@@ -205,8 +187,8 @@
 										"fileversion" : 1,
 										"appversion" : 										{
 											"major" : 8,
-											"minor" : 2,
-											"revision" : 2,
+											"minor" : 3,
+											"revision" : 0,
 											"architecture" : "x64",
 											"modernui" : 1
 										}
@@ -271,7 +253,7 @@
 													"numinlets" : 2,
 													"numoutlets" : 2,
 													"outlettype" : [ "", "" ],
-													"patching_rect" : [ 271.0, 155.0, 92.0, 22.0 ],
+													"patching_rect" : [ 14.0, 155.0, 92.0, 22.0 ],
 													"text" : "route knearest"
 												}
 
@@ -281,8 +263,8 @@
 													"id" : "obj-13",
 													"maxclass" : "newobj",
 													"numinlets" : 1,
-													"numoutlets" : 3,
-													"outlettype" : [ "bang", "float", "" ],
+													"numoutlets" : 2,
+													"outlettype" : [ "", "" ],
 													"patching_rect" : [ 14.0, 121.0, 276.0, 22.0 ],
 													"text" : "fluid.kdtree~ help.umap.2.tree @numneighbours 1"
 												}
@@ -309,7 +291,7 @@
 													"maxclass" : "outlet",
 													"numinlets" : 1,
 													"numoutlets" : 0,
-													"patching_rect" : [ 271.0, 198.0, 30.0, 30.0 ]
+													"patching_rect" : [ 14.0, 198.0, 30.0, 30.0 ]
 												}
 
 											}
@@ -324,7 +306,7 @@
 , 											{
 												"patchline" : 												{
 													"destination" : [ "obj-10", 0 ],
-													"source" : [ "obj-13", 2 ]
+													"source" : [ "obj-13", 0 ]
 												}
 
 											}
@@ -353,7 +335,7 @@
  ]
 									}
 ,
-									"patching_rect" : [ 186.0, 629.0, 107.0, 23.0 ],
+									"patching_rect" : [ 20.0, 560.0, 107.0, 23.0 ],
 									"saved_object_attributes" : 									{
 										"description" : "",
 										"digest" : "",
@@ -372,7 +354,7 @@
 									"maxclass" : "ezdac~",
 									"numinlets" : 2,
 									"numoutlets" : 0,
-									"patching_rect" : [ 10.0, 700.0, 45.0, 45.0 ]
+									"patching_rect" : [ 140.0, 670.0, 45.0, 45.0 ]
 								}
 
 							}
@@ -396,8 +378,8 @@
 										"fileversion" : 1,
 										"appversion" : 										{
 											"major" : 8,
-											"minor" : 2,
-											"revision" : 2,
+											"minor" : 3,
+											"revision" : 0,
 											"architecture" : "x64",
 											"modernui" : 1
 										}
@@ -467,8 +449,8 @@
 														"fileversion" : 1,
 														"appversion" : 														{
 															"major" : 8,
-															"minor" : 2,
-															"revision" : 2,
+															"minor" : 3,
+															"revision" : 0,
 															"architecture" : "x64",
 															"modernui" : 1
 														}
@@ -706,8 +688,8 @@
 														"fileversion" : 1,
 														"appversion" : 														{
 															"major" : 8,
-															"minor" : 2,
-															"revision" : 2,
+															"minor" : 3,
+															"revision" : 0,
 															"architecture" : "x64",
 															"modernui" : 1
 														}
@@ -973,13 +955,13 @@
 												"name" : "max6message",
 												"default" : 												{
 													"bgfillcolor" : 													{
-														"type" : "gradient",
+														"angle" : 270.0,
+														"autogradient" : 0,
+														"color" : [ 0.290196, 0.309804, 0.301961, 1.0 ],
 														"color1" : [ 0.866667, 0.866667, 0.866667, 1.0 ],
 														"color2" : [ 0.788235, 0.788235, 0.788235, 1.0 ],
-														"color" : [ 0.290196, 0.309804, 0.301961, 1.0 ],
-														"angle" : 270.0,
 														"proportion" : 0.39,
-														"autogradient" : 0
+														"type" : "gradient"
 													}
 ,
 													"textcolor_inverse" : [ 0.0, 0.0, 0.0, 1.0 ]
@@ -1000,7 +982,7 @@
  ]
 									}
 ,
-									"patching_rect" : [ 10.0, 629.0, 160.0, 60.0 ],
+									"patching_rect" : [ 140.0, 600.0, 160.0, 60.0 ],
 									"viewvisibility" : 1
 								}
 
@@ -1012,7 +994,7 @@
 									"numinlets" : 1,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 186.0, 679.0, 108.0, 23.0 ],
+									"patching_rect" : [ 20.0, 600.0, 108.0, 23.0 ],
 									"text" : "prepend highlight"
 								}
 
@@ -1025,7 +1007,7 @@
 									"maxclass" : "comment",
 									"numinlets" : 1,
 									"numoutlets" : 0,
-									"patching_rect" : [ 320.0, 167.0, 297.0, 69.0 ],
+									"patching_rect" : [ 330.0, 127.0, 297.0, 69.0 ],
 									"text" : "Reduce the dataset from the first tab with 140 values per identifier. Experiment with the numneighbours and mindist values to see how it affects the characteristics of the output."
 								}
 
@@ -1036,9 +1018,9 @@
 									"id" : "obj-31",
 									"maxclass" : "newobj",
 									"numinlets" : 1,
-									"numoutlets" : 3,
-									"outlettype" : [ "bang", "float", "" ],
-									"patching_rect" : [ 212.0, 277.0, 177.0, 23.0 ],
+									"numoutlets" : 2,
+									"outlettype" : [ "", "" ],
+									"patching_rect" : [ 222.0, 237.0, 177.0, 23.0 ],
 									"text" : "fluid.dataset~ help.umap.2.dr"
 								}
 
@@ -1049,9 +1031,9 @@
 									"id" : "obj-22",
 									"maxclass" : "newobj",
 									"numinlets" : 1,
-									"numoutlets" : 3,
-									"outlettype" : [ "bang", "float", "" ],
-									"patching_rect" : [ 10.0, 277.0, 195.0, 23.0 ],
+									"numoutlets" : 2,
+									"outlettype" : [ "", "" ],
+									"patching_rect" : [ 20.0, 237.0, 195.0, 23.0 ],
 									"text" : "fluid.umap~ @numdimensions 2"
 								}
 
@@ -1067,14 +1049,14 @@
 										"fileversion" : 1,
 										"appversion" : 										{
 											"major" : 8,
-											"minor" : 2,
-											"revision" : 2,
+											"minor" : 3,
+											"revision" : 0,
 											"architecture" : "x64",
 											"modernui" : 1
 										}
 ,
 										"classnamespace" : "box",
-										"rect" : [ 84.0, 131.0, 734.0, 455.0 ],
+										"rect" : [ 84.0, 131.0, 678.0, 402.0 ],
 										"bglocked" : 0,
 										"openinpresentation" : 0,
 										"default_fontsize" : 12.0,
@@ -1109,7 +1091,7 @@
 													"maxclass" : "comment",
 													"numinlets" : 1,
 													"numoutlets" : 0,
-													"patching_rect" : [ 557.0, 306.0, 152.0, 60.0 ],
+													"patching_rect" : [ 483.0, 278.0, 152.0, 60.0 ],
 													"text" : "fit a kdtree so we can use our mouse to navgiate around the fluid.umap~ outputs in the fluid.plotter.",
 													"textcolor" : [ 0.501960784313725, 0.501960784313725, 0.501960784313725, 1.0 ]
 												}
@@ -1135,7 +1117,7 @@
 													"numinlets" : 2,
 													"numoutlets" : 1,
 													"outlettype" : [ "" ],
-													"patching_rect" : [ 373.0, 293.0, 129.0, 22.0 ],
+													"patching_rect" : [ 299.0, 265.0, 129.0, 22.0 ],
 													"text" : "fit help.umap.2.drnorm"
 												}
 
@@ -1145,9 +1127,9 @@
 													"id" : "obj-3",
 													"maxclass" : "newobj",
 													"numinlets" : 1,
-													"numoutlets" : 3,
-													"outlettype" : [ "bang", "float", "" ],
-													"patching_rect" : [ 373.0, 355.0, 168.0, 22.0 ],
+													"numoutlets" : 2,
+													"outlettype" : [ "", "" ],
+													"patching_rect" : [ 299.0, 305.0, 168.0, 22.0 ],
 													"text" : "fluid.kdtree~ help.umap.2.tree"
 												}
 
@@ -1157,8 +1139,8 @@
 													"id" : "obj-42",
 													"maxclass" : "newobj",
 													"numinlets" : 1,
-													"numoutlets" : 3,
-													"outlettype" : [ "bang", "float", "" ],
+													"numoutlets" : 2,
+													"outlettype" : [ "", "" ],
 													"patching_rect" : [ 120.0, 121.0, 191.0, 22.0 ],
 													"text" : "fluid.dataset~ help.umap.2.drnorm"
 												}
@@ -1171,7 +1153,7 @@
 													"numinlets" : 2,
 													"numoutlets" : 2,
 													"outlettype" : [ "", "" ],
-													"patching_rect" : [ 263.0, 355.0, 69.0, 22.0 ],
+													"patching_rect" : [ 189.0, 305.0, 69.0, 22.0 ],
 													"text" : "route dump"
 												}
 
@@ -1183,7 +1165,7 @@
 													"numinlets" : 1,
 													"numoutlets" : 2,
 													"outlettype" : [ "dump", "bang" ],
-													"patching_rect" : [ 91.0, 237.0, 55.0, 22.0 ],
+													"patching_rect" : [ 17.0, 209.0, 55.0, 22.0 ],
 													"text" : "t dump b"
 												}
 
@@ -1195,7 +1177,7 @@
 													"numinlets" : 2,
 													"numoutlets" : 2,
 													"outlettype" : [ "", "" ],
-													"patching_rect" : [ 91.0, 192.0, 99.0, 22.0 ],
+													"patching_rect" : [ 17.0, 164.0, 99.0, 22.0 ],
 													"text" : "route fittransform"
 												}
 
@@ -1205,9 +1187,9 @@
 													"id" : "obj-35",
 													"maxclass" : "newobj",
 													"numinlets" : 1,
-													"numoutlets" : 3,
-													"outlettype" : [ "bang", "float", "" ],
-													"patching_rect" : [ 91.0, 293.0, 191.0, 22.0 ],
+													"numoutlets" : 2,
+													"outlettype" : [ "", "" ],
+													"patching_rect" : [ 17.0, 265.0, 191.0, 22.0 ],
 													"text" : "fluid.dataset~ help.umap.2.drnorm"
 												}
 
@@ -1229,8 +1211,8 @@
 													"id" : "obj-33",
 													"maxclass" : "newobj",
 													"numinlets" : 1,
-													"numoutlets" : 3,
-													"outlettype" : [ "bang", "float", "" ],
+													"numoutlets" : 2,
+													"outlettype" : [ "", "" ],
 													"patching_rect" : [ 17.0, 121.0, 93.0, 22.0 ],
 													"text" : "fluid.normalize~"
 												}
@@ -1257,7 +1239,7 @@
 													"maxclass" : "outlet",
 													"numinlets" : 1,
 													"numoutlets" : 0,
-													"patching_rect" : [ 263.0, 414.0, 30.0, 30.0 ]
+													"patching_rect" : [ 189.0, 342.0, 30.0, 30.0 ]
 												}
 
 											}
@@ -1273,7 +1255,7 @@
 													"mode" : 0,
 													"numinlets" : 1,
 													"numoutlets" : 0,
-													"patching_rect" : [ 362.0, 285.0, 193.0, 102.0 ],
+													"patching_rect" : [ 288.0, 257.0, 193.0, 86.0 ],
 													"proportion" : 0.5
 												}
 
@@ -1299,7 +1281,7 @@
 										"lines" : [ 											{
 												"patchline" : 												{
 													"destination" : [ "obj-38", 0 ],
-													"source" : [ "obj-33", 2 ]
+													"source" : [ "obj-33", 0 ]
 												}
 
 											}
@@ -1313,7 +1295,7 @@
 , 											{
 												"patchline" : 												{
 													"destination" : [ "obj-41", 0 ],
-													"source" : [ "obj-35", 2 ]
+													"source" : [ "obj-35", 1 ]
 												}
 
 											}
@@ -1334,7 +1316,7 @@
 , 											{
 												"patchline" : 												{
 													"destination" : [ "obj-5", 0 ],
-													"midpoints" : [ 136.5, 279.0, 382.5, 279.0 ],
+													"midpoints" : [ 62.5, 251.0, 308.5, 251.0 ],
 													"source" : [ "obj-40", 1 ]
 												}
 
@@ -1363,7 +1345,7 @@
  ]
 									}
 ,
-									"patching_rect" : [ 186.0, 317.0, 220.0, 23.0 ],
+									"patching_rect" : [ 20.0, 270.0, 220.0, 23.0 ],
 									"saved_object_attributes" : 									{
 										"description" : "",
 										"digest" : "",
@@ -1382,7 +1364,7 @@
 									"numinlets" : 2,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 10.0, 150.0, 290.0, 23.0 ],
+									"patching_rect" : [ 20.0, 110.0, 290.0, 23.0 ],
 									"text" : "fittransform help.umap.1.analysis help.umap.2.dr"
 								}
 
@@ -1391,12 +1373,13 @@
 								"box" : 								{
 									"filename" : "fluid.plotter",
 									"id" : "obj-19",
+									"jsarguments" : [ 0.5 ],
 									"maxclass" : "jsui",
 									"numinlets" : 2,
 									"numoutlets" : 2,
 									"outlettype" : [ "", "" ],
 									"parameter_enable" : 0,
-									"patching_rect" : [ 186.0, 349.0, 270.0, 270.0 ]
+									"patching_rect" : [ 20.0, 302.0, 240.0, 240.0 ]
 								}
 
 							}
@@ -1412,7 +1395,7 @@
 									"mode" : 0,
 									"numinlets" : 1,
 									"numoutlets" : 0,
-									"patching_rect" : [ 4.0, 143.0, 306.0, 117.0 ],
+									"patching_rect" : [ 14.0, 103.0, 306.0, 117.0 ],
 									"proportion" : 0.5
 								}
 
@@ -1420,15 +1403,8 @@
  ],
 						"lines" : [ 							{
 								"patchline" : 								{
-									"destination" : [ "obj-19", 1 ],
-									"midpoints" : [ 446.5, 303.0, 446.5, 303.0 ],
-									"source" : [ "obj-1", 0 ]
-								}
-
-							}
-, 							{
-								"patchline" : 								{
 									"destination" : [ "obj-56", 0 ],
+									"midpoints" : [ 29.5, 585.0, 29.5, 585.0 ],
 									"source" : [ "obj-19", 0 ]
 								}
 
@@ -1436,14 +1412,14 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-45", 0 ],
-									"source" : [ "obj-22", 2 ]
+									"source" : [ "obj-22", 0 ]
 								}
 
 							}
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-22", 0 ],
-									"midpoints" : [ 19.5, 174.0, 19.5, 174.0 ],
+									"midpoints" : [ 29.5, 134.0, 29.5, 134.0 ],
 									"source" : [ "obj-30", 0 ]
 								}
 
@@ -1451,7 +1427,7 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-19", 1 ],
-									"midpoints" : [ 195.5, 714.0, 468.0, 714.0, 468.0, 345.0, 446.5, 345.0 ],
+									"midpoints" : [ 29.5, 730.0, 314.0, 730.0, 314.0, 291.0, 250.5, 291.0 ],
 									"source" : [ "obj-35", 0 ]
 								}
 
@@ -1482,7 +1458,7 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-35", 0 ],
-									"midpoints" : [ 195.5, 653.0, 195.5, 653.0 ],
+									"midpoints" : [ 29.5, 584.0, 29.5, 584.0 ],
 									"order" : 0,
 									"source" : [ "obj-56", 0 ]
 								}
@@ -1491,7 +1467,7 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-48", 0 ],
-									"midpoints" : [ 195.5, 654.0, 175.0, 654.0, 175.0, 615.0, 19.5, 615.0 ],
+									"midpoints" : [ 29.5, 591.0, 149.5, 591.0 ],
 									"order" : 1,
 									"source" : [ "obj-56", 0 ]
 								}
@@ -1500,7 +1476,7 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-22", 0 ],
-									"midpoints" : [ 79.5, 264.0, 19.5, 264.0 ],
+									"midpoints" : [ 89.5, 224.0, 29.5, 224.0 ],
 									"source" : [ "obj-7", 0 ]
 								}
 
@@ -1508,7 +1484,7 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-22", 0 ],
-									"midpoints" : [ 129.5, 264.0, 19.5, 264.0 ],
+									"midpoints" : [ 139.5, 224.0, 29.5, 224.0 ],
 									"source" : [ "obj-9", 0 ]
 								}
 
@@ -1538,13 +1514,13 @@
 								"name" : "max6message",
 								"default" : 								{
 									"bgfillcolor" : 									{
-										"type" : "gradient",
+										"angle" : 270.0,
+										"autogradient" : 0,
+										"color" : [ 0.290196, 0.309804, 0.301961, 1.0 ],
 										"color1" : [ 0.866667, 0.866667, 0.866667, 1.0 ],
 										"color2" : [ 0.788235, 0.788235, 0.788235, 1.0 ],
-										"color" : [ 0.290196, 0.309804, 0.301961, 1.0 ],
-										"angle" : 270.0,
 										"proportion" : 0.39,
-										"autogradient" : 0
+										"type" : "gradient"
 									}
 ,
 									"textcolor_inverse" : [ 0.0, 0.0, 0.0, 1.0 ]
@@ -1589,8 +1565,8 @@
 						"fileversion" : 1,
 						"appversion" : 						{
 							"major" : 8,
-							"minor" : 2,
-							"revision" : 2,
+							"minor" : 3,
+							"revision" : 0,
 							"architecture" : "x64",
 							"modernui" : 1
 						}
@@ -1627,18 +1603,6 @@
 						"assistshowspatchername" : 0,
 						"boxes" : [ 							{
 								"box" : 								{
-									"id" : "obj-1",
-									"maxclass" : "newobj",
-									"numinlets" : 1,
-									"numoutlets" : 1,
-									"outlettype" : [ "" ],
-									"patching_rect" : [ 630.0, 260.0, 171.0, 23.0 ],
-									"text" : "loadmess pointsizescale 0.5"
-								}
-
-							}
-, 							{
-								"box" : 								{
 									"id" : "obj-56",
 									"maxclass" : "newobj",
 									"numinlets" : 1,
@@ -1648,8 +1612,8 @@
 										"fileversion" : 1,
 										"appversion" : 										{
 											"major" : 8,
-											"minor" : 2,
-											"revision" : 2,
+											"minor" : 3,
+											"revision" : 0,
 											"architecture" : "x64",
 											"modernui" : 1
 										}
@@ -1714,7 +1678,7 @@
 													"numinlets" : 2,
 													"numoutlets" : 2,
 													"outlettype" : [ "", "" ],
-													"patching_rect" : [ 292.0, 157.0, 92.0, 22.0 ],
+													"patching_rect" : [ 13.0, 155.0, 92.0, 22.0 ],
 													"text" : "route knearest"
 												}
 
@@ -1724,8 +1688,8 @@
 													"id" : "obj-13",
 													"maxclass" : "newobj",
 													"numinlets" : 1,
-													"numoutlets" : 3,
-													"outlettype" : [ "bang", "float", "" ],
+													"numoutlets" : 2,
+													"outlettype" : [ "", "" ],
 													"patching_rect" : [ 13.0, 122.0, 298.0, 22.0 ],
 													"text" : "fluid.kdtree~ help.umap.1.tree @numneighbours 1"
 												}
@@ -1752,7 +1716,7 @@
 													"maxclass" : "outlet",
 													"numinlets" : 1,
 													"numoutlets" : 0,
-													"patching_rect" : [ 292.0, 192.0, 30.0, 30.0 ]
+													"patching_rect" : [ 13.0, 190.0, 30.0, 30.0 ]
 												}
 
 											}
@@ -1767,7 +1731,7 @@
 , 											{
 												"patchline" : 												{
 													"destination" : [ "obj-10", 0 ],
-													"source" : [ "obj-13", 2 ]
+													"source" : [ "obj-13", 0 ]
 												}
 
 											}
@@ -1796,7 +1760,7 @@
  ]
 									}
 ,
-									"patching_rect" : [ 320.0, 540.0, 107.0, 23.0 ],
+									"patching_rect" : [ 340.0, 540.0, 107.0, 23.0 ],
 									"saved_object_attributes" : 									{
 										"description" : "",
 										"digest" : "",
@@ -1821,7 +1785,7 @@
 									"numoutlets" : 3,
 									"outlettype" : [ "", "", "int" ],
 									"parameter_enable" : 0,
-									"patching_rect" : [ 910.0, 152.5, 20.0, 20.0 ],
+									"patching_rect" : [ 930.0, 152.5, 20.0, 20.0 ],
 									"rounded" : 60.0,
 									"text" : "2",
 									"textcolor" : [ 0.34902, 0.34902, 0.34902, 1.0 ]
@@ -1841,7 +1805,7 @@
 									"numoutlets" : 3,
 									"outlettype" : [ "", "", "int" ],
 									"parameter_enable" : 0,
-									"patching_rect" : [ 218.0, 152.5, 20.0, 20.0 ],
+									"patching_rect" : [ 238.0, 152.5, 20.0, 20.0 ],
 									"rounded" : 60.0,
 									"text" : "1",
 									"textcolor" : [ 0.34902, 0.34902, 0.34902, 1.0 ]
@@ -1855,7 +1819,7 @@
 									"maxclass" : "ezdac~",
 									"numinlets" : 2,
 									"numoutlets" : 0,
-									"patching_rect" : [ 440.0, 661.0, 45.0, 45.0 ]
+									"patching_rect" : [ 460.0, 661.0, 45.0, 45.0 ]
 								}
 
 							}
@@ -1879,8 +1843,8 @@
 										"fileversion" : 1,
 										"appversion" : 										{
 											"major" : 8,
-											"minor" : 2,
-											"revision" : 2,
+											"minor" : 3,
+											"revision" : 0,
 											"architecture" : "x64",
 											"modernui" : 1
 										}
@@ -1950,8 +1914,8 @@
 														"fileversion" : 1,
 														"appversion" : 														{
 															"major" : 8,
-															"minor" : 2,
-															"revision" : 2,
+															"minor" : 3,
+															"revision" : 0,
 															"architecture" : "x64",
 															"modernui" : 1
 														}
@@ -2189,8 +2153,8 @@
 														"fileversion" : 1,
 														"appversion" : 														{
 															"major" : 8,
-															"minor" : 2,
-															"revision" : 2,
+															"minor" : 3,
+															"revision" : 0,
 															"architecture" : "x64",
 															"modernui" : 1
 														}
@@ -2456,13 +2420,13 @@
 												"name" : "max6message",
 												"default" : 												{
 													"bgfillcolor" : 													{
-														"type" : "gradient",
+														"angle" : 270.0,
+														"autogradient" : 0,
+														"color" : [ 0.290196, 0.309804, 0.301961, 1.0 ],
 														"color1" : [ 0.866667, 0.866667, 0.866667, 1.0 ],
 														"color2" : [ 0.788235, 0.788235, 0.788235, 1.0 ],
-														"color" : [ 0.290196, 0.309804, 0.301961, 1.0 ],
-														"angle" : 270.0,
 														"proportion" : 0.39,
-														"autogradient" : 0
+														"type" : "gradient"
 													}
 ,
 													"textcolor_inverse" : [ 0.0, 0.0, 0.0, 1.0 ]
@@ -2483,7 +2447,7 @@
  ]
 									}
 ,
-									"patching_rect" : [ 440.0, 590.0, 160.0, 60.0 ],
+									"patching_rect" : [ 460.0, 590.0, 160.0, 60.0 ],
 									"viewvisibility" : 1
 								}
 
@@ -2495,7 +2459,7 @@
 									"numinlets" : 1,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 320.0, 590.0, 108.0, 23.0 ],
+									"patching_rect" : [ 340.0, 590.0, 108.0, 23.0 ],
 									"text" : "prepend highlight"
 								}
 
@@ -2507,7 +2471,7 @@
 									"maxclass" : "comment",
 									"numinlets" : 1,
 									"numoutlets" : 0,
-									"patching_rect" : [ 611.0, 150.0, 297.0, 25.0 ],
+									"patching_rect" : [ 631.0, 150.0, 297.0, 25.0 ],
 									"text" : "Reduce 26 dimensions to 2 for every identifier"
 								}
 
@@ -2518,9 +2482,9 @@
 									"id" : "obj-31",
 									"maxclass" : "newobj",
 									"numinlets" : 1,
-									"numoutlets" : 3,
-									"outlettype" : [ "bang", "float", "" ],
-									"patching_rect" : [ 522.0, 190.0, 177.0, 23.0 ],
+									"numoutlets" : 2,
+									"outlettype" : [ "", "" ],
+									"patching_rect" : [ 542.0, 190.0, 177.0, 23.0 ],
 									"text" : "fluid.dataset~ help.umap.1.dr"
 								}
 
@@ -2531,9 +2495,9 @@
 									"id" : "obj-22",
 									"maxclass" : "newobj",
 									"numinlets" : 1,
-									"numoutlets" : 3,
-									"outlettype" : [ "bang", "float", "" ],
-									"patching_rect" : [ 320.0, 190.0, 195.0, 23.0 ],
+									"numoutlets" : 2,
+									"outlettype" : [ "", "" ],
+									"patching_rect" : [ 340.0, 190.0, 195.0, 23.0 ],
 									"text" : "fluid.umap~ @numdimensions 2"
 								}
 
@@ -2549,8 +2513,8 @@
 										"fileversion" : 1,
 										"appversion" : 										{
 											"major" : 8,
-											"minor" : 2,
-											"revision" : 2,
+											"minor" : 3,
+											"revision" : 0,
 											"architecture" : "x64",
 											"modernui" : 1
 										}
@@ -2586,12 +2550,24 @@
 										"assistshowspatchername" : 0,
 										"boxes" : [ 											{
 												"box" : 												{
+													"id" : "obj-1",
+													"maxclass" : "newobj",
+													"numinlets" : 2,
+													"numoutlets" : 2,
+													"outlettype" : [ "", "" ],
+													"patching_rect" : [ 17.0, 61.0, 99.0, 22.0 ],
+													"text" : "route fittransform"
+												}
+
+											}
+, 											{
+												"box" : 												{
 													"id" : "obj-10",
 													"linecount" : 4,
 													"maxclass" : "comment",
 													"numinlets" : 1,
 													"numoutlets" : 0,
-													"patching_rect" : [ 557.0, 306.0, 152.0, 60.0 ],
+													"patching_rect" : [ 464.0, 301.0, 152.0, 60.0 ],
 													"text" : "fit a kdtree so we can use our mouse to navgiate around the fluid.umap~ outputs in the fluid.plotter.",
 													"textcolor" : [ 0.501960784313725, 0.501960784313725, 0.501960784313725, 1.0 ]
 												}
@@ -2604,7 +2580,7 @@
 													"maxclass" : "comment",
 													"numinlets" : 1,
 													"numoutlets" : 0,
-													"patching_rect" : [ 340.0, 71.5, 152.0, 60.0 ],
+													"patching_rect" : [ 334.0, 117.5, 155.0, 60.0 ],
 													"text" : "Normalise the fluid.umap~ output because it results in an arbitrary range for the values.",
 													"textcolor" : [ 0.501960784313725, 0.501960784313725, 0.501960784313725, 1.0 ]
 												}
@@ -2617,7 +2593,7 @@
 													"numinlets" : 2,
 													"numoutlets" : 1,
 													"outlettype" : [ "" ],
-													"patching_rect" : [ 373.0, 293.0, 129.0, 22.0 ],
+													"patching_rect" : [ 276.0, 295.0, 129.0, 22.0 ],
 													"text" : "fit help.umap.1.drnorm"
 												}
 
@@ -2627,9 +2603,9 @@
 													"id" : "obj-3",
 													"maxclass" : "newobj",
 													"numinlets" : 1,
-													"numoutlets" : 3,
-													"outlettype" : [ "bang", "float", "" ],
-													"patching_rect" : [ 373.0, 355.0, 168.0, 22.0 ],
+													"numoutlets" : 2,
+													"outlettype" : [ "", "" ],
+													"patching_rect" : [ 276.0, 338.0, 168.0, 22.0 ],
 													"text" : "fluid.kdtree~ help.umap.1.tree"
 												}
 
@@ -2639,9 +2615,9 @@
 													"id" : "obj-42",
 													"maxclass" : "newobj",
 													"numinlets" : 1,
-													"numoutlets" : 3,
-													"outlettype" : [ "bang", "float", "" ],
-													"patching_rect" : [ 120.0, 121.0, 191.0, 22.0 ],
+													"numoutlets" : 2,
+													"outlettype" : [ "", "" ],
+													"patching_rect" : [ 120.0, 155.5, 191.0, 22.0 ],
 													"text" : "fluid.dataset~ help.umap.1.drnorm"
 												}
 
@@ -2653,7 +2629,7 @@
 													"numinlets" : 2,
 													"numoutlets" : 2,
 													"outlettype" : [ "", "" ],
-													"patching_rect" : [ 263.0, 355.0, 69.0, 22.0 ],
+													"patching_rect" : [ 189.0, 338.0, 69.0, 22.0 ],
 													"text" : "route dump"
 												}
 
@@ -2665,7 +2641,7 @@
 													"numinlets" : 1,
 													"numoutlets" : 2,
 													"outlettype" : [ "dump", "bang" ],
-													"patching_rect" : [ 91.0, 237.0, 55.0, 22.0 ],
+													"patching_rect" : [ 17.0, 248.0, 55.0, 22.0 ],
 													"text" : "t dump b"
 												}
 
@@ -2677,7 +2653,7 @@
 													"numinlets" : 2,
 													"numoutlets" : 2,
 													"outlettype" : [ "", "" ],
-													"patching_rect" : [ 91.0, 192.0, 99.0, 22.0 ],
+													"patching_rect" : [ 17.0, 210.0, 99.0, 22.0 ],
 													"text" : "route fittransform"
 												}
 
@@ -2687,9 +2663,9 @@
 													"id" : "obj-35",
 													"maxclass" : "newobj",
 													"numinlets" : 1,
-													"numoutlets" : 3,
-													"outlettype" : [ "bang", "float", "" ],
-													"patching_rect" : [ 91.0, 293.0, 191.0, 22.0 ],
+													"numoutlets" : 2,
+													"outlettype" : [ "", "" ],
+													"patching_rect" : [ 17.0, 295.0, 191.0, 22.0 ],
 													"text" : "fluid.dataset~ help.umap.1.drnorm"
 												}
 
@@ -2701,7 +2677,7 @@
 													"numinlets" : 2,
 													"numoutlets" : 1,
 													"outlettype" : [ "" ],
-													"patching_rect" : [ 17.0, 63.0, 263.0, 22.0 ],
+													"patching_rect" : [ 17.0, 109.0, 263.0, 22.0 ],
 													"text" : "fittransform help.umap.1.dr help.umap.1.drnorm"
 												}
 
@@ -2711,9 +2687,9 @@
 													"id" : "obj-33",
 													"maxclass" : "newobj",
 													"numinlets" : 1,
-													"numoutlets" : 3,
-													"outlettype" : [ "bang", "float", "" ],
-													"patching_rect" : [ 17.0, 121.0, 93.0, 22.0 ],
+													"numoutlets" : 2,
+													"outlettype" : [ "", "" ],
+													"patching_rect" : [ 17.0, 155.5, 93.0, 22.0 ],
 													"text" : "fluid.normalize~"
 												}
 
@@ -2739,7 +2715,7 @@
 													"maxclass" : "outlet",
 													"numinlets" : 1,
 													"numoutlets" : 0,
-													"patching_rect" : [ 263.0, 414.0, 30.0, 30.0 ]
+													"patching_rect" : [ 189.0, 380.0, 30.0, 30.0 ]
 												}
 
 											}
@@ -2755,7 +2731,7 @@
 													"mode" : 0,
 													"numinlets" : 1,
 													"numoutlets" : 0,
-													"patching_rect" : [ 362.0, 285.0, 193.0, 102.0 ],
+													"patching_rect" : [ 265.0, 287.0, 193.0, 88.0 ],
 													"proportion" : 0.5
 												}
 
@@ -2772,7 +2748,7 @@
 													"mode" : 0,
 													"numinlets" : 1,
 													"numoutlets" : 0,
-													"patching_rect" : [ 23.0, 65.0, 324.0, 103.0 ],
+													"patching_rect" : [ 8.0, 96.0, 324.0, 103.0 ],
 													"proportion" : 0.5
 												}
 
@@ -2780,8 +2756,15 @@
  ],
 										"lines" : [ 											{
 												"patchline" : 												{
+													"destination" : [ "obj-34", 0 ],
+													"source" : [ "obj-1", 0 ]
+												}
+
+											}
+, 											{
+												"patchline" : 												{
 													"destination" : [ "obj-38", 0 ],
-													"source" : [ "obj-33", 2 ]
+													"source" : [ "obj-33", 0 ]
 												}
 
 											}
@@ -2795,7 +2778,7 @@
 , 											{
 												"patchline" : 												{
 													"destination" : [ "obj-41", 0 ],
-													"source" : [ "obj-35", 2 ]
+													"source" : [ "obj-35", 1 ]
 												}
 
 											}
@@ -2809,6 +2792,7 @@
 , 											{
 												"patchline" : 												{
 													"destination" : [ "obj-35", 0 ],
+													"midpoints" : [ 26.5, 271.0, 26.5, 271.0 ],
 													"source" : [ "obj-40", 0 ]
 												}
 
@@ -2816,7 +2800,7 @@
 , 											{
 												"patchline" : 												{
 													"destination" : [ "obj-5", 0 ],
-													"midpoints" : [ 136.5, 279.0, 382.5, 279.0 ],
+													"midpoints" : [ 62.5, 280.0, 285.5, 280.0 ],
 													"source" : [ "obj-40", 1 ]
 												}
 
@@ -2830,7 +2814,7 @@
 											}
 , 											{
 												"patchline" : 												{
-													"destination" : [ "obj-34", 0 ],
+													"destination" : [ "obj-1", 0 ],
 													"source" : [ "obj-43", 0 ]
 												}
 
@@ -2845,7 +2829,7 @@
  ]
 									}
 ,
-									"patching_rect" : [ 320.0, 228.0, 220.0, 23.0 ],
+									"patching_rect" : [ 340.0, 228.0, 220.0, 23.0 ],
 									"saved_object_attributes" : 									{
 										"description" : "",
 										"digest" : "",
@@ -2864,7 +2848,7 @@
 									"numinlets" : 2,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 320.0, 150.0, 290.0, 23.0 ],
+									"patching_rect" : [ 340.0, 150.0, 290.0, 23.0 ],
 									"text" : "fittransform help.umap.1.analysis help.umap.1.dr"
 								}
 
@@ -2876,7 +2860,7 @@
 									"maxclass" : "comment",
 									"numinlets" : 1,
 									"numoutlets" : 0,
-									"patching_rect" : [ 10.0, 430.0, 270.0, 239.0 ],
+									"patching_rect" : [ 30.0, 430.0, 270.0, 239.0 ],
 									"text" : "Each identifier is a segment of sound from a corpus of all the media files in the Fluid Corpus Manipulation Toolkit package.\n\nFor each identifier, there are 140 values derived from MFCC analysis.We're going to use fluid.umap~ to reduce the data, so that each identifier only has two variables. \n\nIdeally, these new values that fluid.umap~ calculates will be able to preserve much of the intrinsic characteristics of the higher dimension data and in theory, we should get a two dimensional representation that has some kind of perceptually meaningful shape to it.",
 									"textcolor" : [ 0.501960784313725, 0.501960784313725, 0.501960784313725, 1.0 ]
 								}
@@ -2889,7 +2873,7 @@
 									"maxclass" : "comment",
 									"numinlets" : 1,
 									"numoutlets" : 0,
-									"patching_rect" : [ 36.0, 150.0, 180.0, 25.0 ],
+									"patching_rect" : [ 56.0, 150.0, 180.0, 25.0 ],
 									"text" : "Start by loading some data"
 								}
 
@@ -2900,7 +2884,7 @@
 									"maxclass" : "dict.view",
 									"numinlets" : 1,
 									"numoutlets" : 0,
-									"patching_rect" : [ 10.0, 228.0, 270.0, 192.0 ]
+									"patching_rect" : [ 30.0, 228.0, 270.0, 192.0 ]
 								}
 
 							}
@@ -2912,7 +2896,7 @@
 									"numoutlets" : 1,
 									"outlettype" : [ "bang" ],
 									"parameter_enable" : 0,
-									"patching_rect" : [ 10.0, 150.0, 24.0, 24.0 ]
+									"patching_rect" : [ 30.0, 150.0, 24.0, 24.0 ]
 								}
 
 							}
@@ -2920,12 +2904,13 @@
 								"box" : 								{
 									"filename" : "fluid.plotter",
 									"id" : "obj-19",
+									"jsarguments" : [ 0.5 ],
 									"maxclass" : "jsui",
 									"numinlets" : 2,
 									"numoutlets" : 2,
 									"outlettype" : [ "", "" ],
 									"parameter_enable" : 0,
-									"patching_rect" : [ 320.0, 260.0, 270.0, 270.0 ]
+									"patching_rect" : [ 340.0, 260.0, 270.0, 270.0 ]
 								}
 
 							}
@@ -2940,8 +2925,8 @@
 										"fileversion" : 1,
 										"appversion" : 										{
 											"major" : 8,
-											"minor" : 2,
-											"revision" : 2,
+											"minor" : 3,
+											"revision" : 0,
 											"architecture" : "x64",
 											"modernui" : 1
 										}
@@ -2998,8 +2983,8 @@
 														"fileversion" : 1,
 														"appversion" : 														{
 															"major" : 8,
-															"minor" : 2,
-															"revision" : 2,
+															"minor" : 3,
+															"revision" : 0,
 															"architecture" : "x64",
 															"modernui" : 1
 														}
@@ -3052,7 +3037,7 @@
 																	"numinlets" : 3,
 																	"numoutlets" : 2,
 																	"outlettype" : [ "", "" ],
-																	"patching_rect" : [ 201.0, 380.0, 181.0, 22.0 ],
+																	"patching_rect" : [ 55.0, 424.0, 181.0, 22.0 ],
 																	"text" : "combine s /media/ s @triggers 2"
 																}
 
@@ -3064,7 +3049,7 @@
 																	"numinlets" : 2,
 																	"numoutlets" : 2,
 																	"outlettype" : [ "", "" ],
-																	"patching_rect" : [ 189.5, 434.0, 51.0, 22.0 ],
+																	"patching_rect" : [ 55.0, 458.0, 51.0, 22.0 ],
 																	"text" : "zl.group"
 																}
 
@@ -3076,7 +3061,7 @@
 																	"numinlets" : 2,
 																	"numoutlets" : 2,
 																	"outlettype" : [ "", "" ],
-																	"patching_rect" : [ 363.0, 312.0, 81.0, 22.0 ],
+																	"patching_rect" : [ 217.0, 392.0, 81.0, 22.0 ],
 																	"text" : "route getlabel"
 																}
 
@@ -3088,7 +3073,7 @@
 																	"numinlets" : 2,
 																	"numoutlets" : 1,
 																	"outlettype" : [ "" ],
-																	"patching_rect" : [ 202.0, 262.0, 67.0, 22.0 ],
+																	"patching_rect" : [ 217.0, 328.0, 67.0, 22.0 ],
 																	"text" : "getlabel $1"
 																}
 
@@ -3100,7 +3085,7 @@
 																	"numinlets" : 2,
 																	"numoutlets" : 3,
 																	"outlettype" : [ "bang", "bang", "int" ],
-																	"patching_rect" : [ 177.0, 238.0, 44.0, 22.0 ],
+																	"patching_rect" : [ 16.0, 280.0, 97.0, 22.0 ],
 																	"text" : "uzi 0 0"
 																}
 
@@ -3110,9 +3095,9 @@
 																	"id" : "obj-17",
 																	"maxclass" : "newobj",
 																	"numinlets" : 1,
-																	"numoutlets" : 3,
-																	"outlettype" : [ "bang", "float", "" ],
-																	"patching_rect" : [ 202.0, 286.0, 180.0, 22.0 ],
+																	"numoutlets" : 2,
+																	"outlettype" : [ "", "" ],
+																	"patching_rect" : [ 217.0, 359.0, 180.0, 22.0 ],
 																	"text" : "fluid.labelset~ kdtree.files.loader"
 																}
 
@@ -3124,7 +3109,7 @@
 																	"numinlets" : 2,
 																	"numoutlets" : 2,
 																	"outlettype" : [ "", "" ],
-																	"patching_rect" : [ 177.0, 211.0, 61.0, 22.0 ],
+																	"patching_rect" : [ 16.0, 248.0, 61.0, 22.0 ],
 																	"text" : "route size"
 																}
 
@@ -3134,9 +3119,9 @@
 																	"id" : "obj-10",
 																	"maxclass" : "newobj",
 																	"numinlets" : 1,
-																	"numoutlets" : 3,
-																	"outlettype" : [ "bang", "float", "" ],
-																	"patching_rect" : [ 16.0, 183.0, 180.0, 22.0 ],
+																	"numoutlets" : 2,
+																	"outlettype" : [ "", "" ],
+																	"patching_rect" : [ 16.0, 211.0, 180.0, 22.0 ],
 																	"text" : "fluid.labelset~ kdtree.files.loader"
 																}
 
@@ -3148,7 +3133,7 @@
 																	"numinlets" : 2,
 																	"numoutlets" : 1,
 																	"outlettype" : [ "" ],
-																	"patching_rect" : [ 16.0, 154.0, 247.0, 22.0 ],
+																	"patching_rect" : [ 16.0, 167.0, 247.0, 22.0 ],
 																	"text" : "read $1/misc/flucoma_corpus_files.json, size"
 																}
 
@@ -3160,7 +3145,7 @@
 																	"numinlets" : 2,
 																	"numoutlets" : 2,
 																	"outlettype" : [ "", "" ],
-																	"patching_rect" : [ 16.0, 71.0, 73.0, 22.0 ],
+																	"patching_rect" : [ 16.0, 59.0, 73.0, 22.0 ],
 																	"text" : "combine s .."
 																}
 
@@ -3172,7 +3157,7 @@
 																	"numinlets" : 1,
 																	"numoutlets" : 2,
 																	"outlettype" : [ "", "int" ],
-																	"patching_rect" : [ 16.0, 98.0, 75.0, 22.0 ],
+																	"patching_rect" : [ 16.0, 92.0, 75.0, 22.0 ],
 																	"text" : "conformpath"
 																}
 
@@ -3198,7 +3183,7 @@
 																	"maxclass" : "outlet",
 																	"numinlets" : 1,
 																	"numoutlets" : 0,
-																	"patching_rect" : [ 189.5, 469.625, 30.0, 30.0 ]
+																	"patching_rect" : [ 55.0, 495.625, 30.0, 30.0 ]
 																}
 
 															}
@@ -3206,7 +3191,7 @@
 														"lines" : [ 															{
 																"patchline" : 																{
 																	"destination" : [ "obj-15", 0 ],
-																	"source" : [ "obj-10", 2 ]
+																	"source" : [ "obj-10", 0 ]
 																}
 
 															}
@@ -3234,13 +3219,15 @@
 , 															{
 																"patchline" : 																{
 																	"destination" : [ "obj-21", 0 ],
-																	"source" : [ "obj-17", 2 ]
+																	"midpoints" : [ 226.5, 374.0, 226.5, 374.0 ],
+																	"source" : [ "obj-17", 0 ]
 																}
 
 															}
 , 															{
 																"patchline" : 																{
 																	"destination" : [ "obj-20", 0 ],
+																	"midpoints" : [ 103.5, 314.0, 226.5, 314.0 ],
 																	"source" : [ "obj-18", 2 ]
 																}
 
@@ -3248,6 +3235,7 @@
 , 															{
 																"patchline" : 																{
 																	"destination" : [ "obj-22", 0 ],
+																	"midpoints" : [ 64.5, 409.0, 40.0, 409.0, 40.0, 454.0, 64.5, 454.0 ],
 																	"source" : [ "obj-18", 1 ]
 																}
 
@@ -3290,7 +3278,7 @@
 , 															{
 																"patchline" : 																{
 																	"destination" : [ "obj-29", 0 ],
-																	"midpoints" : [ 446.0, 349.5, 210.5, 349.5 ],
+																	"midpoints" : [ 446.0, 315.0, 64.5, 315.0 ],
 																	"source" : [ "obj-30", 1 ]
 																}
 
@@ -3335,14 +3323,14 @@
 														"fileversion" : 1,
 														"appversion" : 														{
 															"major" : 8,
-															"minor" : 2,
-															"revision" : 2,
+															"minor" : 3,
+															"revision" : 0,
 															"architecture" : "x64",
 															"modernui" : 1
 														}
 ,
 														"classnamespace" : "box",
-														"rect" : [ 84.0, 131.0, 640.0, 480.0 ],
+														"rect" : [ 1059.0, 459.0, 640.0, 480.0 ],
 														"bglocked" : 0,
 														"openinpresentation" : 0,
 														"default_fontsize" : 12.0,
@@ -3372,12 +3360,24 @@
 														"assistshowspatchername" : 0,
 														"boxes" : [ 															{
 																"box" : 																{
+																	"id" : "obj-3",
+																	"maxclass" : "newobj",
+																	"numinlets" : 1,
+																	"numoutlets" : 1,
+																	"outlettype" : [ "bang" ],
+																	"patching_rect" : [ 15.0, 152.0, 22.0, 22.0 ],
+																	"text" : "t b"
+																}
+
+															}
+, 															{
+																"box" : 																{
 																	"id" : "obj-16",
 																	"maxclass" : "message",
 																	"numinlets" : 2,
 																	"numoutlets" : 1,
 																	"outlettype" : [ "" ],
-																	"patching_rect" : [ 15.0, 76.0, 201.0, 22.0 ],
+																	"patching_rect" : [ 15.0, 66.0, 201.0, 22.0 ],
 																	"text" : "startchan 0, bang, startchan 1, bang"
 																}
 
@@ -3387,9 +3387,9 @@
 																	"id" : "obj-13",
 																	"maxclass" : "newobj",
 																	"numinlets" : 1,
-																	"numoutlets" : 3,
-																	"outlettype" : [ "bang", "float", "" ],
-																	"patching_rect" : [ 15.0, 118.0, 581.0, 22.0 ],
+																	"numoutlets" : 2,
+																	"outlettype" : [ "", "" ],
+																	"patching_rect" : [ 15.0, 108.0, 581.0, 22.0 ],
 																	"text" : "fluid.bufcompose~ @source help.umap.1.temp @destination help.umap.1.src @destgain 0.5 @numchans 1"
 																}
 
@@ -3415,14 +3415,14 @@
 																	"maxclass" : "outlet",
 																	"numinlets" : 1,
 																	"numoutlets" : 0,
-																	"patching_rect" : [ 15.0, 161.0, 30.0, 30.0 ]
+																	"patching_rect" : [ 15.0, 193.0, 30.0, 30.0 ]
 																}
 
 															}
  ],
 														"lines" : [ 															{
 																"patchline" : 																{
-																	"destination" : [ "obj-20", 0 ],
+																	"destination" : [ "obj-3", 0 ],
 																	"source" : [ "obj-13", 0 ]
 																}
 
@@ -3441,10 +3441,17 @@
 																}
 
 															}
+, 															{
+																"patchline" : 																{
+																	"destination" : [ "obj-20", 0 ],
+																	"source" : [ "obj-3", 0 ]
+																}
+
+															}
  ]
 													}
 ,
-													"patching_rect" : [ 67.0, 233.0, 100.0, 22.0 ],
+													"patching_rect" : [ 67.0, 228.0, 100.0, 22.0 ],
 													"saved_object_attributes" : 													{
 														"description" : "",
 														"digest" : "",
@@ -3584,8 +3591,8 @@
 													"id" : "obj-5",
 													"maxclass" : "newobj",
 													"numinlets" : 1,
-													"numoutlets" : 3,
-													"outlettype" : [ "bang", "float", "" ],
+													"numoutlets" : 2,
+													"outlettype" : [ "", "" ],
 													"patching_rect" : [ 67.0, 308.125, 196.0, 22.0 ],
 													"text" : "fluid.dataset~ help.umap.1.analysis"
 												}
@@ -3596,8 +3603,8 @@
 													"id" : "obj-1",
 													"maxclass" : "newobj",
 													"numinlets" : 1,
-													"numoutlets" : 3,
-													"outlettype" : [ "bang", "float", "" ],
+													"numoutlets" : 2,
+													"outlettype" : [ "", "" ],
 													"patching_rect" : [ 47.0, 436.0, 180.0, 22.0 ],
 													"text" : "fluid.kdtree~ help.umap.1.kdtree"
 												}
@@ -3658,7 +3665,7 @@
 , 											{
 												"patchline" : 												{
 													"destination" : [ "obj-22", 0 ],
-													"source" : [ "obj-5", 2 ]
+													"source" : [ "obj-5", 1 ]
 												}
 
 											}
@@ -3708,13 +3715,13 @@
 												"name" : "max6message",
 												"default" : 												{
 													"bgfillcolor" : 													{
-														"type" : "gradient",
+														"angle" : 270.0,
+														"autogradient" : 0,
+														"color" : [ 0.290196, 0.309804, 0.301961, 1.0 ],
 														"color1" : [ 0.866667, 0.866667, 0.866667, 1.0 ],
 														"color2" : [ 0.788235, 0.788235, 0.788235, 1.0 ],
-														"color" : [ 0.290196, 0.309804, 0.301961, 1.0 ],
-														"angle" : 270.0,
 														"proportion" : 0.39,
-														"autogradient" : 0
+														"type" : "gradient"
 													}
 ,
 													"textcolor_inverse" : [ 0.0, 0.0, 0.0, 1.0 ]
@@ -3735,7 +3742,7 @@
  ]
 									}
 ,
-									"patching_rect" : [ 10.0, 190.0, 82.0, 23.0 ],
+									"patching_rect" : [ 30.0, 190.0, 82.0, 23.0 ],
 									"saved_object_attributes" : 									{
 										"description" : "",
 										"digest" : "",
@@ -3764,7 +3771,7 @@
 									"numinlets" : 0,
 									"numoutlets" : 0,
 									"offset" : [ 0.0, 0.0 ],
-									"patching_rect" : [ 600.0, 10.0, 220.0, 110.0 ],
+									"patching_rect" : [ 532.0, 10.0, 220.0, 110.0 ],
 									"viewvisibility" : 1
 								}
 
@@ -3781,20 +3788,12 @@
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
 									"parameter_enable" : 0,
-									"patching_rect" : [ 10.0, 10.0, 580.0, 120.0 ]
+									"patching_rect" : [ 10.0, 10.0, 520.0, 120.0 ]
 								}
 
 							}
  ],
 						"lines" : [ 							{
-								"patchline" : 								{
-									"destination" : [ "obj-19", 1 ],
-									"midpoints" : [ 639.5, 285.0, 612.0, 285.0, 612.0, 250.0, 580.5, 250.0 ],
-									"source" : [ "obj-1", 0 ]
-								}
-
-							}
-, 							{
 								"patchline" : 								{
 									"destination" : [ "obj-56", 0 ],
 									"source" : [ "obj-19", 0 ]
@@ -3811,8 +3810,7 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-45", 0 ],
-									"midpoints" : [ 505.5, 220.0, 329.5, 220.0 ],
-									"source" : [ "obj-22", 2 ]
+									"source" : [ "obj-22", 0 ]
 								}
 
 							}
@@ -3833,7 +3831,7 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-19", 1 ],
-									"midpoints" : [ 329.5, 714.0, 613.0, 714.0, 613.0, 249.0, 580.5, 249.0 ],
+									"midpoints" : [ 349.5, 714.0, 633.0, 714.0, 633.0, 249.0, 600.5, 249.0 ],
 									"source" : [ "obj-35", 0 ]
 								}
 
@@ -3864,7 +3862,7 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-35", 0 ],
-									"midpoints" : [ 329.5, 564.0, 329.5, 564.0 ],
+									"midpoints" : [ 349.5, 564.0, 349.5, 564.0 ],
 									"order" : 0,
 									"source" : [ "obj-56", 0 ]
 								}
@@ -3873,7 +3871,7 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-48", 0 ],
-									"midpoints" : [ 329.5, 576.0, 449.5, 576.0 ],
+									"midpoints" : [ 349.5, 576.0, 469.5, 576.0 ],
 									"order" : 1,
 									"source" : [ "obj-56", 0 ]
 								}
@@ -3904,13 +3902,13 @@
 								"name" : "max6message",
 								"default" : 								{
 									"bgfillcolor" : 									{
-										"type" : "gradient",
+										"angle" : 270.0,
+										"autogradient" : 0,
+										"color" : [ 0.290196, 0.309804, 0.301961, 1.0 ],
 										"color1" : [ 0.866667, 0.866667, 0.866667, 1.0 ],
 										"color2" : [ 0.788235, 0.788235, 0.788235, 1.0 ],
-										"color" : [ 0.290196, 0.309804, 0.301961, 1.0 ],
-										"angle" : 270.0,
 										"proportion" : 0.39,
-										"autogradient" : 0
+										"type" : "gradient"
 									}
 ,
 									"textcolor_inverse" : [ 0.0, 0.0, 0.0, 1.0 ]
@@ -3955,8 +3953,8 @@
 						"fileversion" : 1,
 						"appversion" : 						{
 							"major" : 8,
-							"minor" : 2,
-							"revision" : 2,
+							"minor" : 3,
+							"revision" : 0,
 							"architecture" : "x64",
 							"modernui" : 1
 						}
@@ -3993,6 +3991,18 @@
 						"assistshowspatchername" : 0,
 						"boxes" : [ 							{
 								"box" : 								{
+									"id" : "obj-13",
+									"maxclass" : "comment",
+									"numinlets" : 1,
+									"numoutlets" : 0,
+									"patching_rect" : [ 10.0, 62.0, 660.0, 21.0 ],
+									"text" : "This is a fun example to see how UMAP \"thinks\". A three-dimensional mammoth is reduced into two dimensions.",
+									"textcolor" : [ 0.501960784313725, 0.501960784313725, 0.501960784313725, 1.0 ]
+								}
+
+							}
+, 							{
+								"box" : 								{
 									"id" : "obj-5",
 									"maxclass" : "comment",
 									"numinlets" : 1,
@@ -4000,27 +4010,6 @@
 									"patching_rect" : [ 370.0, 690.0, 607.0, 21.0 ],
 									"text" : "This example and the data is drawn almost entirely from https://pair-code.github.io/understanding-umap/",
 									"textcolor" : [ 0.501960784313725, 0.501960784313725, 0.501960784313725, 1.0 ]
-								}
-
-							}
-, 							{
-								"box" : 								{
-									"args" : [ "umap" ],
-									"bgmode" : 0,
-									"border" : 0,
-									"clickthrough" : 0,
-									"enablehscroll" : 0,
-									"enablevscroll" : 0,
-									"id" : "obj-8",
-									"lockeddragscroll" : 0,
-									"lockedsize" : 0,
-									"maxclass" : "bpatcher",
-									"name" : "fluid.learn.maxpat",
-									"numinlets" : 0,
-									"numoutlets" : 0,
-									"offset" : [ 0.0, 0.0 ],
-									"patching_rect" : [ 600.0, 10.0, 220.0, 110.0 ],
-									"viewvisibility" : 1
 								}
 
 							}
@@ -4036,7 +4025,7 @@
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
 									"parameter_enable" : 0,
-									"patching_rect" : [ 10.0, 10.0, 580.0, 120.0 ]
+									"patching_rect" : [ 10.0, 10.0, 260.0, 50.0 ]
 								}
 
 							}
@@ -4192,8 +4181,8 @@
 										"fileversion" : 1,
 										"appversion" : 										{
 											"major" : 8,
-											"minor" : 2,
-											"revision" : 2,
+											"minor" : 3,
+											"revision" : 0,
 											"architecture" : "x64",
 											"modernui" : 1
 										}
@@ -4354,8 +4343,8 @@
 													"id" : "obj-80",
 													"maxclass" : "newobj",
 													"numinlets" : 1,
-													"numoutlets" : 3,
-													"outlettype" : [ "bang", "float", "" ],
+													"numoutlets" : 2,
+													"outlettype" : [ "", "" ],
 													"patching_rect" : [ 16.0, 84.0, 257.0, 22.0 ],
 													"text" : "fluid.dataset~ help.umap.mammoth.colours"
 												}
@@ -4433,7 +4422,7 @@
 , 											{
 												"patchline" : 												{
 													"destination" : [ "obj-9", 0 ],
-													"source" : [ "obj-80", 2 ]
+													"source" : [ "obj-80", 1 ]
 												}
 
 											}
@@ -4469,13 +4458,13 @@
 												"name" : "max6message",
 												"default" : 												{
 													"bgfillcolor" : 													{
-														"type" : "gradient",
+														"angle" : 270.0,
+														"autogradient" : 0,
+														"color" : [ 0.290196, 0.309804, 0.301961, 1.0 ],
 														"color1" : [ 0.866667, 0.866667, 0.866667, 1.0 ],
 														"color2" : [ 0.788235, 0.788235, 0.788235, 1.0 ],
-														"color" : [ 0.290196, 0.309804, 0.301961, 1.0 ],
-														"angle" : 270.0,
 														"proportion" : 0.39,
-														"autogradient" : 0
+														"type" : "gradient"
 													}
 ,
 													"textcolor_inverse" : [ 0.0, 0.0, 0.0, 1.0 ]
@@ -4630,14 +4619,14 @@
 										"fileversion" : 1,
 										"appversion" : 										{
 											"major" : 8,
-											"minor" : 2,
-											"revision" : 2,
+											"minor" : 3,
+											"revision" : 0,
 											"architecture" : "x64",
 											"modernui" : 1
 										}
 ,
 										"classnamespace" : "box",
-										"rect" : [ 679.0, -990.0, 913.0, 488.0 ],
+										"rect" : [ 679.0, 87.0, 913.0, 488.0 ],
 										"bglocked" : 0,
 										"openinpresentation" : 0,
 										"default_fontsize" : 12.0,
@@ -4684,7 +4673,7 @@
 													"numinlets" : 2,
 													"numoutlets" : 1,
 													"outlettype" : [ "" ],
-													"patching_rect" : [ 441.600006341934204, 64.20000022649765, 343.0, 22.0 ],
+													"patching_rect" : [ 621.600006341934204, 69.20000022649765, 343.0, 22.0 ],
 													"text" : "fittransform help.umap.mammoth help.umap.mammoth.colours"
 												}
 
@@ -4698,7 +4687,7 @@
 													"numinlets" : 0,
 													"numoutlets" : 1,
 													"outlettype" : [ "bang" ],
-													"patching_rect" : [ 10.0, 16.0, 30.0, 30.0 ]
+													"patching_rect" : [ 181.0, 10.0, 30.0, 30.0 ]
 												}
 
 											}
@@ -4757,7 +4746,7 @@
 													"numinlets" : 2,
 													"numoutlets" : 1,
 													"outlettype" : [ "" ],
-													"patching_rect" : [ 621.600006341934204, 147.333341181278229, 204.0, 22.0 ],
+													"patching_rect" : [ 621.600006341934204, 152.333341181278229, 204.0, 22.0 ],
 													"text" : "tobuffer help.umap.mammothcolours"
 												}
 
@@ -4767,9 +4756,9 @@
 													"id" : "obj-80",
 													"maxclass" : "newobj",
 													"numinlets" : 1,
-													"numoutlets" : 3,
-													"outlettype" : [ "bang", "float", "" ],
-													"patching_rect" : [ 621.600006341934204, 190.333341181278229, 238.0, 22.0 ],
+													"numoutlets" : 2,
+													"outlettype" : [ "", "" ],
+													"patching_rect" : [ 621.600006341934204, 195.333341181278229, 238.0, 22.0 ],
 													"text" : "fluid.dataset~ help.umap.mammoth.colours"
 												}
 
@@ -4779,9 +4768,9 @@
 													"id" : "obj-98",
 													"maxclass" : "newobj",
 													"numinlets" : 1,
-													"numoutlets" : 3,
-													"outlettype" : [ "bang", "float", "" ],
-													"patching_rect" : [ 441.600006341934204, 106.0, 199.0, 22.0 ],
+													"numoutlets" : 2,
+													"outlettype" : [ "", "" ],
+													"patching_rect" : [ 621.600006341934204, 111.0, 199.0, 22.0 ],
 													"text" : "fluid.normalize~ @min 0.1 @max 1."
 												}
 
@@ -4841,7 +4830,7 @@
 													"numinlets" : 2,
 													"numoutlets" : 1,
 													"outlettype" : [ "" ],
-													"patching_rect" : [ 181.0, 147.333341181278229, 182.0, 22.0 ],
+													"patching_rect" : [ 181.0, 156.333341181278229, 182.0, 22.0 ],
 													"text" : "tobuffer help.umap.mammothbuf"
 												}
 
@@ -4851,9 +4840,9 @@
 													"id" : "obj-30",
 													"maxclass" : "newobj",
 													"numinlets" : 1,
-													"numoutlets" : 3,
-													"outlettype" : [ "bang", "float", "" ],
-													"patching_rect" : [ 181.0, 186.333341181278229, 227.0, 22.0 ],
+													"numoutlets" : 2,
+													"outlettype" : [ "", "" ],
+													"patching_rect" : [ 181.0, 195.333341181278229, 227.0, 22.0 ],
 													"text" : "fluid.dataset~ help.umap.mammoth.norm"
 												}
 
@@ -4865,7 +4854,7 @@
 													"numinlets" : 2,
 													"numoutlets" : 1,
 													"outlettype" : [ "" ],
-													"patching_rect" : [ 10.0, 64.20000022649765, 331.0, 22.0 ],
+													"patching_rect" : [ 181.0, 73.20000022649765, 331.0, 22.0 ],
 													"text" : "fittransform help.umap.mammoth help.umap.mammoth.norm"
 												}
 
@@ -4875,9 +4864,9 @@
 													"id" : "obj-25",
 													"maxclass" : "newobj",
 													"numinlets" : 1,
-													"numoutlets" : 3,
-													"outlettype" : [ "bang", "float", "" ],
-													"patching_rect" : [ 10.0, 106.20000022649765, 190.0, 22.0 ],
+													"numoutlets" : 2,
+													"outlettype" : [ "", "" ],
+													"patching_rect" : [ 181.0, 115.20000022649765, 190.0, 22.0 ],
 													"text" : "fluid.normalize~ @min -1 @max 1"
 												}
 
@@ -4900,7 +4889,7 @@
 													"maxclass" : "newobj",
 													"numinlets" : 9,
 													"numoutlets" : 2,
-													"outlettype" : [ "jit_matrix", "" ],
+													"outlettype" : [ "", "" ],
 													"patching_rect" : [ 181.0, 448.266681432723999, 484.0, 22.0 ],
 													"text" : "jit.gl.mesh pcloud @draw_mode points @color 1 1 1 0.3 @point_size 4 @blend_enable 1"
 												}
@@ -4933,7 +4922,7 @@
 , 											{
 												"patchline" : 												{
 													"destination" : [ "obj-35", 0 ],
-													"source" : [ "obj-25", 2 ]
+													"source" : [ "obj-25", 0 ]
 												}
 
 											}
@@ -4947,8 +4936,7 @@
 , 											{
 												"patchline" : 												{
 													"destination" : [ "obj-68", 0 ],
-													"midpoints" : [ 398.5, 220.133344769477844, 190.5, 220.133344769477844 ],
-													"source" : [ "obj-30", 2 ]
+													"source" : [ "obj-30", 0 ]
 												}
 
 											}
@@ -4978,7 +4966,7 @@
 , 											{
 												"patchline" : 												{
 													"destination" : [ "obj-10", 0 ],
-													"midpoints" : [ 19.5, 47.0, 451.100006341934204, 47.0 ],
+													"midpoints" : [ 190.5, 54.100000113248825, 631.100006341934204, 54.100000113248825 ],
 													"order" : 0,
 													"source" : [ "obj-5", 0 ]
 												}
@@ -4987,7 +4975,7 @@
 , 											{
 												"patchline" : 												{
 													"destination" : [ "obj-28", 0 ],
-													"midpoints" : [ 19.5, 47.0, 19.5, 47.0 ],
+													"midpoints" : [ 190.5, 56.100000113248825, 190.5, 56.100000113248825 ],
 													"order" : 1,
 													"source" : [ "obj-5", 0 ]
 												}
@@ -5027,8 +5015,7 @@
 , 											{
 												"patchline" : 												{
 													"destination" : [ "obj-81", 0 ],
-													"midpoints" : [ 850.100006341934204, 224.133344769477844, 631.100006341934204, 224.133344769477844 ],
-													"source" : [ "obj-80", 2 ]
+													"source" : [ "obj-80", 0 ]
 												}
 
 											}
@@ -5083,7 +5070,7 @@
 , 											{
 												"patchline" : 												{
 													"destination" : [ "obj-79", 0 ],
-													"source" : [ "obj-98", 2 ]
+													"source" : [ "obj-98", 0 ]
 												}
 
 											}
@@ -5120,13 +5107,13 @@
 												"name" : "max6message",
 												"default" : 												{
 													"bgfillcolor" : 													{
-														"type" : "gradient",
+														"angle" : 270.0,
+														"autogradient" : 0,
+														"color" : [ 0.290196, 0.309804, 0.301961, 1.0 ],
 														"color1" : [ 0.866667, 0.866667, 0.866667, 1.0 ],
 														"color2" : [ 0.788235, 0.788235, 0.788235, 1.0 ],
-														"color" : [ 0.290196, 0.309804, 0.301961, 1.0 ],
-														"angle" : 270.0,
 														"proportion" : 0.39,
-														"autogradient" : 0
+														"type" : "gradient"
 													}
 ,
 													"textcolor_inverse" : [ 0.0, 0.0, 0.0, 1.0 ]
@@ -5188,8 +5175,8 @@
 									"id" : "obj-89",
 									"maxclass" : "newobj",
 									"numinlets" : 1,
-									"numoutlets" : 3,
-									"outlettype" : [ "bang", "float", "" ],
+									"numoutlets" : 2,
+									"outlettype" : [ "", "" ],
 									"patching_rect" : [ 10.0, 205.0, 212.0, 23.0 ],
 									"text" : "fluid.dataset~ help.umap.mammoth"
 								}
@@ -5206,8 +5193,8 @@
 										"fileversion" : 1,
 										"appversion" : 										{
 											"major" : 8,
-											"minor" : 2,
-											"revision" : 2,
+											"minor" : 3,
+											"revision" : 0,
 											"architecture" : "x64",
 											"modernui" : 1
 										}
@@ -5246,9 +5233,9 @@
 													"id" : "obj-12",
 													"maxclass" : "newobj",
 													"numinlets" : 1,
-													"numoutlets" : 3,
-													"outlettype" : [ "bang", "float", "" ],
-													"patching_rect" : [ 459.0, 145.0, 170.0, 22.0 ],
+													"numoutlets" : 2,
+													"outlettype" : [ "", "" ],
+													"patching_rect" : [ 320.0, 149.0, 170.0, 22.0 ],
 													"text" : "fluid.dataset~ help.umap.1.out"
 												}
 
@@ -5260,7 +5247,7 @@
 													"numinlets" : 2,
 													"numoutlets" : 2,
 													"outlettype" : [ "", "" ],
-													"patching_rect" : [ 232.0, 210.0, 107.0, 22.0 ],
+													"patching_rect" : [ 12.0, 218.0, 107.0, 22.0 ],
 													"text" : "route fittransform"
 												}
 
@@ -5272,7 +5259,7 @@
 													"numinlets" : 2,
 													"numoutlets" : 2,
 													"outlettype" : [ "", "" ],
-													"patching_rect" : [ 151.0, 110.0, 107.0, 22.0 ],
+													"patching_rect" : [ 12.0, 114.0, 107.0, 22.0 ],
 													"text" : "route fittransform"
 												}
 
@@ -5284,7 +5271,7 @@
 													"numinlets" : 2,
 													"numoutlets" : 1,
 													"outlettype" : [ "" ],
-													"patching_rect" : [ 232.0, 250.0, 41.0, 22.0 ],
+													"patching_rect" : [ 12.0, 253.0, 41.0, 22.0 ],
 													"text" : "dump"
 												}
 
@@ -5294,9 +5281,9 @@
 													"id" : "obj-24",
 													"maxclass" : "newobj",
 													"numinlets" : 1,
-													"numoutlets" : 3,
-													"outlettype" : [ "bang", "float", "" ],
-													"patching_rect" : [ 232.0, 290.0, 213.0, 22.0 ],
+													"numoutlets" : 2,
+													"outlettype" : [ "", "" ],
+													"patching_rect" : [ 12.0, 293.0, 213.0, 22.0 ],
 													"text" : "fluid.dataset~ help.umap.1.outnorm"
 												}
 
@@ -5308,7 +5295,7 @@
 													"numinlets" : 2,
 													"numoutlets" : 1,
 													"outlettype" : [ "" ],
-													"patching_rect" : [ 151.0, 145.0, 275.0, 22.0 ],
+													"patching_rect" : [ 12.0, 149.0, 275.0, 22.0 ],
 													"text" : "fittransform help.umap.1.out help.umap.1.outnorm"
 												}
 
@@ -5318,9 +5305,9 @@
 													"id" : "obj-21",
 													"maxclass" : "newobj",
 													"numinlets" : 1,
-													"numoutlets" : 3,
-													"outlettype" : [ "bang", "float", "" ],
-													"patching_rect" : [ 151.0, 175.0, 100.0, 22.0 ],
+													"numoutlets" : 2,
+													"outlettype" : [ "", "" ],
+													"patching_rect" : [ 12.0, 179.0, 100.0, 22.0 ],
 													"text" : "fluid.normalize~"
 												}
 
@@ -5332,7 +5319,7 @@
 													"numinlets" : 2,
 													"numoutlets" : 2,
 													"outlettype" : [ "", "" ],
-													"patching_rect" : [ 426.0, 330.0, 74.0, 22.0 ],
+													"patching_rect" : [ 206.0, 327.0, 74.0, 22.0 ],
 													"text" : "route dump"
 												}
 
@@ -5342,8 +5329,8 @@
 													"id" : "obj-13",
 													"maxclass" : "newobj",
 													"numinlets" : 1,
-													"numoutlets" : 3,
-													"outlettype" : [ "bang", "float", "" ],
+													"numoutlets" : 2,
+													"outlettype" : [ "", "" ],
 													"patching_rect" : [ 12.0, 75.0, 158.0, 22.0 ],
 													"text" : "fluid.umap~ @iterations 200"
 												}
@@ -5370,7 +5357,7 @@
 													"maxclass" : "outlet",
 													"numinlets" : 1,
 													"numoutlets" : 0,
-													"patching_rect" : [ 426.0, 359.0, 30.0, 30.0 ]
+													"patching_rect" : [ 206.0, 356.0, 30.0, 30.0 ]
 												}
 
 											}
@@ -5378,7 +5365,7 @@
 										"lines" : [ 											{
 												"patchline" : 												{
 													"destination" : [ "obj-42", 0 ],
-													"source" : [ "obj-13", 2 ]
+													"source" : [ "obj-13", 0 ]
 												}
 
 											}
@@ -5392,7 +5379,7 @@
 , 											{
 												"patchline" : 												{
 													"destination" : [ "obj-43", 0 ],
-													"source" : [ "obj-21", 2 ]
+													"source" : [ "obj-21", 0 ]
 												}
 
 											}
@@ -5406,7 +5393,7 @@
 , 											{
 												"patchline" : 												{
 													"destination" : [ "obj-18", 0 ],
-													"source" : [ "obj-24", 2 ]
+													"source" : [ "obj-24", 1 ]
 												}
 
 											}
@@ -5463,13 +5450,13 @@
 												"name" : "max6message",
 												"default" : 												{
 													"bgfillcolor" : 													{
-														"type" : "gradient",
+														"angle" : 270.0,
+														"autogradient" : 0,
+														"color" : [ 0.290196, 0.309804, 0.301961, 1.0 ],
 														"color1" : [ 0.866667, 0.866667, 0.866667, 1.0 ],
 														"color2" : [ 0.788235, 0.788235, 0.788235, 1.0 ],
-														"color" : [ 0.290196, 0.309804, 0.301961, 1.0 ],
-														"angle" : 270.0,
 														"proportion" : 0.39,
-														"autogradient" : 0
+														"type" : "gradient"
 													}
 ,
 													"textcolor_inverse" : [ 0.0, 0.0, 0.0, 1.0 ]
@@ -5591,8 +5578,8 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-3", 0 ],
-									"midpoints" : [ 212.5, 241.0, 19.5, 241.0 ],
-									"source" : [ "obj-89", 2 ]
+									"midpoints" : [ 212.5, 243.5, 19.5, 243.5 ],
+									"source" : [ "obj-89", 1 ]
 								}
 
 							}
@@ -5646,13 +5633,13 @@
 								"name" : "max6message",
 								"default" : 								{
 									"bgfillcolor" : 									{
-										"type" : "gradient",
+										"angle" : 270.0,
+										"autogradient" : 0,
+										"color" : [ 0.290196, 0.309804, 0.301961, 1.0 ],
 										"color1" : [ 0.866667, 0.866667, 0.866667, 1.0 ],
 										"color2" : [ 0.788235, 0.788235, 0.788235, 1.0 ],
-										"color" : [ 0.290196, 0.309804, 0.301961, 1.0 ],
-										"angle" : 270.0,
 										"proportion" : 0.39,
-										"autogradient" : 0
+										"type" : "gradient"
 									}
 ,
 									"textcolor_inverse" : [ 0.0, 0.0, 0.0, 1.0 ]
@@ -5697,8 +5684,8 @@
 						"fileversion" : 1,
 						"appversion" : 						{
 							"major" : 8,
-							"minor" : 2,
-							"revision" : 2,
+							"minor" : 3,
+							"revision" : 0,
 							"architecture" : "x64",
 							"modernui" : 1
 						}
@@ -5762,53 +5749,6 @@
 			"inherited_shortname" : 1
 		}
 ,
-		"dependency_cache" : [ 			{
-				"name" : "fluid.bufcompose~.mxo",
-				"type" : "iLaX"
-			}
-, 			{
-				"name" : "fluid.concataudiofiles.maxpat",
-				"bootpath" : "~/Documents/documents@hudd/research/projects/fluid corpus navigation/research/nightly_builds/Max/FluidCorpusManipulation/patchers",
-				"patcherrelativepath" : "../../nightly_builds/Max/FluidCorpusManipulation/patchers",
-				"type" : "JSON",
-				"implicit" : 1
-			}
-, 			{
-				"name" : "fluid.flucomaorg.maxpat",
-				"bootpath" : "~/Documents/documents@hudd/research/projects/fluid corpus navigation/research/flucoma-max/help",
-				"patcherrelativepath" : ".",
-				"type" : "JSON",
-				"implicit" : 1
-			}
-, 			{
-				"name" : "fluid.learn.maxpat",
-				"bootpath" : "~/Documents/documents@hudd/research/projects/fluid corpus navigation/research/flucoma-max/help",
-				"patcherrelativepath" : ".",
-				"type" : "JSON",
-				"implicit" : 1
-			}
-, 			{
-				"name" : "fluid.libmanipulation.mxo",
-				"type" : "iLaX"
-			}
-, 			{
-				"name" : "fluid.list2buf.mxo",
-				"type" : "iLaX"
-			}
-, 			{
-				"name" : "fluid.plotter.js",
-				"bootpath" : "~/Documents/documents@hudd/research/projects/fluid corpus navigation/research/nightly_builds/Max/FluidCorpusManipulation/jsui",
-				"patcherrelativepath" : "../../nightly_builds/Max/FluidCorpusManipulation/jsui",
-				"type" : "TEXT",
-				"implicit" : 1
-			}
-, 			{
-				"name" : "helpdetails.js",
-				"bootpath" : "C74:/help/resources",
-				"type" : "TEXT",
-				"implicit" : 1
-			}
- ],
 		"autosave" : 0,
 		"styles" : [ 			{
 				"name" : "max6box",
@@ -5834,13 +5774,13 @@
 				"name" : "max6message",
 				"default" : 				{
 					"bgfillcolor" : 					{
-						"type" : "gradient",
+						"angle" : 270.0,
+						"autogradient" : 0,
+						"color" : [ 0.290196, 0.309804, 0.301961, 1.0 ],
 						"color1" : [ 0.866667, 0.866667, 0.866667, 1.0 ],
 						"color2" : [ 0.788235, 0.788235, 0.788235, 1.0 ],
-						"color" : [ 0.290196, 0.309804, 0.301961, 1.0 ],
-						"angle" : 270.0,
 						"proportion" : 0.39,
-						"autogradient" : 0
+						"type" : "gradient"
 					}
 ,
 					"textcolor_inverse" : [ 0.0, 0.0, 0.0, 1.0 ]


### PR DESCRIPTION
Many patches were broken due to the new changes in fluid.dataset~.

I've fixed those (mostly changed connections) and taken the liberty to "Maxify" the style of many of the patchers.

- update dataset
- fix broken cabling in datasetquery
- update kmeans
- make more max-like in style
- "maxify" the style
- fix connections and maxify style of labelset~
- fix connections in umap and maxify
- fix connections and mafixy fluid.grid~
- update kdtree~ help with fixed cables and max style
- fix connections and maxify style of normalize
- cosmetic upgrades
