### PR TITLE
Fixes issue #371 - outName static cast error in debug builds

### DIFF
--- a/source/include/clients/nrt/FluidListToBuf.hpp
+++ b/source/include/clients/nrt/FluidListToBuf.hpp
@@ -32,7 +32,7 @@ struct FluidListToBuf
   t_object*     defaultOut;
   t_buffer_ref* outputRef;
   t_symbol*     defaultOutName{nullptr};
-  t_atom        outName;
+  t_symbol*     outName;
   index         axis{0};
   index         canResize;
   index         startChannel{0};
@@ -130,7 +130,7 @@ void* FluidListToBuf_new(t_symbol*, long argc, t_atom* argv)
                                                &bufferArgs);
                                       
   x->output.reset(new MaxBufferAdaptor((t_object*) x, x->defaultOutName));
-  atom_setsym(&x->outName, x->defaultOutName);
+  x->outName = x->defaultOutName;
   {
   auto buf = MaxBufferAdaptor::Access(x->output.get());
   buf.resize(argCount > 0 ? atom_getlong(argv) : 0,
@@ -150,12 +150,12 @@ t_max_err FluidListToBuf_setOut(FluidListToBuf* x, t_object* /*attr*/,
     t_symbol* s = atom_getsym(argv);
     if (s == gensym(""))
     {
-      atom_setsym(&x->outName, x->defaultOutName);
+      x->outName = x->defaultOutName;
       x->output.reset(new MaxBufferAdaptor((t_object*) x, x->defaultOutName));
     }
     else
     {
-      atom_setsym(&x->outName, s);
+      x->outName = s;
       x->output.reset(new MaxBufferAdaptor((t_object*) x, s));
     }
   }
@@ -254,7 +254,9 @@ void FluidListToBuf_list(FluidListToBuf* x, t_symbol* /*s*/, long argc,
     std::transform(argv, argv + count, frames.begin(),
                    [](const atom& a) -> float { return atom_getfloat(&a); });
 
-    outlet_anything(x->outlet, bufferSym, 1, &x->outName);
+    t_atom outNameAtom;
+    atom_setsym(&outNameAtom, x->outName);
+    outlet_anything(x->outlet, bufferSym, 1, &outNameAtom);
   }
 }
 

--- a/source/include/clients/nrt/FluidListToBuf.hpp
+++ b/source/include/clients/nrt/FluidListToBuf.hpp
@@ -32,7 +32,7 @@ struct FluidListToBuf
   t_object*     defaultOut;
   t_buffer_ref* outputRef;
   t_symbol*     defaultOutName{nullptr};
-  t_symbol*     outName;
+  t_symbol*     outName{nullptr};
   index         axis{0};
   index         canResize;
   index         startChannel{0};


### PR DESCRIPTION
@AlexHarker 
As discussed in https://github.com/flucoma/flucoma-max/pull/372, here's a new PR with a cleaned up branch.

This fixes the original static cast bug that arose from a CLASS_ATTR_SYM being used for a t_atom type.

Instead of changing the CLASS_ATTR, as the variable is only ever used as a t_atom once and is being converted to a symbol type many times, it is changed to a t_symbol type and now only ever converted to a t_atom once (lines 257-259).