### PR TITLE
[Fix] Saner maximum sizes for modulatable examples

### DIFF
--- a/help/fluid.ampslice~.maxhelp
+++ b/help/fluid.ampslice~.maxhelp
@@ -103,11 +103,11 @@
 , 							{
 								"box" : 								{
 									"id" : "obj-4",
-									"linecount" : 9,
+									"linecount" : 7,
 									"maxclass" : "comment",
 									"numinlets" : 1,
 									"numoutlets" : 0,
-									"patching_rect" : [ 410.0, 310.0, 156.0, 127.0 ],
+									"patching_rect" : [ 410.0, 310.0, 159.0, 100.0 ],
 									"text" : "an example where many of the parameters are tuned to a specific musical example.\n\nThe sensitivity doesn't catch everything, but its sensitive to the most salient hits.",
 									"textcolor" : [ 0.501960784313725, 0.501960784313725, 0.501960784313725, 1.0 ]
 								}

--- a/help/fluid.bufnoveltyslice~.maxhelp
+++ b/help/fluid.bufnoveltyslice~.maxhelp
@@ -234,7 +234,7 @@
 									"numoutlets" : 3,
 									"outlettype" : [ "", "", "int" ],
 									"parameter_enable" : 0,
-									"patching_rect" : [ 623.0, 452.5, 20.0, 20.0 ],
+									"patching_rect" : [ 767.0, 462.5, 20.0, 20.0 ],
 									"rounded" : 60.0,
 									"text" : "4",
 									"textcolor" : [ 0.34902, 0.34902, 0.34902, 1.0 ]
@@ -249,7 +249,7 @@
 									"maxclass" : "comment",
 									"numinlets" : 1,
 									"numoutlets" : 0,
-									"patching_rect" : [ 422.0, 450.0, 199.0, 25.0 ],
+									"patching_rect" : [ 566.0, 460.0, 199.0, 25.0 ],
 									"text" : "Select a segment to play back"
 								}
 
@@ -299,7 +299,7 @@
 									"orientation" : 1,
 									"outlettype" : [ "signal", "signal", "", "float", "list" ],
 									"parameter_enable" : 1,
-									"patching_rect" : [ 370.0, 525.0, 136.0, 47.0 ],
+									"patching_rect" : [ 514.0, 535.0, 136.0, 47.0 ],
 									"saved_attribute_attributes" : 									{
 										"valueof" : 										{
 											"parameter_longname" : "live.gain~",
@@ -618,7 +618,7 @@
  ]
 									}
 ,
-									"patching_rect" : [ 370.0, 495.0, 104.0, 23.0 ],
+									"patching_rect" : [ 514.0, 505.0, 104.0, 23.0 ],
 									"saved_object_attributes" : 									{
 										"description" : "",
 										"digest" : "",
@@ -639,7 +639,7 @@
 									"numoutlets" : 2,
 									"outlettype" : [ "", "bang" ],
 									"parameter_enable" : 0,
-									"patching_rect" : [ 370.0, 450.0, 52.0, 23.0 ]
+									"patching_rect" : [ 514.0, 460.0, 52.0, 23.0 ]
 								}
 
 							}
@@ -665,7 +665,7 @@
 									"numinlets" : 1,
 									"numoutlets" : 2,
 									"outlettype" : [ "float", "bang" ],
-									"patching_rect" : [ 546.5, 400.0, 131.0, 23.0 ],
+									"patching_rect" : [ 340.0, 440.0, 131.0, 23.0 ],
 									"text" : "buffer~ help.ns.slices"
 								}
 
@@ -757,7 +757,7 @@
 									"numoutlets" : 3,
 									"outlettype" : [ "", "", "int" ],
 									"parameter_enable" : 0,
-									"patching_rect" : [ 507.0, 607.5, 20.0, 20.0 ],
+									"patching_rect" : [ 651.0, 617.5, 20.0, 20.0 ],
 									"rounded" : 60.0,
 									"text" : "1",
 									"textcolor" : [ 0.34902, 0.34902, 0.34902, 1.0 ]
