### PR TITLE
Bump Download Artifact Action Version

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -58,12 +58,12 @@ jobs:
       - name: make parent folder
         run : mkdir -p "FluidCorpusManipulation"
 
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v3
         with:
           name: macbuild
           path: "FluidCorpusManipulation"
 
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v3
         with:
           name: winbuild
           path: "FluidCorpusManipulation/externals"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,12 +57,12 @@ jobs:
       - name: make parent folder
         run : mkdir -p "FluidCorpusManipulation"
 
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v3
         with:
           name: macbuild
           path: "FluidCorpusManipulation"
 
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v3
         with:
           name: winbuild
           path: "FluidCorpusManipulation/externals"


### PR DESCRIPTION
As the title explains this bumps the artifact version, which mitigates a deprecation of node 12.

https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/
