### PR TITLE
Feature/voice allocator

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -78,4 +78,5 @@ jobs:
           files: FluCoMa*
           prerelease: true
           tag_name: ${{ needs.macbuild.outputs.version }}
+          target_commitish: ${{ github.sha }}
           draft: false

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -69,6 +69,14 @@ jobs:
       
       - name: zip
         run: zip -r FluCoMa-Max-"${{ needs.macbuild.outputs.version }}".zip "FluidCorpusManipulation"
+      
+      - name: delete pre-existing release
+        uses: dev-drprasad/delete-tag-and-release@v0.2.0
+        with:
+          delete_release: true # default: false
+          tag_name: ${{ needs.macbuild.outputs.version }} # tag name to delete
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: package and upload
         uses: softprops/action-gh-release@v1

--- a/source/include/FluidMaxWrapper.hpp
+++ b/source/include/FluidMaxWrapper.hpp
@@ -588,11 +588,14 @@ class FluidMaxWrapper
     void operator()(FluidMaxWrapper* x, long ac, t_atom* av)
     {
       FluidContext c;
-            
+      
+      index whichIn =  proxy_getinlet((t_object *)x);
+        
       atom_getdouble_array(std::min<index>(x->mListSize, ac), av,
                            std::min<index>(x->mListSize, ac),
-                           x->mInputListData[0].data());
-      x->mClient.process(x->mInputListViews, x->mOutputListViews, c);
+                           x->mInputListData[whichIn].data());
+    
+      if (!whichIn) x->mClient.process(x->mInputListViews, x->mOutputListViews, c);
 
       for (index i = asSigned(x->mDataOutlets.size()) - 1; i >= 0; --i)
       {
@@ -1262,9 +1265,9 @@ public:
       //we already have a left inlet, but do we need more?
       index newInlets = controlInputs - 1;
       mProxies.reserve(newInlets);
-      for (index i = 1; i <= newInlets; ++i)
+      for (index i = newInlets; i >= 1; --i)
         mProxies.push_back(
-            proxy_new(this, static_cast<long>(i + 1), &this->mProxyNumber));
+            proxy_new(this, static_cast<long>(i), &this->mProxyNumber));
     }
 
     //new proxy inlets for any additional input buffers beyond the first


### PR DESCRIPTION
this is the modification to the wrapper to organize and buffer more than one control inlet. So far it works but only if the lists provided are of the same length.

In the provided patch below, we can see in std::cout the content of all behaves properly if all inputs are of 5 items. other lengths seem to offset the writing in various manners...

<pre><code>
----------begin_max5_patcher----------
545.3ocuV1siaCBDE9Z6mhQbsajAi+quJUqVw5P2xJGrkMNMqVsu6c.bZx1l
1FmP8EfDSFygOFxAdKNh7T2A4HA9L7EHJ5s3nHWHafn4wQjchCMshQWZjcxw
QwyRRh+2LxCFWbJvfriQ0S6T5Vow8Ir4f8BSy2T5mebP1X7RRSK2jl.7BaeV
tsmw1jBObZd5lLGmH5bTeHyq8R+rPH+7CTacKltmd4SLhMz6ww1tj6kNFEnL
F1xvFGa4Kk0rRGeU01dpEy.BKkFRZqqgpJnrDJJf7bfyWJq7Y7pbrlF1BKMM
nrBHo.xIrXJYd978EgEx5+G0yEejkWeBv7vBXUvKhKltzyNjFXymxfZ9PQyG
JZ9PQyGJZ9PWr4Cyy5r4CsLnvVDRXQiVzmEsYQW1a1jclPOtAiy7vVTAaIEq
nXA8FpmefypfxIOnbZeW.vgEiHdZ+LDCr6S1sfnV9c7a+MB+Z6jZ6l8cpFon
ssqQX5FtHrY+k5I2eUYEyei4+5OnY+QZSlaW7lyyo1k.oUo+02+4Vd13ebqX
raZn4nL9qnRfSqusxQiRKLpN8Y4PwbnvCWby9Z0o5J0gcm5TtR7TrR5juR6a
7UhmrqTmz6TG1JoCktREH7Ay2hPdCBQe+d4v3bxNMPWwWPKNbXUhanR6G5bk
HCx8pi46iHFP+NCZ1MM3VWjCE9GaS10sUNnmTNG7XKcnjNGWs.uQoW3AwYLG
+d7O.ng7K4D
-----------end_max5_patcher-----------
</code></pre>