@@ -772,7 +772,7 @@
 									"maxclass" : "comment",
 									"numinlets" : 1,
 									"numoutlets" : 0,
-									"patching_rect" : [ 417.0, 605.0, 88.0, 25.0 ],
+									"patching_rect" : [ 561.0, 615.0, 88.0, 25.0 ],
 									"text" : "Start audio"
 								}
 
@@ -818,7 +818,7 @@
 									"maxclass" : "ezdac~",
 									"numinlets" : 2,
 									"numoutlets" : 0,
-									"patching_rect" : [ 370.0, 595.0, 45.0, 45.0 ]
+									"patching_rect" : [ 514.0, 605.0, 45.0, 45.0 ]
 								}
 
 							}
@@ -831,8 +831,8 @@
 									"numinlets" : 1,
 									"numoutlets" : 2,
 									"outlettype" : [ "", "" ],
-									"patching_rect" : [ 140.0, 400.0, 390.0, 23.0 ],
-									"text" : "fluid.bufnoveltyslice~ @source help.ns.src @indices help.ns.slices"
+									"patching_rect" : [ 140.0, 400.0, 622.0, 23.0 ],
+									"text" : "fluid.bufnoveltyslice~ @source help.ns.src @indices help.ns.slices @maxfiltersize 71 @maxkernelsize 101"
 								}
 
 							}

--- a/help/fluid.bufonsetslice~.maxhelp
+++ b/help/fluid.bufonsetslice~.maxhelp
@@ -57,7 +57,7 @@
 						}
 ,
 						"classnamespace" : "box",
-						"rect" : [ 34.0, 126.0, 789.0, 616.0 ],
+						"rect" : [ 0.0, 26.0, 789.0, 616.0 ],
 						"bglocked" : 0,
 						"openinpresentation" : 0,
 						"default_fontsize" : 12.0,
@@ -3599,7 +3599,7 @@
 						}
 ,
 						"classnamespace" : "box",
-						"rect" : [ 0.0, 26.0, 789.0, 616.0 ],
+						"rect" : [ 34.0, 126.0, 789.0, 616.0 ],
 						"bglocked" : 0,
 						"openinpresentation" : 0,
 						"default_fontsize" : 12.0,

--- a/help/fluid.noveltyslice~.maxhelp
+++ b/help/fluid.noveltyslice~.maxhelp
@@ -58,7 +58,7 @@
 						}
 ,
 						"classnamespace" : "box",
-						"rect" : [ 0.0, 26.0, 792.0, 555.0 ],
+						"rect" : [ 100.0, 126.0, 792.0, 555.0 ],
 						"bglocked" : 0,
 						"openinpresentation" : 0,
 						"default_fontsize" : 13.0,
@@ -109,7 +109,7 @@
 									"numinlets" : 1,
 									"numoutlets" : 1,
 									"outlettype" : [ "bang" ],
-									"patching_rect" : [ 290.0, 90.0, 62.0, 23.0 ],
+									"patching_rect" : [ 290.0, 70.0, 62.0, 23.0 ],
 									"text" : "loadbang"
 								}
 
@@ -128,7 +128,7 @@
 									"numinlets" : 1,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 350.0, 432.5, 340.0, 92.5 ],
+									"patching_rect" : [ 400.0, 440.0, 340.0, 92.5 ],
 									"text" : "Ultimately, fluid.noveltyslice~ is about balancing the different parameters and the latency they create, to change the algorithms notion of what is \"novel\". Check out the learn reference for more information on what novelty is and how it is determined.\n\n<link href=\"; max launchbrowser https://learn.flucoma.org/reference/noveltyslice\" >https://learn.flucoma.org/reference/noveltyslice</link>",
 									"textcolor" : [ 0.501960784313725, 0.501960784313725, 0.501960784313725, 1.0 ]
 								}
@@ -142,7 +142,7 @@
 									"maxclass" : "comment",
 									"numinlets" : 1,
 									"numoutlets" : 0,
