### PR TITLE
CMake: Install Max index json files for object lookup

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -187,6 +187,9 @@ if(DOCS)
   install(DIRECTORY "${MAX_DOC_OUT}/" 
           DESTINATION "${MAX_PACKAGE_ROOT}/docs"  
           PATTERN "*.xml")
+  install(FILES "${MAX_DOC_OUT}/../interfaces/flucoma-obj-qlookup.json" 
+                "${MAX_DOC_OUT}/../interfaces/max.db.json" 
+          DESTINATION "${MAX_PACKAGE_ROOT}/interfaces")
 endif()
 
 install(DIRECTORY "${fluid_waveform_SOURCE_DIR}/" DESTINATION ${MAX_PACKAGE_ROOT})


### PR DESCRIPTION
fixes #296 : make sure `flucoma-obj-qlookup.json` and `max.db.json` are `install`ed