### PR TITLE
wrapper: adding the primary parameters to the max in the error line, fix #392

### DIFF
--- a/source/include/FluidMaxWrapper.hpp
+++ b/source/include/FluidMaxWrapper.hpp
@@ -1467,7 +1467,7 @@ public:
     {
       object_warn((t_object*) x,
                   "Too many arguments. Got %d, expect at most %d", ac,
-                  ParamDescType::NumFixedParams + isControlIn<typename Client::Client>);
+                  ParamDescType::NumFixedParams + ParamDescType::NumPrimaryParams + isControlIn<typename Client::Client>);
     }
 
     return x;


### PR DESCRIPTION
adding the number of primary parameters to the list of max num arg