-									"patching_rect" : [ 494.0, 310.0, 218.0, 108.0 ],
+									"patching_rect" : [ 494.0, 290.0, 218.0, 108.0 ],
 									"text" : "A small kernelsize calculating novelty on the spectrum of the signal. Captures only the more significant changes without sacrificing latency because the threshold is much higher. It is at times a little noisy though.",
 									"textcolor" : [ 0.501960784313725, 0.501960784313725, 0.501960784313725, 1.0 ]
 								}
@@ -156,7 +156,7 @@
 									"numinlets" : 2,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 392.0, 310.0, 98.0, 81.0 ],
+									"patching_rect" : [ 392.0, 290.0, 98.0, 81.0 ],
 									"text" : "kernelsize 3, threshold 0.5, feature 0, minslicelength 1, filtersize 1"
 								}
 
@@ -169,7 +169,7 @@
 									"maxclass" : "comment",
 									"numinlets" : 1,
 									"numoutlets" : 0,
-									"patching_rect" : [ 442.0, 220.0, 193.0, 79.0 ],
+									"patching_rect" : [ 460.0, 200.0, 193.0, 79.0 ],
 									"text" : "A large kernelsize calculating novelty on the spectrum of the signal. Captures only the more significant changes at the expense of latency.",
 									"textcolor" : [ 0.501960784313725, 0.501960784313725, 0.501960784313725, 1.0 ]
 								}
@@ -183,7 +183,7 @@
 									"numinlets" : 2,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 290.0, 130.0, 100.0, 81.0 ],
+									"patching_rect" : [ 290.0, 110.0, 100.0, 81.0 ],
 									"text" : "kernelsize 5, threshold 0.61, feature 4, minslicelength 3, filtersize 1"
 								}
 
@@ -196,8 +196,8 @@
 									"numinlets" : 2,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 340.0, 220.0, 100.0, 81.0 ],
-									"text" : "kernelsize 41, threshold 0.7, feature 0, minslicelength 1, filtersize 1"
+									"patching_rect" : [ 340.0, 200.0, 110.0, 81.0 ],
+									"text" : "kernelsize 41, threshold 0.35, feature 0, minslicelength 1, filtersize 1"
 								}
 
 							}
@@ -209,7 +209,7 @@
 									"maxclass" : "comment",
 									"numinlets" : 1,
 									"numoutlets" : 0,
-									"patching_rect" : [ 392.0, 138.0, 205.0, 65.0 ],
+									"patching_rect" : [ 392.0, 118.0, 205.0, 65.0 ],
 									"text" : "A small kernelsize calculating novelty on the loudness of the signal. Captures a medium amount of detail in the drum loop.",
 									"textcolor" : [ 0.501960784313725, 0.501960784313725, 0.501960784313725, 1.0 ]
 								}
@@ -228,7 +228,7 @@
 									"numoutlets" : 3,
 									"outlettype" : [ "", "", "int" ],
 									"parameter_enable" : 0,
-									"patching_rect" : [ 210.0, 250.0, 20.0, 20.0 ],
+									"patching_rect" : [ 210.0, 230.0, 20.0, 20.0 ],
 									"rounded" : 60.0,
 									"text" : "2",
 									"textcolor" : [ 0.34902, 0.34902, 0.34902, 1.0 ]
@@ -244,7 +244,7 @@
 									"maxclass" : "comment",
 									"numinlets" : 1,
 									"numoutlets" : 0,
-									"patching_rect" : [ 60.0, 239.5, 145.0, 40.0 ],
+									"patching_rect" : [ 60.0, 219.5, 145.0, 40.0 ],
 									"text" : "Play the selected audio"
 								}
 
@@ -262,7 +262,7 @@
 									"numoutlets" : 3,
 									"outlettype" : [ "", "", "int" ],
 									"parameter_enable" : 0,
-									"patching_rect" : [ 168.0, 493.0, 20.0, 20.0 ],
+									"patching_rect" : [ 168.0, 473.0, 20.0, 20.0 ],
 									"rounded" : 60.0,
 									"text" : "1",
 									"textcolor" : [ 0.34902, 0.34902, 0.34902, 1.0 ]
@@ -276,7 +276,7 @@
 									"maxclass" : "comment",
 									"numinlets" : 1,
 									"numoutlets" : 0,
