### PR TITLE
Don't attempt to assign memory when outputSize is negative (or zero)

### DIFF
--- a/source/include/FluidMaxWrapper.hpp
+++ b/source/include/FluidMaxWrapper.hpp
@@ -1369,7 +1369,7 @@ public:
                          ? mListSize
                          : mClient.controlChannelsOut().max;
 
-      if (outputSize)
+      if (outputSize > 0)
       {
         mOutputListData.resize(mClient.controlChannelsOut().count, outputSize);
         mOutputListAtoms.reserve(outputSize);


### PR DESCRIPTION
Fixes the bug in the nightlies with objects instacrashing.