### PR TITLE
Corrected the URLs to learn/YouTube content in Inspiration tab of the Toolkit patch

### DIFF
--- a/extras/Fluid Corpus Manipulation Toolkit.maxpat
+++ b/extras/Fluid Corpus Manipulation Toolkit.maxpat
@@ -1600,39 +1600,39 @@
 														"count" : 9,
 														"data" : [ 															{
 																"key" : 0,
-																"value" : [ "eldridge-kiefer" ]
-															}
-, 															{
-																"key" : 1,
 																"value" : [ "hayes" ]
 															}
 , 															{
-																"key" : 2,
+																"key" : 1,
 																"value" : [ "burton" ]
 															}
 , 															{
-																"key" : 3,
-																"value" : [ "harker" ]
-															}
-, 															{
-																"key" : 4,
-																"value" : [ "pluta" ]
-															}
-, 															{
-																"key" : 5,
+																"key" : 2,
 																"value" : [ "pasquet" ]
 															}
 , 															{
-																"key" : 6,
+																"key" : 3,
 																"value" : [ "constanzo" ]
 															}
 , 															{
-																"key" : 7,
+																"key" : 4,
+																"value" : [ "harker" ]
+															}
+, 															{
+																"key" : 5,
+																"value" : [ "pluta" ]
+															}
+, 															{
+																"key" : 6,
 																"value" : [ "devine" ]
 															}
 , 															{
-																"key" : 8,
+																"key" : 7,
 																"value" : [ "tutschku" ]
+															}
+, 															{
+																"key" : 8,
+																"value" : [ "eldridge-kiefer" ]
 															}
  ]
 													}
@@ -1682,39 +1682,39 @@
 														"count" : 9,
 														"data" : [ 															{
 																"key" : 0,
-																"value" : [ "https://youtu.be/c03_84_P7PQ" ]
-															}
-, 															{
-																"key" : 1,
 																"value" : [ "https://youtu.be/BzSRs_7S9cg" ]
 															}
 , 															{
-																"key" : 2,
+																"key" : 1,
 																"value" : [ "https://youtu.be/hYaZq1JCTQo" ]
 															}
 , 															{
-																"key" : 3,
-																"value" : [ "https://youtu.be/lHEWsysupaA" ]
-															}
-, 															{
-																"key" : 4,
-																"value" : [ "https://youtu.be/jWwJd9UmixQ" ]
-															}
-, 															{
-																"key" : 5,
+																"key" : 2,
 																"value" : [ "https://youtu.be/qqR_gORRwRA" ]
 															}
 , 															{
-																"key" : 6,
-																"value" : [ "https://www.youtube.com/watch?v=MTWklm1oXWQ" ]
+																"key" : 3,
+																"value" : [ "https://youtu.be/MTWklm1oXWQ" ]
 															}
 , 															{
-																"key" : 7,
+																"key" : 4,
+																"value" : [ "https://youtu.be/lHEWsysupaA" ]
+															}
+, 															{
+																"key" : 5,
+																"value" : [ "https://youtu.be/jWwJd9UmixQ" ]
+															}
+, 															{
+																"key" : 6,
 																"value" : [ "https://youtu.be/F0iCU_uqJHg" ]
 															}
 , 															{
-																"key" : 8,
+																"key" : 7,
 																"value" : [ "https://youtu.be/xPqT-atQIik" ]
+															}
+, 															{
+																"key" : 8,
+																"value" : [ "https://youtu.be/c03_84_P7PQ" ]
 															}
  ]
 													}


### PR DESCRIPTION
### Problem
- The visual order of the entries in the inspiration tab do not correspond with where their links (learn/YouTube) send to, e.g. Alice & Chris's learn / YouTube link is on Lauren's page etc. as you go down the list. 
- Some YouTube videos are attached to the wrong performers too. 

### Fix

- I kept the order found in the original Presentation-mode patcher and corrected:
  - `lines 1603-1635`: The order of the performer names in `[coll fluid-composer-learns]`
  - `lines 1685-1717`: The URLs to the incorrectly linked YouTube videos in `[coll fluid-composer-links]`