-									"patching_rect" : [ 77.0, 490.5, 89.0, 25.0 ],
+									"patching_rect" : [ 77.0, 470.5, 89.0, 25.0 ],
 									"text" : "Start Audio"
 								}
 
@@ -290,7 +290,7 @@
 									"numoutlets" : 2,
 									"outlettype" : [ "", "bang" ],
 									"parameter_enable" : 0,
-									"patching_rect" : [ 138.0, 381.0, 55.0, 23.0 ]
+									"patching_rect" : [ 138.0, 361.0, 55.0, 23.0 ]
 								}
 
 							}
@@ -301,7 +301,7 @@
 									"numinlets" : 2,
 									"numoutlets" : 1,
 									"outlettype" : [ "signal" ],
-									"patching_rect" : [ 30.0, 420.0, 127.0, 23.0 ],
+									"patching_rect" : [ 30.0, 400.0, 127.0, 23.0 ],
 									"text" : "delay~ 22050 22050"
 								}
 
@@ -313,7 +313,7 @@
 									"numinlets" : 1,
 									"numoutlets" : 3,
 									"outlettype" : [ "", "", "" ],
-									"patching_rect" : [ 137.75, 331.0, 139.5, 23.0 ],
+									"patching_rect" : [ 137.75, 311.0, 139.5, 23.0 ],
 									"text" : "getattr latency"
 								}
 
@@ -325,7 +325,7 @@
 									"maxclass" : "ezdac~",
 									"numinlets" : 2,
 									"numoutlets" : 0,
-									"patching_rect" : [ 30.0, 480.0, 45.0, 45.0 ]
+									"patching_rect" : [ 30.0, 460.0, 45.0, 45.0 ]
 								}
 
 							}
@@ -346,7 +346,7 @@
 									"numoutlets" : 1,
 									"offset" : [ 0.0, 0.0 ],
 									"outlettype" : [ "signal" ],
-									"patching_rect" : [ 30.0, 120.0, 231.0, 122.0 ],
+									"patching_rect" : [ 30.0, 100.0, 231.0, 122.0 ],
 									"viewvisibility" : 1
 								}
 
@@ -358,8 +358,8 @@
 									"numinlets" : 1,
 									"numoutlets" : 2,
 									"outlettype" : [ "signal", "" ],
-									"patching_rect" : [ 198.0, 420.0, 111.0, 23.0 ],
-									"text" : "fluid.noveltyslice~"
+									"patching_rect" : [ 198.0, 400.0, 229.0, 23.0 ],
+									"text" : "fluid.noveltyslice~ @maxkernelsize 41"
 								}
 
 							}
@@ -383,7 +383,7 @@
 						"lines" : [ 							{
 								"patchline" : 								{
 									"destination" : [ "obj-1", 0 ],
-									"midpoints" : [ 39.5, 443.0, 39.5, 443.0 ],
+									"midpoints" : [ 39.5, 423.0, 39.5, 423.0 ],
 									"source" : [ "obj-10", 0 ]
 								}
 
@@ -398,7 +398,7 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-10", 0 ],
-									"midpoints" : [ 39.5, 244.0, 39.5, 244.0 ],
+									"midpoints" : [ 39.5, 224.0, 39.5, 224.0 ],
 									"order" : 1,
 									"source" : [ "obj-2", 0 ]
 								}
@@ -407,7 +407,7 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-3", 0 ],
-									"midpoints" : [ 39.5, 367.0, 207.5, 367.0 ],
+									"midpoints" : [ 39.5, 347.0, 207.5, 347.0 ],
 									"order" : 0,
 									"source" : [ "obj-2", 0 ]
 								}
@@ -416,7 +416,7 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-1", 1 ],
-									"midpoints" : [ 207.5, 467.0, 65.5, 467.0 ],
+									"midpoints" : [ 207.5, 447.0, 65.5, 447.0 ],
 									"source" : [ "obj-3", 0 ]
 								}
 
@@ -424,7 +424,7 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-3", 0 ],
-									"midpoints" : [ 349.5, 406.0, 207.5, 406.0 ],
+									"midpoints" : [ 349.5, 386.0, 207.5, 386.0 ],
 									"source" : [ "obj-31", 0 ]
 								}
 
