### PR TITLE
Rework Max wrapper to allow multiple inputs and different IO sizes fo…

### DIFF
--- a/source/include/FluidMaxWrapper.hpp
+++ b/source/include/FluidMaxWrapper.hpp
@@ -588,19 +588,29 @@ class FluidMaxWrapper
     void operator()(FluidMaxWrapper* x, long ac, t_atom* av)
     {
       FluidContext c;
-            
+
+      index whichIn = proxy_getinlet((t_object *)x);
+
       atom_getdouble_array(std::min<index>(x->mListSize, ac), av,
                            std::min<index>(x->mListSize, ac),
-                           x->mInputListData[0].data());
-      x->mClient.process(x->mInputListViews, x->mOutputListViews, c);
+                           x->mInputListData[whichIn].data());
 
-      for (index i = asSigned(x->mDataOutlets.size()) - 1; i >= 0; --i)
+      if (!whichIn)
       {
-        atom_setdouble_array(
-            std::min<index>(x->mListSize, ac), x->mOutputListAtoms.data(),
-            std::min<index>(x->mListSize, ac), x->mOutputListData[i].data());
-        outlet_list(x->mDataOutlets[i], nullptr, x->mListSize,
-                    x->mOutputListAtoms.data());
+        x->mClient.process(x->mInputListViews, x->mOutputListViews, c);
+
+        index outSize = isControlOutFollowsIn<typename Client::Client> ? std::min<index>(x->mListSize, ac) : x->mClient.controlChannelsOut().size;
+          
+        for (index i = asSigned(x->mDataOutlets.size()) - 1; i >= 0; --i)
+        {
+          assert(x->mOutputListData[i].size() == outSize);
+          atom_setdouble_array(outSize,
+                               x->mOutputListAtoms.data(),
+                               outSize,
+                               x->mOutputListData[i].data());
+          outlet_list(x->mDataOutlets[i], nullptr, outSize,
+                      x->mOutputListAtoms.data());
+        }
       }
     }
   };
@@ -1252,7 +1262,7 @@ public:
     //TODO: this implicitly assumes no audio in?
     if (index controlInputs = mClient.controlChannelsIn())
     {
-      if(mListSize)
+      if (mListSize)
       {
         mInputListData.resize(controlInputs, mListSize);
         for (index i = 1; i <= controlInputs; ++i)
@@ -1262,9 +1272,9 @@ public:
       //we already have a left inlet, but do we need more?
       index newInlets = controlInputs - 1;
       mProxies.reserve(newInlets);
-      for (index i = 1; i <= newInlets; ++i)
+      for (index i = newInlets; i >= 1; --i)
         mProxies.push_back(
-            proxy_new(this, static_cast<long>(i + 1), &this->mProxyNumber));
+            proxy_new(this, static_cast<long>(i), &this->mProxyNumber));
     }
 
     //new proxy inlets for any additional input buffers beyond the first
