### PR TITLE
For `load` and `read` only update params on success :grimace:

### DIFF
--- a/source/include/FluidMaxWrapper.hpp
+++ b/source/include/FluidMaxWrapper.hpp
@@ -2111,7 +2111,8 @@ private:
   updateParams(FluidMaxWrapper*                                        x,
                MessageResult<typename ParamSetType::ValueTuple> const& v)
   {
-    x->mParams.fromTuple(typename ParamSetType::ValueTuple(v.value()));
+    if(v.ok())
+      x->mParams.fromTuple(typename ParamSetType::ValueTuple(v.value()));
   }
 
   static void updateParams(FluidMaxWrapper*, MessageResult<void>) {}


### PR DESCRIPTION
Unsuccessful `load` / `read`, e.g. with malformed JSON, would correctly be flagged as failures but the wrapper wasn't checking this status before just going ahead and wiping the old parameters. Resulting in crashing.  