### PR TITLE
release: pull from invoked branch

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,7 @@ jobs:
       - uses: flucoma/actions/env@main
       - uses: flucoma/actions/max@main
         with:
-          branch: origin/production
+          branch: origin/${{ github.ref_name }}
 
       - uses: actions/upload-artifact@v3
         with:
@@ -26,7 +26,7 @@ jobs:
       - uses: flucoma/actions/env@main
       - uses: flucoma/actions/max@main
         with:
-          branch: origin/production
+          branch: origin/${{ github.ref_name }}
 
       - name: sign and notarise
         uses: flucoma/actions/distribution@main


### PR DESCRIPTION
set release workflow to detect which branch it was triggered from and use that to pull from `flucoma-core` and `flucoma-docs`