@@ -1355,9 +1365,9 @@ public:
   
     if (mClient.controlChannelsOut().count)
     {
-      index outputSize = mClient.controlChannelsOut().max > -1
-                             ? mClient.controlChannelsOut().max
-                             : mListSize;
+      index outputSize = isControlOutFollowsIn<typename Client::Client>
+                         ? mListSize
+                         : mClient.controlChannelsOut().max;
 
       if (outputSize)
       {
@@ -1462,12 +1472,12 @@ public:
   {
     void* x = object_alloc(getClass());
     new (x) FluidMaxWrapper(sym, ac, av);
-    if (static_cast<index>(attr_args_offset(static_cast<short>(ac), av)) - isControlIn<typename Client::Client> >
+    if (static_cast<index>(attr_args_offset(static_cast<short>(ac), av)) - isControlOutFollowsIn<typename Client::Client>>
         ParamDescType::NumFixedParams + ParamDescType::NumPrimaryParams)
     {
       object_warn((t_object*) x,
                   "Too many arguments. Got %d, expect at most %d", ac,
-                  ParamDescType::NumFixedParams + ParamDescType::NumPrimaryParams + isControlIn<typename Client::Client>);
+                  ParamDescType::NumFixedParams + ParamDescType::NumPrimaryParams + isControlOutFollowsIn<typename Client::Client>);
     }
 
     return x;
@@ -1477,7 +1487,6 @@ public:
 
   static void makeClass(const char* className)
   {
-    
     static constexpr bool AudioInput = isAudioIn<typename Client::Client>;
     const ParamDescType& p = Client::getParameterDescriptors();
     const auto&          m = Client::getMessageDescriptors();
@@ -1488,13 +1497,16 @@ public:
     if (isControlIn<typename Client::Client>)
     {
       class_addmethod(getClass(), (method) handleList, "list", A_GIMME, 0);
+    }
+    
+    if (isControlOutFollowsIn<typename Client::Client>)
+    {
       t_object* a = attr_offset_new("autosize", USESYM(atom_long), 0, nullptr, nullptr,
                                   calcoffset(FluidMaxWrapper, mAutosize));
       class_addattr(getClass(), a);
       CLASS_ATTR_FILTER_CLIP(getClass(), "autosize", 0, 1);
       CLASS_ATTR_STYLE_LABEL(getClass(), "autosize", 0, "onoff",
-                           "Set auto size for list output");
-                                  
+                           "Set auto resizing of list input and output");
     }
     
     class_addmethod(getClass(), (method) doNotify, "notify", A_CANT, 0);
@@ -1520,9 +1532,8 @@ public:
     p.template iterateMutable<SetupAttribute>();
     p.template iterateFixed<SetupReadOnlyAttribute>();
     
-    
     //for non-audio classes, give us cold inlets for non-left
-    if(!AudioInput)
+    if (!AudioInput)
       class_addmethod(getClass(), (method)stdinletinfo, "inletinfo", A_CANT, 0);
     
     class_dumpout_wrap(getClass());
@@ -1555,72 +1566,48 @@ public:
 
   void resizeListHandlers(index newSize)
   {
+    if (mListSize != newSize)
+    {
+      mListSize = newSize;
       index numIns = mClient.controlChannelsIn();
-      mListSize = newSize; 
-      if(mListSize)
+      mInputListData.resize(numIns, mListSize);
+      mInputListViews.clear();
+      for (index i = 0; i < numIns; ++i)
       {
-        mInputListData.resize(numIns,mListSize);
-        mInputListViews.clear();
-        for (index i = 0; i < numIns; ++i)
-        {
-          mInputListViews.emplace_back(mInputListData.row(i));
-        }
+        mInputListViews.emplace_back(mInputListData.row(i));
+      }
 
-        index outputSize = mClient.controlChannelsOut().size > -1
-                               ? mClient.controlChannelsOut().size
-                               : mListSize;
-
-        mOutputListData.resize(mClient.controlChannelsOut().count, outputSize);
-        mOutputListAtoms.reserve(outputSize);
+      if (isControlOutFollowsIn<typename Client::Client>)
+      {
+        mOutputListData.resize(mClient.controlChannelsOut().count, mListSize);
+        mOutputListAtoms.reserve(mListSize);
         mOutputListViews.clear();
         for (index i = 0; i < mClient.controlChannelsOut().count; ++i)
         {
           mOutputListViews.emplace_back(mOutputListData.row(i));
         }
       }
+    }
   }
 
-  static void doList(FluidMaxWrapper* x, t_symbol*, long ac, t_atom* av)
+  static void handleList(FluidMaxWrapper* x, t_symbol* /*s*/, long ac, t_atom* av)
   {
+    if (!x->mListSize && !x->mAutosize)
+    {
+      object_error((t_object*)x, "No list size argument nor autosize enabled: can't do anything");
+      return;
+    }
 
-//    if(!isr() && x->mAutosize && (ac != x->mListSize)) x->resizeListHandlers(ac);
+    if (!x->mAutosize && ac != x->mListSize)
+    {
+      object_warn((t_object*)x, "bad input list size (%d), expect %d",ac,x->mListSize);
+      return;
+    }
+     
+    if (x->mAutosize)
+      x->resizeListHandlers(ac);
+      
     x->mListHandler(x, ac, av);
-  }
-  
-  static void doListResize(FluidMaxWrapper* x, t_symbol*, long ac, t_atom*)
-  {
-    x->resizeListHandlers(ac);
-  }
-  
-  
-  static void handleList(FluidMaxWrapper* x, t_symbol* s, long ac, t_atom* av)
-  {
-      if(!x->mListSize && !x->mAutosize)
-      {
-        object_error((t_object*)x, "No list size argument nor autosize enabled: can't do anything");
-        return;
-      }
-      
-      if(isr())
-      {
-        if(x->mAutosize && ac != x->mListSize)
-        {
-          object_warn((t_object*)x, "input list size (%d) != object argument (%d) and autosize is enabled: this operation will be deferred",ac,x->mListSize);
-          defer(x, method(doListResize), s, static_cast<short>(ac), av);
-          defer(x, (method) doList, s, static_cast<short>(ac), av);
-          return;
-        }
-
-        if(!x->mAutosize && ac != x->mListSize)
-        {
-          object_warn((t_object*)x, "bad input list size (%d), expect %d",ac,x->mListSize);
-          return;
-        }
-      }
-      else if(ac != x->mListSize) doListResize(x,s,ac,av);
-      
-      doList(x,s,ac,av);
-      
   }
   
   static void doSharedClientRefer(FluidMaxWrapper* x, t_symbol* newName)
@@ -1753,7 +1740,7 @@ private:
     {
       long argCount{0};
       
-      if(isControlIn<typename Client::Client>)
+      if (isControlOutFollowsIn<typename Client::Client>)
       {
         mListSize = atom_getlong(av);
         numArgs -= 1;


### PR DESCRIPTION
…r control objects

This work supersedes other work towards making the voice allocator object work

**What it does**
- allows the wrapper to use multiple inputs for different things (this work was in a voice allocator branch, but it is presented here in an edited form
- allows for two different ways of setting input size, one of which is dependent on input size and one of which is not - the difference is determinable at compile time / without a client (this relies on a related PR in core (flucoma/flucoma-core#248)

**Changes**
- I removed the deferral from high priority thread for resizing based on input. There are other places in max (the app) where allocation happens in high priority and it seemed overly fussy/complicated - the restriction with buffer~s is c74 imposed,
- even in the wrapper already I can see places where high priority allocation can occur, so it seemed weird to insist on not doing it in this one place (given all the added indirection and logic required to do so).
 
**Notes:**
- functionality for both the bufstats and voice allocator objects should be correct, and @tremblap and I have determined that these should be the only affected objects.
- similar changes are required in other repos (at least pd, although SC and CLI should be considered also).

Sorry to spam @weefuzzy but I suspect that the removal of the deferral stuff is most contentious here. Also apologies that the PR isn't easier to follow, but there was no obvious way to break this work up.
