### PR TITLE
EOL `.gitattributes` normalisation

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,6 @@
+*.xml	text=auto
+*.json	text=auto
+*.cmake text=auto
+*.txt	text=auto
+
+* binary

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,6 +1,17 @@
-*.xml	text=auto
-*.json	text=auto
-*.cmake text=auto
-*.txt	text=auto
+* text=auto
 
-* binary
+*.cmake text
+*.cpp text
+*.gitattributes text
+*.gitignore text
+*.hpp text
+*.in text
+*.js text
+*.maxhelp text
+*.maxpat text
+*.md text
+*.txt text
+*.xml text
+*.yml text
+
+*.png binary


### PR DESCRIPTION
EOL standardisation with `.gitattributes` to fix issues with versions of Git before 2.10 allowed automatic EOL conversion.