@@ -432,7 +432,7 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-3", 0 ],
-									"midpoints" : [ 299.5, 406.5, 207.5, 406.5 ],
+									"midpoints" : [ 299.5, 386.5, 207.5, 386.5 ],
 									"source" : [ "obj-36", 0 ]
 								}
 
@@ -440,7 +440,7 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-3", 0 ],
-									"midpoints" : [ 401.5, 406.0, 207.5, 406.0 ],
+									"midpoints" : [ 401.5, 386.0, 207.5, 386.0 ],
 									"source" : [ "obj-39", 0 ]
 								}
 
@@ -550,7 +550,7 @@
 						}
 ,
 						"classnamespace" : "box",
-						"rect" : [ 100.0, 126.0, 792.0, 555.0 ],
+						"rect" : [ 0.0, 26.0, 792.0, 555.0 ],
 						"bglocked" : 0,
 						"openinpresentation" : 0,
 						"default_fontsize" : 13.0,

--- a/help/fluid.noveltyslice~.maxhelp
+++ b/help/fluid.noveltyslice~.maxhelp
@@ -151,13 +151,13 @@
 , 							{
 								"box" : 								{
 									"id" : "obj-39",
-									"linecount" : 5,
+									"linecount" : 4,
 									"maxclass" : "message",
 									"numinlets" : 2,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 392.0, 290.0, 98.0, 81.0 ],
-									"text" : "kernelsize 3, threshold 0.5, feature 0, minslicelength 1, filtersize 1"
+									"patching_rect" : [ 392.0, 290.0, 98.0, 67.0 ],
+									"text" : "kernelsize 3, threshold 0.5, minslicelength 1, filtersize 1"
 								}
 
 							}
@@ -178,26 +178,26 @@
 , 							{
 								"box" : 								{
 									"id" : "obj-36",
-									"linecount" : 5,
+									"linecount" : 4,
 									"maxclass" : "message",
 									"numinlets" : 2,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 290.0, 110.0, 100.0, 81.0 ],
-									"text" : "kernelsize 5, threshold 0.61, feature 4, minslicelength 3, filtersize 1"
+									"patching_rect" : [ 290.0, 110.0, 100.0, 67.0 ],
+									"text" : "kernelsize 5, threshold 0.61, minslicelength 3, filtersize 1"
 								}
 
 							}
 , 							{
 								"box" : 								{
 									"id" : "obj-31",
-									"linecount" : 5,
+									"linecount" : 4,
 									"maxclass" : "message",
 									"numinlets" : 2,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 340.0, 200.0, 110.0, 81.0 ],
-									"text" : "kernelsize 41, threshold 0.35, feature 0, minslicelength 1, filtersize 1"
+									"patching_rect" : [ 340.0, 200.0, 110.0, 67.0 ],
+									"text" : "kernelsize 41, threshold 0.35, minslicelength 1, filtersize 1"
 								}
 
 							}

--- a/help/fluid.onsetslice~.maxhelp
+++ b/help/fluid.onsetslice~.maxhelp
@@ -58,7 +58,7 @@
 						}
 ,
 						"classnamespace" : "box",
-						"rect" : [ 0.0, 26.0, 700.0, 656.0 ],
+						"rect" : [ 34.0, 113.0, 700.0, 656.0 ],
 						"bglocked" : 0,
 						"openinpresentation" : 0,
 						"default_fontsize" : 12.0,
@@ -3631,7 +3631,7 @@
 						}
 ,
 						"classnamespace" : "box",
-						"rect" : [ 34.0, 113.0, 700.0, 656.0 ],
+						"rect" : [ 0.0, 26.0, 700.0, 656.0 ],
 						"bglocked" : 0,
 						"openinpresentation" : 0,
 						"default_fontsize" : 12.0,


### PR DESCRIPTION
Adds bigger maxsizes for things that it can be applied to so that those parameters are modulatable in help files. Assuredly this is not the end of these changes but this captures the evident low hanging fruit.
