### PR TITLE
dynamic time warping objects

### DIFF
--- a/init/fluid.libmanipulation-init.txt
+++ b/init/fluid.libmanipulation-init.txt
@@ -16,4 +16,6 @@ max objectfile fluid.grid~ fluid.libmanipulation fluid.grid~;
 max objectfile fluid.datasetquery~ fluid.libmanipulation fluid.datasetquery~;
 max objectfile fluid.mlpregressor~ fluid.libmanipulation fluid.mlpregressor~;
 max objectfile fluid.mlpclassifier~ fluid.libmanipulation fluid.mlpclassifier~;
-max objectfile fluid.dtw~ fluid.libmanipulation fluid.dtw~
+max objectfile fluid.dtw~ fluid.libmanipulation fluid.dtw~;
+max objectfile fluid.dtwclassifier~ fluid.libmanipulation fluid.dtwclassifier~;
+max objectfile fluid.dtwregressor~ fluid.libmanipulation fluid.dtwregressor~;

--- a/init/fluid.libmanipulation-init.txt
+++ b/init/fluid.libmanipulation-init.txt
@@ -15,3 +15,4 @@ max objectfile fluid.grid~ fluid.libmanipulation fluid.grid~;
 max objectfile fluid.datasetquery~ fluid.libmanipulation fluid.datasetquery~;
 max objectfile fluid.mlpregressor~ fluid.libmanipulation fluid.mlpregressor~;
 max objectfile fluid.mlpclassifier~ fluid.libmanipulation fluid.mlpclassifier~;
+max objectfile fluid.dtw~ fluid.libmanipulation fluid.dtw~

--- a/source/include/clients/nrt/FluidListToBuf.hpp
+++ b/source/include/clients/nrt/FluidListToBuf.hpp
@@ -32,7 +32,7 @@ struct FluidListToBuf
   t_object*     defaultOut;
   t_buffer_ref* outputRef;
   t_symbol*     defaultOutName{nullptr};
-  t_atom        outName;
+  t_symbol*     outName{nullptr};
   index         axis{0};
   index         canResize;
   index         startChannel{0};
@@ -130,7 +130,7 @@ void* FluidListToBuf_new(t_symbol*, long argc, t_atom* argv)
                                                &bufferArgs);
                                       
   x->output.reset(new MaxBufferAdaptor((t_object*) x, x->defaultOutName));
-  atom_setsym(&x->outName, x->defaultOutName);
+  x->outName = x->defaultOutName;
   {
   auto buf = MaxBufferAdaptor::Access(x->output.get());
   buf.resize(argCount > 0 ? atom_getlong(argv) : 0,
@@ -150,12 +150,12 @@ t_max_err FluidListToBuf_setOut(FluidListToBuf* x, t_object* /*attr*/,
     t_symbol* s = atom_getsym(argv);
     if (s == gensym(""))
     {
-      atom_setsym(&x->outName, x->defaultOutName);
+      x->outName = x->defaultOutName;
       x->output.reset(new MaxBufferAdaptor((t_object*) x, x->defaultOutName));
     }
     else
     {
-      atom_setsym(&x->outName, s);
+      x->outName = s;
       x->output.reset(new MaxBufferAdaptor((t_object*) x, s));
     }
   }
@@ -254,7 +254,9 @@ void FluidListToBuf_list(FluidListToBuf* x, t_symbol* /*s*/, long argc,
     std::transform(argv, argv + count, frames.begin(),
                    [](const atom& a) -> float { return atom_getfloat(&a); });
 
-    outlet_anything(x->outlet, bufferSym, 1, &x->outName);
+    t_atom outNameAtom;
+    atom_setsym(&outNameAtom, x->outName);
+    outlet_anything(x->outlet, bufferSym, 1, &outNameAtom);
   }
 }
 


### PR DESCRIPTION
add the `dtw`, `dtwclassifier`, and `dtwregressor` objects to the Max init file, see flucoma/flucoma-core#250